### PR TITLE
Show list items on the map

### DIFF
--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -24,7 +24,6 @@ app.mapDirective = function() {
   return {
     restrict: 'E',
     scope: {
-      'center': '=appMapCenter',
       'editCtrl': '=appMapEditCtrl'
     },
     controller: 'AppMapController',
@@ -77,11 +76,7 @@ app.MapController = function($scope, mapFeatureCollection) {
    */
   this.features_ = [];
 
-  var center = this['center'];
-  if (center) {
-    var point = new ol.geom.Point(center);
-    this.features_.push(new ol.Feature(point));
-  } else if (mapFeatureCollection) {
+  if (mapFeatureCollection) {
     var format = new ol.format.GeoJSON();
     goog.array.extend(this.features_,
         format.readFeatures(mapFeatureCollection));
@@ -96,12 +91,14 @@ app.MapController = function($scope, mapFeatureCollection) {
       new ol.layer.Tile({
         source: new ol.source.OSM()
       })
-    ],
-    view: new ol.View({
-      center: center || app.MapController.DEFAULT_CENTER,
-      zoom: app.MapController.DEFAULT_ZOOM
-    })
+    ]
   });
+  if (!mapFeatureCollection) {
+    this.map.setView(new ol.View({
+      center: app.MapController.DEFAULT_CENTER,
+      zoom: app.MapController.DEFAULT_ZOOM
+    }));
+  }
 
   /**
    * @type {ol.View}

--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -41,12 +41,13 @@ app.module.directive('appMap', app.mapDirective);
 
 /**
  * @param {angular.Scope} $scope Directive scope.
- * @param {angular.$window} $window Window object.
+ * @param {?Object} mapFeatureCollection FeatureCollection of features
+ * to show on the map.
  * @constructor
  * @export
  * @ngInject
  */
-app.MapController = function($scope, $window) {
+app.MapController = function($scope, mapFeatureCollection) {
 
   /**
    * @type {angular.Scope}
@@ -77,13 +78,13 @@ app.MapController = function($scope, $window) {
   this.features_ = [];
 
   var center = this['center'];
-  var featureCollection = $window['mapFeatureCollection'];
   if (center) {
     var point = new ol.geom.Point(center);
     this.features_.push(new ol.Feature(point));
-  } else if (featureCollection) {
+  } else if (mapFeatureCollection) {
     var format = new ol.format.GeoJSON();
-    goog.array.extend(this.features_, format.readFeatures(featureCollection));
+    goog.array.extend(this.features_,
+        format.readFeatures(mapFeatureCollection));
   }
 
   /**

--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -6,6 +6,7 @@ goog.require('ngeo.mapDirective');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.format.GeoJSON');
 goog.require('ol.geom.Point');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
@@ -40,11 +41,12 @@ app.module.directive('appMap', app.mapDirective);
 
 /**
  * @param {angular.Scope} $scope Directive scope.
+ * @param {angular.$window} $window Window object.
  * @constructor
  * @export
  * @ngInject
  */
-app.MapController = function($scope) {
+app.MapController = function($scope, $window) {
 
   /**
    * @type {angular.Scope}
@@ -52,17 +54,36 @@ app.MapController = function($scope) {
    */
   this.scope_ = $scope;
 
-  var center = this['center'];
+  /**
+   * @type {?ol.layer.Vector}
+   * @private
+   */
+  this.vectorLayer_ = null;
 
   /**
    * @type {?app.DocumentEditingController}
    * @private
    */
   this.editCtrl_ = this['editCtrl'];
-
   if (this.editCtrl_) {
     this.scope_.$root.$on('documentDataChange',
         goog.bind(this.handleEditModelChange_, this));
+  }
+
+  /**
+   * @type {Array<ol.Feature>}
+   * @private
+   */
+  this.features_ = [];
+
+  var center = this['center'];
+  var featureCollection = $window['mapFeatureCollection'];
+  if (center) {
+    var point = new ol.geom.Point(center);
+    this.features_.push(new ol.Feature(point));
+  } else if (featureCollection) {
+    var format = new ol.format.GeoJSON();
+    goog.array.extend(this.features_, format.readFeatures(featureCollection));
   }
 
   /**
@@ -87,8 +108,12 @@ app.MapController = function($scope) {
    */
   this.view_ = this.map.getView();
 
-  if (center) {
-    this.showCenterPoint_(center);
+  if (!goog.array.isEmpty(this.features_)) {
+    // Recentering on the features extent requires that the map actually
+    // has a target. Else the map size cannot be computed.
+    this.map.on('change:target', goog.bind(function() {
+      this.showFeatures_(this.features_);
+    }, this));
   }
 };
 
@@ -115,27 +140,43 @@ app.MapController.DEFAULT_POINT_ZOOM = 12;
 
 
 /**
- * @param {Array.<number>|ol.geom.Point} point Point to center on.
+ * @return {ol.layer.Vector} Vector layer.
  * @private
  */
-app.MapController.prototype.showCenterPoint_ = function(point) {
-  // TODO: generalize to show any vector features
-  if (point instanceof Array) {
-    point = new ol.geom.Point(point);
+app.MapController.prototype.getVectorLayer_ = function() {
+  if (!this.vectorLayer_) {
+    this.vectorLayer_ = new ol.layer.Vector({
+      source: new ol.source.Vector()
+    });
+
+    // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+    // makes the vector layer "unmanaged", meaning that it is always on top.
+    this.vectorLayer_.setMap(this.map);
   }
-  var feature = new ol.Feature(point);
-  var vectorLayer = new ol.layer.Vector({
-    source: new ol.source.Vector({
-      features: [feature]
-    })
-  });
+  return this.vectorLayer_;
+};
 
-  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
-  // makes the vector layer "unmanaged", meaning that it is always on top.
-  vectorLayer.setMap(this.map);
 
-  this.view_.setCenter(point.getCoordinates());
-  this.view_.setZoom(app.MapController.DEFAULT_POINT_ZOOM);
+/**
+ * @param {Array<ol.Feature>} features Features to show.
+ * @private
+ */
+app.MapController.prototype.showFeatures_ = function(features) {
+  goog.asserts.assert(features.length > 0);
+  var vectorLayer = this.getVectorLayer_();
+  vectorLayer.getSource().addFeatures(features);
+
+  if (features.length == 1 &&
+      features[0].getGeometry() instanceof ol.geom.Point) {
+    var point = /** @type {ol.geom.Point} */ (features[0].getGeometry());
+    this.view_.setCenter(point.getCoordinates());
+    this.view_.setZoom(app.MapController.DEFAULT_POINT_ZOOM);
+  } else {
+    var mapSize = this.map.getSize() || null;
+    this.view_.fit(vectorLayer.getSource().getExtent(), mapSize, {
+      padding: [10, 10, 10, 10]
+    });
+  }
 };
 
 
@@ -146,10 +187,10 @@ app.MapController.prototype.showCenterPoint_ = function(point) {
  */
 app.MapController.prototype.handleEditModelChange_ = function(event, data) {
   if ('geometry' in data && data['geometry']) {
-    // TODO: handle lines and polygons
     var geometry = data['geometry'];
-    if ('geom' in geometry && geometry['geom'] instanceof ol.geom.Point) {
-      this.showCenterPoint_(geometry['geom']);
+    if ('geom' in geometry && geometry['geom'] instanceof ol.geom.Geometry) {
+      var features = [new ol.Feature(geometry['geom'])];
+      this.showFeatures_(features);
     }
   }
 };

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -59,6 +59,9 @@
          var module = angular.module('app');
          module.constant('langUrlTemplate', '${request.static_url('c2corg_ui:static/build/locale/__lang__/c2corg_ui.json')}');
          module.constant('apiUrl', '${api_url}');
+         <%block name="moduleConstantsValues">
+         module.value('mapFeatureCollection', null);
+         </%block>
        })();
     </script>
 

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,30 +1,32 @@
-<%inherit file="../base.html"/>
+<%inherit file="../base.html"/>\
 
 <%block name="pagetitle">
 Waypoints 
-</%block>
+</%block>\
+
+<%block name="moduleConstantsValues">
+% if len(waypoints):
+module.value('mapFeatureCollection', {
+  "type": "FeatureCollection",
+  "features": [
+    <%
+    from json import dumps, loads
+    features = [];
+    for waypoint in waypoints:
+        features.append({
+            "type": "Feature",
+            "geometry": loads(waypoint['geometry']['geom'])
+        })
+    features = map(lambda f: dumps(f), features)
+    %>
+    ${', '.join(features) | n}
+  ]
+});
+% endif
+</%block>\
 
 <h1>${self.pagetitle()}</h1>
 % if len(waypoints):
-  <script>
-    // FIXME: use service or module.value
-    var mapFeatureCollection = {
-      "type": "FeatureCollection",
-      "features": [
-        <%
-        from json import dumps, loads
-        features = [];
-        for waypoint in waypoints:
-            features.append({
-                "type": "Feature",
-                "geometry": loads(waypoint['geometry']['geom'])
-            })
-        features = map(lambda f: dumps(f), features)
-        %>
-        ${', '.join(features) | n}
-      ]
-    };
-  </script>
   <app-map></app-map>
 % endif
 <p>${total} waypoints</p>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -5,7 +5,28 @@ Waypoints
 </%block>
 
 <h1>${self.pagetitle()}</h1>
-<app-map></app-map>
+% if len(waypoints):
+  <script>
+    // FIXME: use service or module.value
+    var mapFeatureCollection = {
+      "type": "FeatureCollection",
+      "features": [
+        <%
+        from json import dumps, loads
+        features = [];
+        for waypoint in waypoints:
+            features.append({
+                "type": "Feature",
+                "geometry": loads(waypoint['geometry']['geom'])
+            })
+        features = map(lambda f: dumps(f), features)
+        %>
+        ${', '.join(features) | n}
+      ]
+    };
+  </script>
+  <app-map></app-map>
+% endif
 <p>${total} waypoints</p>
 <ul>
   <li><a href="${request.route_url('waypoints_add')}">Add a waypoint</a></li>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -8,15 +8,34 @@ geometry4326 = transform(geometry, 'epsg:3857', 'epsg:4326')
 
 <%block name="pagetitle">
 ${locale['title']}
-</%block>
+</%block>\
+
+<%block name="moduleConstantsValues">
+module.value('mapFeatureCollection', {
+  "type": "FeatureCollection",
+  "features": [{
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [${geometry.x}, ${geometry.y}]},
+    "properties": {
+      "title": "${locale['title']}",
+      % if waypoint['waypoint_type'] != 'climbing_outdoor':
+      "elevation": ${waypoint['elevation']},
+      % endif
+      "waypoint_type": "${waypoint['waypoint_type']}"
+    }
+  }]
+});
+</%block>\
 
 <h1>${self.pagetitle()}</h1>
 <ul>
   <li>Id: ${waypoint_id}</li>
   <li>Culture: ${culture}</li>
+  <li>Type: ${waypoint['waypoint_type']}</li>
+  % if waypoint['waypoint_type'] != 'climbing_outdoor':
   <li>Elevation: ${waypoint['elevation']} m</li>
-  <li>Longitude: ${geometry4326.x} °E</li>
-  <li>Latitude: ${geometry4326.y} °N</li>
+  % endif
+  <li>Coordinates: ${geometry4326.x} °E / ${geometry4326.y} °N</li>
   <li>Maps info: ${get_attr(waypoint, 'maps_info')}</li>
   <li>Description: ${get_attr(locale, 'description')}</li>
 </ul>
@@ -28,7 +47,7 @@ ${locale['title']}
   % endfor
   </ul>
 % endif
-<app-map app-map-center="[${geometry.x}, ${geometry.y}]"></app-map>
+<app-map></app-map>
 <ul>
   <li>History (TODO)</li>
   <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}">Edit</a></li>


### PR DESCRIPTION
This PR adds a FeatureCollection object in the waypoint list page, it is then passed to the map controller in order to show the features on the map.

As for now the collection is passed using a global JS variable and the Angular $window object. Perhaps using a module value (or a service?) would be cleaner but I have not succeeded yet: I got an error saying that the ``app`` module does not (yet?) exist when writing
```
var module = angular.module('app');
module.value('mapFeatureCollection', ...);
```
in https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/templates/waypoint/index.html
Perhaps because this code should be rather added at the end of the HTML page?

Geometries must be provided in the list response from the API => relies on https://github.com/c2corg/v6_common/pull/5