### PR TITLE
Add pages and API calls tests for routes and waypoints

### DIFF
--- a/c2corg_ui/tests/views/test_route.py
+++ b/c2corg_ui/tests/views/test_route.py
@@ -1,4 +1,5 @@
 from c2corg_ui.tests.views import BaseTestUi
+from c2corg_ui.views.route import Route
 
 
 class TestRouteUi(BaseTestUi):
@@ -6,7 +7,13 @@ class TestRouteUi(BaseTestUi):
     def setUp(self):  # noqa
         self.set_prefix("/routes")
         BaseTestUi.setUp(self)
+        self.view = Route(request=self.request)
 
-    def test_index(self):
-        response = self.app.get(self._prefix, status=200)
-        self.assertEqual(response.content_type, 'text/html')
+    def test_pages(self):
+        self._test_pages()
+
+    def test_api_call(self):
+        self._test_api_call()
+
+    def test_get_documents(self):
+        self._test_get_documents()

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -1,4 +1,5 @@
 from c2corg_ui.tests.views import BaseTestUi
+from c2corg_ui.views.waypoint import Waypoint
 
 
 class TestWaypointUi(BaseTestUi):
@@ -6,7 +7,13 @@ class TestWaypointUi(BaseTestUi):
     def setUp(self):  # noqa
         self.set_prefix("/waypoints")
         BaseTestUi.setUp(self)
+        self.view = Waypoint(request=self.request)
 
-    def test_index(self):
-        response = self.app.get(self._prefix, status=200)
-        self.assertEqual(response.content_type, 'text/html')
+    def test_pages(self):
+        self._test_pages()
+
+    def test_api_call(self):
+        self._test_api_call()
+
+    def test_get_documents(self):
+        self._test_get_documents()


### PR DESCRIPTION
This PR adds a few tests for the UI app.
It's not easy to create relevent tests because:
* we can't assume that the API actually has documents and if yes, what documents.
* creating/editing a doc is done using client-side request to the API, not server-side.

Any ideas of what tests could be added?

As for now I have created similar tests for both routes and waypoints: do you think I should factorize them in the BaseTestUi class and call the factorized methods in WP/Route tests? https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/tests/views/__init__.py#L4

I have also added tests of "private" methods like _call_api or _get_documents. Is it done the right way?
Since both tests pretty much test the same thing (that calling /waypoints from the API returns a list), I wonder if ``test_get_documents`` is really needed.