### PR TITLE
Run tests on Travis with embedded API server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,15 @@ language: python
 python:
 - 2.7
 
+addons:
+  postgresql: "9.4"
+
 install:
 - make -f config/travis .build/dev-requirements.timestamp
 - make -f config/travis install
+
+before_script:
+- scripts/travis-api-server.sh
 
 script:
 - make -f config/travis check

--- a/config/travis
+++ b/config/travis
@@ -2,3 +2,4 @@ include config/dev
 
 export instanceid = travis
 export base_url = /${instanceid}
+export api_url = http://localhost:6543

--- a/scripts/travis-api-server.sh
+++ b/scripts/travis-api-server.sh
@@ -1,0 +1,19 @@
+# Sets up an instance of the API server running at localhost:5432
+
+# clone repo, set up database and install dependencies
+git clone https://github.com/c2corg/v6_api.git
+cd v6_api
+echo "create user \"www-data\" with password 'www-data;'" | psql -U postgres
+PGUSER=postgres USER=travis scripts/create_user_db_test.sh
+make -f config/travis .build/dev-requirements.timestamp
+make -f config/travis install
+.build/venv/bin/initialize_c2corg_api_db development.ini
+
+# run the test server in the background
+echo "Starting API server..."
+nohup make -f config/travis serve 2>&1&
+echo $! > server_pid.txt
+# wait for the server to start
+.build/venv/bin/python -c "from webtest.http import check_server
+print('Status: %s' % (check_server('localhost', 6543)))"
+echo "API server running on localhost:6543"


### PR DESCRIPTION
When running the tests on Travis...

 * Clone the c2corg_api repo (master branch).
 * Install c2corg_api and set up a database.
 * Start an API server at localhost:5432.
 * Use this server to run the unit tests of the UI application.

By doing this we don't have to rely any more on an external API server.

Closes #2 