### PR TITLE
Convert WP coordinates before passing them to templates

### DIFF
--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -3,6 +3,7 @@
 <%
 waypoint_id = waypoint['document_id']
 other_cultures = filter(lambda l: l != culture, waypoint['available_cultures'])
+geometry4326 = transform(geometry, 'epsg:3857', 'epsg:4326')
 %>\
 
 <%block name="pagetitle">
@@ -14,6 +15,8 @@ ${locale['title']}
   <li>Id: ${waypoint_id}</li>
   <li>Culture: ${culture}</li>
   <li>Elevation: ${waypoint['elevation']} m</li>
+  <li>Longitude: ${geometry4326.x} °E</li>
+  <li>Latitude: ${geometry4326.y} °N</li>
   <li>Maps info: ${get_attr(waypoint, 'maps_info')}</li>
   <li>Description: ${get_attr(locale, 'description')}</li>
 </ul>

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -1,5 +1,6 @@
 from c2corg_ui.tests.views import BaseTestUi
 from c2corg_ui.views.waypoint import Waypoint
+from shapely.geometry import Point
 
 
 class TestWaypointUi(BaseTestUi):
@@ -17,3 +18,22 @@ class TestWaypointUi(BaseTestUi):
 
     def test_get_documents(self):
         self._test_get_documents()
+
+    def test_reprojection(self):
+        # Testing lon/lat coordinates
+        point = Point(6, 46)
+        point2 = self.view._transform(point, 'epsg:4326', 'epsg:3857')
+        self.assertAlmostEqual(point2.x, 667916, delta=1)
+        self.assertAlmostEqual(point2.y, 5780349, delta=1)
+        point3 = self.view._transform(point2, 'epsg:3857', 'epsg:4326')
+        self.assertAlmostEqual(point3.x, point.x)
+        self.assertAlmostEqual(point3.y, point.y)
+
+        # Testing CH1903 coordinates
+        point4 = Point(600000, 200000)
+        point5 = self.view._transform(point4, 'epsg:21781', 'epsg:3857')
+        self.assertAlmostEqual(point5.x, 828064, delta=1)
+        self.assertAlmostEqual(point5.y, 5934093, delta=1)
+        point6 = self.view._transform(point5, 'epsg:3857', 'epsg:21781')
+        self.assertAlmostEqual(point6.x, point4.x, delta=1)
+        self.assertAlmostEqual(point6.y, point4.y, delta=1)

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -1,4 +1,8 @@
+from shapely.geometry import asShape
+from shapely.ops import transform
+from functools import partial
 import httplib2
+import pyproj
 import json
 
 from pyramid.httpexceptions import (
@@ -66,3 +70,12 @@ class Document(object):
         resp, content = self._call_api(url)
         # TODO: better error handling
         return content if resp.status == 200 else []
+
+    def _get_geometry(self, data):
+        return asShape(json.loads(data))
+
+    def _transform(self, geometry, source_epsg, dest_epsg):
+        source_proj = pyproj.Proj(init=source_epsg)
+        dest_proj = pyproj.Proj(init=dest_epsg)
+        project = partial(pyproj.transform, source_proj, dest_proj)
+        return transform(project, geometry)

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -24,7 +24,9 @@ class Waypoint(Document):
         self.template_input.update({
             'culture': culture,
             'waypoint': waypoint,
-            'locale': locale
+            'locale': locale,
+            'geometry': self._get_geometry(waypoint['geometry']['geom']),
+            'transform': self._transform
         })
         return self.template_input
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ requires = [
     'pyramid_closure',
     'waitress',
     'httplib2',
+    'shapely',
+    'pyproj',
+    'functools32',
     ]
 
 setup(name='c2corg_ui',


### PR DESCRIPTION
The conversion is done in the view. I wonder if it should be done in the mako templates instead (since we  will also need the geometry for the map).