### PR TITLE
Map directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,18 @@ help:
 	@echo
 	@echo "Main targets:"
 	@echo
-	@echo "- check			     Perform a number of checks on the code (runs flake 8 and test)"
-	@echo "- test			     Run the unit tests"
-	@echo "- clean			     Remove generated files"
-	@echo "- cleanall		     Remove all the build artefacts"
-	@echo "- compile-catalog     Compile the translation catalog"
-	@echo "- flake8              Run flake8 checker on the Python code"
-	@echo "- lint                Check the JavaScript code with linters"
-	@echo "- install		     Install and build the project"
-	@echo "- serve			     Run the development server (pserve)"
-	@echo "- template		     Replace the config vars in the .in templates"
-	@echo "- update-node-modules Update node modules (using --force)"
+	@echo "- check					Perform a number of checks on the code (runs flake 8 and test)"
+	@echo "- test					Run the unit tests"
+	@echo "- clean					Remove generated files"
+	@echo "- cleanall				Remove all the build artefacts"
+	@echo "- compile-catalog		Compile the translation catalog"
+	@echo "- flake8					Run flake8 checker on the Python code"
+	@echo "- lint					Check the JavaScript code with linters"
+	@echo "- build					Build the project"
+	@echo "- install				Install and build the project"
+	@echo "- serve					Run the development server (pserve)"
+	@echo "- template				Replace the config vars in the .in templates"
+	@echo "- update-node-modules	Update node modules (using --force)"
 	@echo
 
 .PHONY: check

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -8,3 +8,4 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.documentEditingDirective');
+goog.require('app.mapDirective');

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -1,11 +1,6 @@
 goog.provide('app.MainController');
 
 goog.require('app');
-goog.require('ngeo.mapDirective');
-goog.require('ol.Map');
-goog.require('ol.View');
-goog.require('ol.layer.Tile');
-goog.require('ol.source.OSM');
 
 
 
@@ -35,22 +30,6 @@ app.MainController = function(gettextCatalog, langUrlTemplate) {
    * @export
    */
   this.lang;
-
-  /**
-   * @type {ol.Map}
-   * export
-   */
-  this.map = new ol.Map({
-    layers: [
-      new ol.layer.Tile({
-        source: new ol.source.OSM()
-      })
-    ],
-    view: new ol.View({
-      center: [0, 0],
-      zoom: 4
-    })
-  });
 
   this.switchLanguage('fr');
 };

--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -3,15 +3,18 @@ goog.provide('app.mapDirective');
 
 goog.require('app');
 goog.require('ngeo.mapDirective');
+goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.geom.Point');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
 
 
 /**
- * This directive gets a reference to the map instance through the "app-map"
- * attribute.
+ * This directive is used to display a pre-configured map in v6_ui pages.
  *
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -19,9 +22,9 @@ goog.require('ol.source.OSM');
 app.mapDirective = function() {
   return {
     restrict: 'E',
-    /*scope: {
-      'map': '=appMap'
-    },*/
+    scope: {
+      'center': '=appMapCenter'
+    },
     controller: 'AppMapController',
     controllerAs: 'mapCtrl',
     bindToController: true,
@@ -41,6 +44,8 @@ app.module.directive('appMap', app.mapDirective);
  */
 app.MapController = function() {
 
+  var center = this['center'];
+
   /**
    * @type {ol.Map}
    * export
@@ -52,11 +57,47 @@ app.MapController = function() {
       })
     ],
     view: new ol.View({
-      center: [0, 0],
-      zoom: 4
+      center: center || app.MapController.DEFAULT_CENTER,
+      zoom: app.MapController.DEFAULT_ZOOM
     })
   });
+
+  if (center) {
+    var feature = new ol.Feature(new ol.geom.Point(center));
+    var vectorLayer = new ol.layer.Vector({
+      source: new ol.source.Vector({
+        features: [feature]
+      })
+    });
+
+    // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+    // makes the vector layer "unmanaged", meaning that it is always on top.
+    vectorLayer.setMap(this.map);
+
+    this.map.getView().setZoom(app.MapController.DEFAULT_POINT_ZOOM);
+  }
 };
+
+
+/**
+ * @const
+ * @type {Array.<number>}
+ */
+app.MapController.DEFAULT_CENTER = [0, 0];
+
+
+/**
+ * @const
+ * @type {number}
+ */
+app.MapController.DEFAULT_ZOOM = 4;
+
+
+/**
+ * @const
+ * @type {number}
+ */
+app.MapController.DEFAULT_POINT_ZOOM = 12;
 
 
 app.module.controller('AppMapController', app.MapController);

--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -1,0 +1,62 @@
+goog.provide('app.MapController');
+goog.provide('app.mapDirective');
+
+goog.require('app');
+goog.require('ngeo.mapDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/**
+ * This directive gets a reference to the map instance through the "app-map"
+ * attribute.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.mapDirective = function() {
+  return {
+    restrict: 'E',
+    /*scope: {
+      'map': '=appMap'
+    },*/
+    controller: 'AppMapController',
+    controllerAs: 'mapCtrl',
+    bindToController: true,
+    template: '<div class="map" ngeo-map=mapCtrl.map></div>'
+  };
+};
+
+
+app.module.directive('appMap', app.mapDirective);
+
+
+
+/**
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.MapController = function() {
+
+  /**
+   * @type {ol.Map}
+   * export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+};
+
+
+app.module.controller('AppMapController', app.MapController);

--- a/c2corg_ui/templates/index.html
+++ b/c2corg_ui/templates/index.html
@@ -1,7 +1,7 @@
 <%inherit file="base.html"/>
 
 <h1 translate>Welcome to Camptocamp.org</h1>
-<div id="map" ngeo-map="mainCtrl.map"></div>
+<app-map></app-map>
 <ul>
   <li><a href="${request.route_url('waypoints_index')}" translate>Waypoints</a></li>
   <li><a href="${request.route_url('routes_index')}" translate>Routes</a></li>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -79,4 +79,4 @@ FIXME: Adding/editing page title
   </p>
 </form>
 <h2>Georeferencing the route</h2>
-<div id="map" ngeo-map="mainCtrl.map"></div>
+<app-map></app-map>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -5,7 +5,9 @@ Routes
 </%block>
 
 <h1>Routes</h1>
+<app-map></app-map>
 <ul>
+  <li><a href="${request.route_url('routes_add')}">Add a route</a></li>
 % for route in routes:
   <%
   id = route['document_id']
@@ -17,5 +19,3 @@ Routes
   (id ${id})</li>
 % endfor
 </ul>
-<p><a href="${request.route_url('routes_add')}">Add a route</a></p>
-<div id="map" ngeo-map="mainCtrl.map"></div>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -25,7 +25,7 @@ ${locale['title']}
   % endfor
   </ul>
 % endif
-<div id="map" ngeo-map="mainCtrl.map"></div>
+<app-map></app-map>
 <ul>
   <li>History (TODO)</li>
   <li><a href="${request.route_url('routes_edit', id=route_id, culture=culture)}">Edit</a></li>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -95,4 +95,4 @@ FIXME: Adding/editing page title
   </p>
 </form>
 <h2>Georeferencing the waypoint</h2>
-<div id="map" ngeo-map="mainCtrl.map"></div>
+<app-map></app-map>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -53,7 +53,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="longitude-group" class="form-group" ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid }">
     <label>Longitude</label>
-    <input type="number" name="longitude" ng-model="waypoint.geometry.geom.longitude" class="form-control" required min="-180" max="180" /> °E
+    <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" class="form-control" required min="-180" max="180" /> °E
     <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$touched">
       <p ng-message="required">Longitude is required.</p>
       <p ng-message="min">Longitude must be between -180° and 180°.</p>
@@ -62,7 +62,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="latitude-group" class="form-group" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid }">
     <label>Latitude</label>
-    <input type="number" name="latitude" ng-model="waypoint.geometry.geom.latitude" class="form-control" required required min="-90" max="90" /> °N
+    <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" class="form-control" required required min="-90" max="90" /> °N
     <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$touched">
       <p ng-message="required">Latitude is required.</p>
       <p ng-message="min">Latitude must be between -90° and 90°.</p>
@@ -93,6 +93,5 @@ FIXME: Adding/editing page title
     %>
     <a href="${cancel_url}">Cancel</a>
   </p>
+  <app-map app-map-edit-ctrl="editCtrl"></app-map>
 </form>
-<h2>Georeferencing the waypoint</h2>
-<app-map></app-map>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -5,7 +5,9 @@ Waypoints
 </%block>
 
 <h1>${self.pagetitle()}</h1>
+<app-map></app-map>
 <ul>
+  <li><a href="${request.route_url('waypoints_add')}">Add a waypoint</a></li>
 % for waypoint in waypoints:
   <%
   id = waypoint['document_id']
@@ -17,5 +19,3 @@ Waypoints
   (id ${id})</li>
 % endfor
 </ul>
-<p><a href="${request.route_url('waypoints_add')}">Add a waypoint</a></p>
-<div id="map" ngeo-map="mainCtrl.map"></div>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -28,7 +28,7 @@ ${locale['title']}
   % endfor
   </ul>
 % endif
-<app-map></app-map>
+<app-map app-map-center="[${geometry.x}, ${geometry.y}]"></app-map>
 <ul>
   <li>History (TODO)</li>
   <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}">Edit</a></li>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -28,7 +28,7 @@ ${locale['title']}
   % endfor
   </ul>
 % endif
-<div id="map" ngeo-map="mainCtrl.map"></div>
+<app-map></app-map>
 <ul>
   <li>History (TODO)</li>
   <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}">Edit</a></li>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1,6 +1,5 @@
 @import (inline) "../node_modules/openlayers/css/ol.css";
 
-#map {
-  width: 600px;
+.map {
   height: 400px;
 }


### PR DESCRIPTION
This PR creates a dedicated directive/controller to manage maps.

As for now it is possible to provide the coordinates of a waypoint and have the map recentered on it.

It would be interesting to be able to link a model in order to update show the the WP in the editing page as well, update its position when coords are changed (and of course update the form when a point is clicked on the map).

The current feature feeding is a little too simple as for now (especially when showing a route). We might need to be able to feed the features using an API call that would return a FeatureCollection of the object and its associated object.
Or to get the geometries of the features in a list (index) page.
Most likely done in another PR.