### PR TITLE
Use angular-gettext to translate interface strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ cleanall: clean
 	rm -rf node_modules
 
 .PHONY: compile-catalog
-compile-catalog: c2corg_ui/static/build/locale/fr/c2corg_ui.json
+compile-catalog: c2corg_ui/static/build/locale/fr/c2corg_ui.json c2corg_ui/static/build/locale/de/c2corg_ui.json c2corg_ui/static/build/locale/it/c2corg_ui.json c2corg_ui/static/build/locale/en/c2corg_ui.json c2corg_ui/static/build/locale/es/c2corg_ui.json c2corg_ui/static/build/locale/eu/c2corg_ui.json c2corg_ui/static/build/locale/ca/c2corg_ui.json
 
 .PHONY: test
 test: .build/venv/bin/nosetests
@@ -103,8 +103,8 @@ c2corg_ui/closure/%.py: $(CLOSURE_LIBRARY_PATH)/closure/bin/build/%.py
 c2corg_ui/locale/c2corg_ui-client.pot: $(APP_HTML_FILES)
 	node tools/extract-messages.js $^ > $@
 
-c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po: c2corg_ui/locale/c2corg_ui-client.pot
-	cd c2corg_ui/locale && msgmerge --update fr/LC_MESSAGES/c2corg_ui-client.po c2corg_ui-client.pot
+c2corg_ui/locale/%/LC_MESSAGES/c2corg_ui-client.po: c2corg_ui/locale/c2corg_ui-client.pot
+	msgmerge --update $@ $<
 
 c2corg_ui/static/build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js .build/externs/angular-1.3-http-promise.js .build/node_modules.timestamp
 	mkdir -p $(dir $@)
@@ -118,7 +118,7 @@ c2corg_ui/static/build/build.css: $(LESS_FILES) .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/.bin/lessc less/c2corg_ui.less > $@
 
-c2corg_ui/static/build/locale/fr/c2corg_ui.json: c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+c2corg_ui/static/build/locale/%/c2corg_ui.json: c2corg_ui/locale/%/LC_MESSAGES/c2corg_ui-client.po
 	mkdir -p $(dir $@)
 	node tools/compile-catalog $< > $@
 

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -45,12 +45,12 @@ msgstr ""
 msgid "Culture is required."
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the WP"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -33,6 +33,10 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 #: c2corg_ui/templates/route/edit.html
@@ -80,7 +84,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -89,7 +92,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -148,6 +148,214 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
 #: c2corg_ui/templates/route/index.html
 msgid "{{nbItems}} routes"
 msgstr ""

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -7,10 +7,6 @@ msgstr ""
 msgid "Activities"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Activities is required."
-msgstr ""
-
 #: c2corg_ui/templates/route/index.html
 msgid "Add a route"
 msgstr ""
@@ -40,11 +36,6 @@ msgstr ""
 msgid "Culture"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/route/edit.html
-msgid "Culture is required."
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -71,10 +62,6 @@ msgid "Elevation"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
 msgid "Elevation must be smaller than 9999 m."
 msgstr ""
 
@@ -94,20 +81,12 @@ msgid "Latitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
 msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude is required."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -139,12 +118,12 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/route/edit.html
-msgid "Title"
+msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/route/edit.html
-msgid "Title is required."
+msgid "Title"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -154,10 +133,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type is required."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/view.html

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -172,3 +172,11 @@ msgstr ""
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"
 msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -3,11 +3,169 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: c2corg_ui/templates/index.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities is required."
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Culture is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the WP"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
 msgid "Routes"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Title is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
 msgid "Waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -19,6 +19,10 @@ msgstr ""
 msgid "Back to homepage"
 msgstr ""
 
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/route/edit.html
 msgid "Cancel"

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,361 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itineraris"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Benvingut/da a Camptocamp.org!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
@@ -34,6 +34,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -78,7 +82,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -87,7 +90,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/edit.html
@@ -35,6 +35,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -79,7 +83,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -88,7 +91,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,362 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Routen"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr "Waypoints"
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Willkommen bei Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,362 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr "Activities"
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr "Add a route"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr "Add a waypoint"
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr "Back to homepage"
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr "Browse site in"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr "Cancel"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr "Comment about the changes"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr "Culture"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr "Describe here the gear needed for this route"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr "Describe here the waypoint"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr "Description"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr "Edit"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr "Elevation"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr "Elevation must be smaller than 9999 m."
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr "Gear"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr "Height"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr "Latitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr "Latitude must be between -90° and 90°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr "Longitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr "Longitude must be between -180° and 180°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr "Maps info"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr "Route type"
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Routes"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr "Save"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr "Short description of the applied changes"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr "This field is required."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr "Title"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr "Title is too short."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr "Type"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr "View in other culture:"
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr "Waypoints"
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Welcome to Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr "access"
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr "base_camp"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr "bergschrund"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr "bisse"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr "bivouac"
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr "ca"
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr "camp_site"
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr "cave"
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr "cliff"
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr "climbing_indoor"
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr "climbing_outdoor"
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr "confluence"
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr "de"
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr "en"
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr "es"
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr "eu"
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr "expedition"
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr "fr"
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr "gite"
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr "glacier"
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr "hiking"
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr "hut"
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr "ice_climbing"
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr "it"
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr "lake"
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr "local_product"
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr "locality"
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr "loop"
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr "loop_hut"
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr "misc"
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr "mountain_climbing"
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr "moutain_biking"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr "paragliding"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr "paragliding_landing"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr "paragliding_takeoff"
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr "pass"
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr "pit"
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr "raid"
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr "return_same_way"
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr "rock_climbing"
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr "shelter"
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr "skitouring"
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr "snow_ice_mixed"
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr "snowshoeing"
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr "summit"
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr "traverse"
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr "via_ferrata"
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr "virtual"
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr "waterfall"
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr "waterpoint"
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr "weather_station"
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr "webcam"
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr "{{nbItems}} routes"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr "{{nbItems}} waypoints"

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/edit.html
@@ -36,6 +36,10 @@ msgstr "Cancel"
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
 msgstr "Comment about the changes"
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
@@ -79,7 +83,6 @@ msgid "Height"
 msgstr "Height"
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -88,7 +91,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr "Latitude must be between -90° and 90°."
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr "Longitude"
 

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,362 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itinerarios"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "¡Bienvenido/a a Camptocamp.org!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/edit.html
@@ -35,6 +35,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -79,7 +83,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -88,7 +91,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,361 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Ibilbideak"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Ongi etorri Camptocamp.org-era!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
@@ -34,6 +34,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -78,7 +82,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -87,7 +90,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -165,3 +165,11 @@ msgstr "Points de passage"
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"
 msgstr "Bienvenue sur Camptocamp.org"
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr "{{nbItems}} itinéraires trouvés"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr "{{nbItems}} points de passage trouvés"

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -48,13 +48,13 @@ msgstr "Langue"
 msgid "Culture is required."
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the WP"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr "Décrivez ici l'itinéraire"
 
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
@@ -132,7 +132,7 @@ msgstr "Enregistrer"
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Short description of the applied changes"
-msgstr ""
+msgstr "Courte description des changements appliqués"
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Title"

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "Activities"
 msgstr "Activités"
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Activities is required."
-msgstr ""
-
 #: c2corg_ui/templates/route/index.html
 msgid "Add a route"
 msgstr "Ajouter un itinéraire"
@@ -44,10 +40,6 @@ msgstr "Courte description des changements"
 msgid "Culture"
 msgstr "Langue"
 
-#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
-msgid "Culture is required."
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
@@ -72,10 +64,6 @@ msgid "Elevation"
 msgstr "Altitude"
 
 #: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
 msgid "Elevation must be smaller than 9999 m."
 msgstr "L'altitude doit être inférieure à 9999m."
 
@@ -93,10 +81,6 @@ msgid "Latitude"
 msgstr "Latitude"
 
 #: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
 msgid "Latitude must be between -90° and 90°."
 msgstr "La latitude doit être comprise en -90° et 90°."
 
@@ -104,10 +88,6 @@ msgstr "La latitude doit être comprise en -90° et 90°."
 #: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr "Longitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude is required."
-msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Longitude must be between -180° and 180°."
@@ -135,12 +115,12 @@ msgid "Short description of the applied changes"
 msgstr "Courte description des changements appliqués"
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
-msgid "Title"
-msgstr "Titre"
+msgid "This field is required."
+msgstr "Ce champ est obligatoire."
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
-msgid "Title is required."
-msgstr ""
+msgid "Title"
+msgstr "Titre"
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Title is too short."
@@ -149,10 +129,6 @@ msgstr "Le titre doit comporter au moins 3 caractères."
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Type"
 msgstr "Type"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type is required."
-msgstr ""
 
 #: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
 msgid "View in other culture:"

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -22,6 +22,10 @@ msgstr "Ajouter un point de passage"
 msgid "Back to homepage"
 msgstr "Retour à la page d'accueil"
 
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr "Naviguer en"
+
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Cancel"
 msgstr "Annuler"

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -1,9 +1,5 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2014-10-22 16:08+0200\n"
-"Last-Translator: Eric Lemoine <eric.lemoine@camptocamp.com>\n"
-"Language-Team: French\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -100,7 +96,7 @@ msgstr "Références cartographiques"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Route type"
-msgstr "Itinéraires"
+msgstr "Type d'itinéraire"
 
 #: c2corg_ui/templates/base.html
 msgid "Routes"
@@ -141,6 +137,214 @@ msgstr "Points de passage"
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"
 msgstr "Bienvenue sur Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr "accès"
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr "camp de base"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr "rimaye"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr "bisse"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr "bivouac"
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr "catalan"
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr "camping"
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr "grotte"
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr "falaise"
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr "SAE"
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr "site de couenne/bloc"
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr "confluent"
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr "allemand"
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr "anglais"
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr "espagnol"
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr "basque"
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr "expédition"
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr "français"
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr "gite"
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr "glacier"
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr "randonnée pédestre"
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr "refuge/cabane"
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr "cascade de glace"
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr "italien"
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr "lac"
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr "produit local/commerce"
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr "lieu-dit"
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr "boucle avec retour au pied de la voie"
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr "boucle avec retour au refuge"
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr "divers"
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr "rocher haute montagne"
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr "VTT"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr "parapente"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr "atterrissage parapente"
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr "décollage parapente"
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr "col"
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr "gouffre"
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr "raid"
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr "aller-retour"
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr "escalade"
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr "abri"
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr "ski, surf"
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr "alpinisme neige, glace et mixte"
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr "raquette"
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr "sommet"
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr "traversée"
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr "via ferrata"
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr "virtuel"
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr "cascade"
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr "point d'eau/source"
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr "station météo"
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr "webcam"
 
 #: c2corg_ui/templates/route/index.html
 msgid "{{nbItems}} routes"

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -10,11 +10,155 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: c2corg_ui/templates/index.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr "Activités"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities is required."
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr "Ajouter un itinéraire"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr "Ajouter un point de passage"
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr "Retour à la page d'accueil"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr "Annuler"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr "Courte description des changements"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr "Langue"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Culture is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the WP"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr "Description"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr "Modifier"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr "Altitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr "L'altitude doit être inférieure à 9999m."
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr "Matériel"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr "Dénivelé"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr "Latitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr "La latitude doit être comprise en -90° et 90°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr "Longitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr "La longitude doit être comprise en -180° et 180°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr "Références cartographiques"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr "Itinéraires"
+
+#: c2corg_ui/templates/base.html
 msgid "Routes"
 msgstr "Itinéraires"
 
-#: c2corg_ui/templates/index.html
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr "Enregistrer"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr "Titre"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr "Le titre doit comporter au moins 3 caractères."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr "Type"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr "Afficher dans une autre langue:"
+
+#: c2corg_ui/templates/base.html
 msgid "Waypoints"
 msgstr "Points de passage"
 

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -34,6 +34,10 @@ msgstr "Annuler"
 msgid "Comment about the changes"
 msgstr "Courte description des changements"
 
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr "Coordonnées"
+
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/view.html
@@ -76,7 +80,6 @@ msgid "Height"
 msgstr "Dénivelé"
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -85,7 +88,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr "La latitude doit être comprise en -90° et 90°."
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr "Longitude"
 

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -1,0 +1,362 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: c 2corg_ui\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Activities"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "Add a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "Add a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itinerari"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Benvenuti a Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "base_camp"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bergschrund"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bisse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "camp_site"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "cliff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_indoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "climbing_outdoor"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "confluence"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "expedition"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "gite"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "glacier"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hiking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "ice_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "it"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "lake"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "local_product"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "locality"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "loop_hut"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "misc"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mountain_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "moutain_biking"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_landing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "paragliding_takeoff"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "pit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "return_same_way"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "rock_climbing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "shelter"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "skitouring"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snow_ice_mixed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "snowshoeing"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "summit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "via_ferrata"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "virtual"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterfall"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "waterpoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: c 2corg_ui\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/edit.html
@@ -35,6 +35,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
 msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -79,7 +83,6 @@ msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Latitude"
 msgstr ""
 
@@ -88,7 +91,6 @@ msgid "Latitude must be between -90° and 90°."
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Longitude"
 msgstr ""
 

--- a/c2corg_ui/static/js/lang.js
+++ b/c2corg_ui/static/js/lang.js
@@ -22,7 +22,7 @@ app.langDirective = function() {
     bindToController: true,
     template: '<select ' +
         'ng-model="langCtrl.culture" ' +
-        'ng-options="culture as langCtrl.translate(culture) ' +
+        'ng-options="culture as translate(culture) ' +
         'for culture in ::langCtrl.cultures" ' +
         'ng-change="langCtrl.updateCulture()"></select>'
   };
@@ -34,6 +34,7 @@ app.module.directive('appLang', app.langDirective);
 
 
 /**
+ * @param {angular.Scope} $rootScope The rootScope provider.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string} langUrlTemplate Language URL template.
  * @param {ngeo.GetBrowserLanguage} ngeoGetBrowserLanguage
@@ -42,7 +43,7 @@ app.module.directive('appLang', app.langDirective);
  * @export
  * @ngInject
  */
-app.LangController = function(gettextCatalog, langUrlTemplate,
+app.LangController = function($rootScope, gettextCatalog, langUrlTemplate,
     ngeoGetBrowserLanguage) {
 
   /**
@@ -64,16 +65,17 @@ app.LangController = function(gettextCatalog, langUrlTemplate,
   this.culture = ngeoGetBrowserLanguage(this['cultures']) || 'fr';
   // TODO: save user choice in web storage and use it when available
   this.updateCulture();
-};
 
-
-/**
- * @param {string} str String to translate.
- * @return {string} Translated string.
- * @export
- */
-app.LangController.prototype.translate = function(str) {
-  return this.gettextCatalog_.getString(str);
+  /**
+   * Put angular-gettext's translate function on the scope to translate
+   * ng-options based dropdown lists. See
+   * https://github.com/rubenv/angular-gettext/issues/58
+   * @param {string} str String to translate.
+   * @return {string} Translated string.
+   */
+  $rootScope['translate'] = function(str) {
+    return gettextCatalog.getString(str);
+  };
 };
 
 

--- a/c2corg_ui/static/js/lang.js
+++ b/c2corg_ui/static/js/lang.js
@@ -1,0 +1,90 @@
+goog.provide('app.LangController');
+goog.provide('app.langDirective');
+
+goog.require('app');
+goog.require('ngeo.GetBrowserLanguage');
+
+
+/**
+ * This directive is used to display a lang selector dropdown.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.langDirective = function() {
+  return {
+    restrict: 'E',
+    scope: {
+      'cultures': '=appLangCultures'
+    },
+    controller: 'AppLangController',
+    controllerAs: 'langCtrl',
+    bindToController: true,
+    template: '<select ' +
+        'ng-model="langCtrl.culture" ' +
+        'ng-options="culture as langCtrl.translate(culture) ' +
+        'for culture in ::langCtrl.cultures" ' +
+        'ng-change="langCtrl.updateCulture()"></select>'
+  };
+};
+
+
+app.module.directive('appLang', app.langDirective);
+
+
+
+/**
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {string} langUrlTemplate Language URL template.
+ * @param {ngeo.GetBrowserLanguage} ngeoGetBrowserLanguage
+ *        GetBrowserLanguage Service.
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.LangController = function(gettextCatalog, langUrlTemplate,
+    ngeoGetBrowserLanguage) {
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.langUrlTemplate_ = langUrlTemplate;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.culture = ngeoGetBrowserLanguage(this['cultures']) || 'fr';
+  // TODO: save user choice in web storage and use it when available
+  this.updateCulture();
+};
+
+
+/**
+ * @param {string} str String to translate.
+ * @return {string} Translated string.
+ * @export
+ */
+app.LangController.prototype.translate = function(str) {
+  return this.gettextCatalog_.getString(str);
+};
+
+
+/**
+ * @export
+ */
+app.LangController.prototype.updateCulture = function() {
+  this.gettextCatalog_.setCurrentLanguage(this.culture);
+  this.gettextCatalog_.loadRemote(
+      this.langUrlTemplate_.replace('__lang__', this.culture));
+};
+
+
+app.module.controller('AppLangController', app.LangController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -8,4 +8,5 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.documentEditingDirective');
+goog.require('app.langDirective');
 goog.require('app.mapDirective');

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -7,32 +7,14 @@ goog.require('app');
 /**
  * @param {angular.Scope} $rootScope The rootScope provider.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
- * @param {string} langUrlTemplate Language URL template.
  * @constructor
  * @export
  * @ngInject
  */
-app.MainController = function($rootScope, gettextCatalog, langUrlTemplate) {
+app.MainController = function($rootScope, gettextCatalog) {
 
   /**
-   * @type {angularGettext.Catalog}
-   * @private
-   */
-  this.gettextCatalog_ = gettextCatalog;
-
-  /**
-   * @type {string}
-   * @private
-   */
-  this.langUrlTemplate_ = langUrlTemplate;
-
-  /**
-   * @type {string}
-   * @export
-   */
-  this.lang;
-
-  /**
+   * TODO: use langController instead?
    * Put angular-gettext's translate function on the scope to translate
    * ng-options based dropdown lists. See
    * https://github.com/rubenv/angular-gettext/issues/58
@@ -42,20 +24,6 @@ app.MainController = function($rootScope, gettextCatalog, langUrlTemplate) {
   $rootScope['translate'] = function(str) {
     return gettextCatalog.getString(str);
   };
-
-  this.switchLanguage('fr');
-};
-
-
-/**
- * @param {string} lang Language code.
- * @export
- */
-app.MainController.prototype.switchLanguage = function(lang) {
-  this.gettextCatalog_.setCurrentLanguage(lang);
-  this.gettextCatalog_.loadRemote(
-      this.langUrlTemplate_.replace('__lang__', lang));
-  this.lang = lang;
 };
 
 

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -5,13 +5,14 @@ goog.require('app');
 
 
 /**
+ * @param {angular.Scope} $rootScope The rootScope provider.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string} langUrlTemplate Language URL template.
  * @constructor
  * @export
  * @ngInject
  */
-app.MainController = function(gettextCatalog, langUrlTemplate) {
+app.MainController = function($rootScope, gettextCatalog, langUrlTemplate) {
 
   /**
    * @type {angularGettext.Catalog}
@@ -30,6 +31,17 @@ app.MainController = function(gettextCatalog, langUrlTemplate) {
    * @export
    */
   this.lang;
+
+  /**
+   * Put angular-gettext's translate function on the scope to translate
+   * ng-options based dropdown lists. See
+   * https://github.com/rubenv/angular-gettext/issues/58
+   * @param {string} str String to translate.
+   * @return {string} Translated string.
+   */
+  $rootScope['translate'] = function(str) {
+    return gettextCatalog.getString(str);
+  };
 
   this.switchLanguage('fr');
 };

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -5,25 +5,11 @@ goog.require('app');
 
 
 /**
- * @param {angular.Scope} $rootScope The rootScope provider.
- * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @constructor
  * @export
  * @ngInject
  */
-app.MainController = function($rootScope, gettextCatalog) {
-
-  /**
-   * TODO: use langController instead?
-   * Put angular-gettext's translate function on the scope to translate
-   * ng-options based dropdown lists. See
-   * https://github.com/rubenv/angular-gettext/issues/58
-   * @param {string} str String to translate.
-   * @return {string} Translated string.
-   */
-  $rootScope['translate'] = function(str) {
-    return gettextCatalog.getString(str);
-  };
+app.MainController = function() {
 };
 
 

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -4,8 +4,7 @@
     closure_library_path = settings.get('closure_library_path')
 %>\
 <!DOCTYPE html>
-## FIXME: use document culture instead of controller lang
-<html lang={{mainCtrl.lang}} ng-app="app" ng-controller="MainController as mainCtrl">
+<html <%block name="pagelang">lang="{{mainCtrl.lang}}"</%block> ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
     <title><%block name="pagetitle">Camptocamp.org</%block></title>
     <meta charset="utf-8">

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -1,7 +1,7 @@
 <%
-    settings = request.registry.settings
-    node_modules_path = settings.get('node_modules_path')
-    closure_library_path = settings.get('closure_library_path')
+settings = request.registry.settings
+node_modules_path = settings.get('node_modules_path')
+closure_library_path = settings.get('closure_library_path')
 %>\
 <!DOCTYPE html>
 <html <%block name="pagelang">lang="{{mainCtrl.lang}}"</%block> ng-app="app" ng-controller="MainController as mainCtrl">
@@ -34,6 +34,11 @@
 
     <div class="page-content">
       ${self.body()}
+    </div>
+
+    <div class="culture-selector">
+      <label translate>Browse site in</label>
+      <app-lang app-lang-cultures="['${"','".join(default_cultures) |n}']"></app-lang>
     </div>
 
 % if debug:

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -4,7 +4,7 @@ node_modules_path = settings.get('node_modules_path')
 closure_library_path = settings.get('closure_library_path')
 %>\
 <!DOCTYPE html>
-<html <%block name="pagelang">lang="{{mainCtrl.lang}}"</%block> ng-app="app" ng-controller="MainController as mainCtrl">
+<html <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
     <title><%block name="pagetitle">Camptocamp.org</%block></title>
     <meta charset="utf-8">

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -4,6 +4,7 @@
     closure_library_path = settings.get('closure_library_path')
 %>\
 <!DOCTYPE html>
+## FIXME: use document culture instead of controller lang
 <html lang={{mainCtrl.lang}} ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
     <title><%block name="pagetitle">Camptocamp.org</%block></title>
@@ -25,10 +26,10 @@
   <body>
 
     <div id="page-header">
-    <a href="${request.route_url('index')}" title="Back to homepage"><img src="${request.static_url('c2corg_ui:static/img/logo.png')}" alt="Camptocamp.org" /></a>
+    <a href="${request.route_url('index')}" title="{{'Back to homepage'|translate}}"><img src="${request.static_url('c2corg_ui:static/img/logo.png')}" alt="Camptocamp.org" /></a>
     <ul>
-      <li><a href="${request.route_url('waypoints_index')}">Waypoints</a></li>
-      <li><a href="${request.route_url('routes_index')}">Routes</a></li>
+      <li><a href="${request.route_url('waypoints_index')}" translate>Waypoints</a></li>
+      <li><a href="${request.route_url('routes_index')}" translate>Routes</a></li>
     </ul>
     </div>
 

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -1,0 +1,64 @@
+<!--
+dummy template containing strings that must be detected by angular-gettext
+See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
+-->
+
+<!-- languages -->
+<span translate>fr</span>
+<span translate>en</span>
+<span translate>de</span>
+<span translate>it</span>
+<span translate>es</span>
+<span translate>ca</span>
+<span translate>eu</span>
+
+<!-- activities -->
+<span translate>skitouring</span>
+<span translate>snow_ice_mixed</span>
+<span translate>mountain_climbing</span>
+<span translate>rock_climbing</span>
+<span translate>ice_climbing</span>
+<span translate>hiking</span>
+<span translate>snowshoeing</span>
+<span translate>paragliding</span>
+<span translate>moutain_biking</span>
+<span translate>via_ferrata</span>
+
+<!-- waypoint_types -->
+<span translate>summit</span>
+<span translate>pass</span>
+<span translate>lake</span>
+<span translate>bisse</span>
+<span translate>waterfall</span>
+<span translate>cliff</span>
+<span translate>cave</span>
+<span translate>pit</span>
+<span translate>locality</span>
+<span translate>confluence</span>
+<span translate>glacier</span>
+<span translate>bergschrund</span>
+<span translate>waterpoint</span>
+<span translate>climbing_outdoor</span>
+<span translate>climbing_indoor</span>
+<span translate>gite</span>
+<span translate>camp_site</span>
+<span translate>hut</span>
+<span translate>shelter</span>
+<span translate>bivouac</span>
+<span translate>base_camp</span>
+<span translate>access</span>
+<span translate>local_product</span>
+<span translate>paragliding_takeoff</span>
+<span translate>paragliding_landing</span>
+<span translate>weather_station</span>
+<span translate>webcam</span>
+<span translate>virtual</span>
+<span translate>misc</span>
+
+<!-- route types -->
+<span translate>return_same_way</span>
+<span translate>loop</span>
+<span translate>loop_hut</span>
+<span translate>traverse</span>
+<span translate>raid</span>
+<span translate>expedition</span>

--- a/c2corg_ui/templates/index.html
+++ b/c2corg_ui/templates/index.html
@@ -2,7 +2,3 @@
 
 <h1 translate>Welcome to Camptocamp.org</h1>
 <app-map></app-map>
-<ul>
-  <li><a href="${request.route_url('waypoints_index')}" translate>Waypoints</a></li>
-  <li><a href="${request.route_url('routes_index')}" translate>Routes</a></li>
-</ul>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -14,7 +14,7 @@ FIXME: Adding/editing page title
 % endif
   name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
   <div id="culture-group" class="form-group" ng-class="{ 'has-error': editForm.culture.$touched && editForm.culture.$invalid }">
-    <label>Culture</label>
+    <label translate>Culture</label>
     % if route_culture:
       ${route_culture}
     % else:
@@ -22,61 +22,60 @@ FIXME: Adding/editing page title
         ng-model="route.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
-        <p ng-message="required">Culture is required.</p> 
+        <p ng-message="required" translate>Culture is required.</p> 
       </div>
     % endif
   </div>
   <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid }">
-    <label>Title</label>
+    <label translate>Title</label>
     <input type="text" name="title" ng-model="route.locales[0].title" class="form-control" required ng-minlength="3" />
     <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched">
-      <p ng-message="required">Title is required.</p> 
-      <p ng-message="minlength">Title is too short.</p>
+      <p ng-message="required" translate>Title is required.</p> 
+      <p ng-message="minlength" translate>Title is too short.</p>
     </div>
   </div>
   <div id="activities-group" class="form-group" ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid }">
-    <label>Activities (TODO: use checkboxes)</label>
+    <label translate>Activities</label>
     <select name="activities" ng-options="activity for activity in ['${"','".join(activities) |n}']"
       ng-model="route.activities" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.activities.$error" ng-if="editForm.activities.$touched">
-      <p ng-message="required">Activities is required.</p> 
+      <p ng-message="required" translate>Activities is required.</p> 
     </div>
   </div>
   <div id="height_diff_up-group" class="form-group" ng-class="{ 'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid }">
-    <label>Height</label>
+    <label translate>Height</label>
     <input type="number" name="height_diff_up" ng-model="route.height_diff_up" class="form-control" /> m
   </div>
   <div id="route_type-group" class="form-group">
-    <label>Route type</label>
+    <label translate>Route type</label>
     <select name="route_type" ng-options="type for type in ['${"','".join(route_types) |n}']"
       ng-model="route.route_type" class="form-control">
     </select>
   </div>
   <div id="description-group" class="form-group">
-    <label>Description</label>
+    <label translate>Description</label>
     <textarea name="description" ng-model="route.locales[0].description" class="form-control"></textarea>
   </div>
   <div id="gear-group" class="form-group">
-    <label>Gear</label>
-    <textarea name="gear" ng-model="route.locales[0].gear" class="form-control" placeholder="Describe here the gear needed for this route"></textarea>
+    <label translate>Gear</label>
+    <textarea name="gear" ng-model="route.locales[0].gear" class="form-control" placeholder="{{'Describe here the gear needed for this route'|translate}}"></textarea>
   </div>
   % if updating_doc:
   <div id="message-group" class="form-group">
-    <label>Comment about the changes</label>
-    <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="Short description of the applied changes" />
+    <label translate>Comment about the changes</label>
+    <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes'|translate}}" />
   </div>
   % endif
   <p>
-    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid">Save</button>
+    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid" translate>Save</button>
     <%
     if updating_doc:
         cancel_url = request.route_url('routes_view', id=route_id, culture=route_culture)
     else:
         cancel_url = request.route_url('routes_index')
     %>
-    <a href="${cancel_url}">Cancel</a>
+    <a href="${cancel_url}" translate>Cancel</a>
   </p>
+  <app-map app-map-edit-ctrl="editCtrl"></app-map>
 </form>
-<h2>Georeferencing the route</h2>
-<app-map></app-map>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -22,7 +22,7 @@ FIXME: Adding/editing page title
         ng-model="route.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
-        <p ng-message="required" translate>Culture is required.</p> 
+        <p ng-message="required" translate>This field is required.</p> 
       </div>
     % endif
   </div>
@@ -30,7 +30,7 @@ FIXME: Adding/editing page title
     <label translate>Title</label>
     <input type="text" name="title" ng-model="route.locales[0].title" class="form-control" required ng-minlength="3" />
     <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched">
-      <p ng-message="required" translate>Title is required.</p> 
+      <p ng-message="required" translate>This field is required.</p> 
       <p ng-message="minlength" translate>Title is too short.</p>
     </div>
   </div>
@@ -40,7 +40,7 @@ FIXME: Adding/editing page title
       ng-model="route.activities" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.activities.$error" ng-if="editForm.activities.$touched">
-      <p ng-message="required" translate>Activities is required.</p> 
+      <p ng-message="required" translate>This field is required.</p> 
     </div>
   </div>
   <div id="height_diff_up-group" class="form-group" ng-class="{ 'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid }">

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -16,9 +16,9 @@ FIXME: Adding/editing page title
   <div id="culture-group" class="form-group" ng-class="{ 'has-error': editForm.culture.$touched && editForm.culture.$invalid }">
     <label translate>Culture</label>
     % if route_culture:
-      ${route_culture}
+      {{translate('${route_culture}')}}
     % else:
-      <select name="culture" ng-options="culture for culture in ['${"','".join(default_cultures) |n}']" 
+      <select name="culture" ng-options="culture as translate(culture) for culture in ['${"','".join(default_cultures) |n}']" 
         ng-model="route.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
@@ -36,7 +36,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="activities-group" class="form-group" ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid }">
     <label translate>Activities</label>
-    <select name="activities" ng-options="activity for activity in ['${"','".join(activities) |n}']"
+    <select name="activities" ng-options="activity as translate(activity) for activity in ['${"','".join(activities) |n}']"
       ng-model="route.activities" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.activities.$error" ng-if="editForm.activities.$touched">
@@ -49,7 +49,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="route_type-group" class="form-group">
     <label translate>Route type</label>
-    <select name="route_type" ng-options="type for type in ['${"','".join(route_types) |n}']"
+    <select name="route_type" ng-options="type as translate(type) for type in ['${"','".join(route_types) |n}']"
       ng-model="route.route_type" class="form-control">
     </select>
   </div>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -2,10 +2,7 @@
 <%
 updating_doc = route_id and route_culture
 %>\
-
-<%block name="pagetitle">
-FIXME: Adding/editing page title
-</%block>
+<%block name="pagetitle">FIXME: Adding/editing page title</%block>
 
 <h1>${self.pagetitle()}</h1>
 <form app-document-editing="routes" app-document-editing-model="route" 

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -6,7 +6,7 @@ Routes
 
 <h1>${self.pagetitle()}</h1>
 <app-map></app-map>
-<p>${total} routes</p>
+<p translate ng-init="nbItems = ${total}">{{nbItems}} routes</p>
 <ul>
   <li><a href="${request.route_url('routes_add')}" translate>Add a route</a></li>
 % for route in routes:

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -8,7 +8,7 @@ Routes
 <app-map></app-map>
 <p>${total} routes</p>
 <ul>
-  <li><a href="${request.route_url('routes_add')}">Add a route</a></li>
+  <li><a href="${request.route_url('routes_add')}" translate>Add a route</a></li>
 % for route in routes:
   <li>
   % for locale in route['locales']:

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,8 +1,5 @@
 <%inherit file="../base.html"/>
-
-<%block name="pagetitle">
-Routes
-</%block>
+<%block name="pagetitle">Routes</%block>
 
 <h1>${self.pagetitle()}</h1>
 <app-map></app-map>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -4,10 +4,8 @@
 route_id = route['document_id']
 other_cultures = filter(lambda l: l != culture, route['available_cultures'])
 %>\
-
-<%block name="pagetitle">
-${locale['title']}
-</%block>
+<%block name="pagelang">lang="${culture}"</%block>
+<%block name="pagetitle">${locale['title']}</%block>
 
 <h1>${self.pagetitle()}</h1>
 <ul>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -12,7 +12,7 @@ ${locale['title']}
 <h1>${self.pagetitle()}</h1>
 <ul>
   <li>Id: ${route_id}</li>
-  <li><span translate>Culture</span> : ${culture}</li>
+  <li><span translate>Culture</span> : {{translate('${culture}')}}</li>
   <li><span translate>Height</span> : ${route['height_diff_up']} m</li>
   <li><span translate>Description</span> : ${get_attr(locale, 'description')}</li>
   <li><span translate>Gear</span> : ${get_attr(locale, 'gear')}</li>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -12,13 +12,13 @@ ${locale['title']}
 <h1>${self.pagetitle()}</h1>
 <ul>
   <li>Id: ${route_id}</li>
-  <li>Culture: ${culture}</li>
-  <li>Height: ${route['height_diff_up']} m</li>
-  <li>Description: ${get_attr(locale, 'description')}</li>
-  <li>Gear: ${get_attr(locale, 'gear')}</li>
+  <li><span translate>Culture</span> : ${culture}</li>
+  <li><span translate>Height</span> : ${route['height_diff_up']} m</li>
+  <li><span translate>Description</span> : ${get_attr(locale, 'description')}</li>
+  <li><span translate>Gear</span> : ${get_attr(locale, 'gear')}</li>
 </ul>
 % if other_cultures:
-  <p>View in other culture:</p>
+  <p translate>View in other culture:</p>
   <ul>
   % for l in other_cultures:
     <li><a href="${request.route_url('routes_view', id=route_id, culture=l)}">${l}</a></li>
@@ -28,6 +28,6 @@ ${locale['title']}
 <app-map></app-map>
 <ul>
   <li>History (TODO)</li>
-  <li><a href="${request.route_url('routes_edit', id=route_id, culture=culture)}">Edit</a></li>
+  <li><a href="${request.route_url('routes_edit', id=route_id, culture=culture)}" translate>Edit</a></li>
 </ul>
 

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -22,7 +22,7 @@ FIXME: Adding/editing page title
         ng-model="waypoint.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
-        <p ng-message="required" translate>Culture is required.</p> 
+        <p ng-message="required" translate>This field is required.</p> 
       </div>
     % endif
   </div>
@@ -30,7 +30,7 @@ FIXME: Adding/editing page title
     <label translate>Title</label>
     <input type="text" name="title" ng-model="waypoint.locales[0].title" class="form-control" required ng-minlength="3" />
     <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched">
-      <p ng-message="required" translate>Title is required.</p> 
+      <p ng-message="required" translate>This field is required.</p> 
       <p ng-message="minlength" translate>Title is too short.</p>
     </div>
   </div>
@@ -40,14 +40,14 @@ FIXME: Adding/editing page title
       ng-model="waypoint.waypoint_type" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.waypoint_type.$error" ng-if="editForm.waypoint_type.$touched">
-      <p ng-message="required" translate>Type is required.</p> 
+      <p ng-message="required" translate>This field is required.</p> 
     </div>
   </div>
   <div id="elevation-group" class="form-group" ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid }">
     <label translate>Elevation</label>
     <input type="number" name="elevation" ng-model="waypoint.elevation" class="form-control" required max="9999" /> m
     <div class="help-block" ng-messages="editForm.elevation.$error" ng-if="editForm.elevation.$touched">
-      <p ng-message="required" translate>Elevation is required.</p> 
+      <p ng-message="required" translate>This field is required.</p> 
       <p ng-message="max" translate>Elevation must be smaller than 9999 m.</p>
     </div>
   </div>
@@ -55,7 +55,7 @@ FIXME: Adding/editing page title
     <label translate>Longitude</label>
     <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" class="form-control" required min="-180" max="180" /> °E
     <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$touched">
-      <p ng-message="required" translate>Longitude is required.</p>
+      <p ng-message="required" translate>This field is required.</p>
       <p ng-message="min" translate>Longitude must be between -180° and 180°.</p>
       <p ng-message="max" translate>Longitude must be between -180° and 180°.</p>
     </div>
@@ -64,7 +64,7 @@ FIXME: Adding/editing page title
     <label translate>Latitude</label>
     <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" class="form-control" required required min="-90" max="90" /> °N
     <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$touched">
-      <p ng-message="required" translate>Latitude is required.</p>
+      <p ng-message="required" translate>This field is required.</p>
       <p ng-message="min" translate>Latitude must be between -90° and 90°.</p>
       <p ng-message="max" translate>Latitude must be between -90° and 90°.</p>
     </div>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -16,9 +16,9 @@ FIXME: Adding/editing page title
   <div id="culture-group" class="form-group" ng-class="{ 'has-error': editForm.culture.$touched && editForm.culture.$invalid }">
     <label translate>Culture</label>
     % if waypoint_culture:
-      ${waypoint_culture}
+      {{translate('${waypoint_culture}')}}
     % else:
-      <select name="culture" ng-options="culture for culture in ['${"','".join(default_cultures) |n}']" 
+      <select name="culture" ng-options="culture as translate(culture) for culture in ['${"','".join(default_cultures) |n}']" 
         ng-model="waypoint.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
@@ -36,7 +36,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="waypoint_type-group" class="form-group" ng-class="{ 'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid }">
     <label translate>Type</label>
-    <select name="waypoint_type" ng-options="type for type in ['${"','".join(waypoint_types) |n}']"
+    <select name="waypoint_type" ng-options="type as translate(type) for type in ['${"','".join(waypoint_types) |n}']"
       ng-model="waypoint.waypoint_type" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.waypoint_type.$error" ng-if="editForm.waypoint_type.$touched">

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -14,7 +14,7 @@ FIXME: Adding/editing page title
 % endif
   name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
   <div id="culture-group" class="form-group" ng-class="{ 'has-error': editForm.culture.$touched && editForm.culture.$invalid }">
-    <label>Culture</label>
+    <label translate>Culture</label>
     % if waypoint_culture:
       ${waypoint_culture}
     % else:
@@ -22,76 +22,76 @@ FIXME: Adding/editing page title
         ng-model="waypoint.locales[0].culture" class="form-control" required>
       </select>
       <div class="help-block" ng-messages="editForm.culture.$error" ng-if="editForm.culture.$touched">
-        <p ng-message="required">Culture is required.</p> 
+        <p ng-message="required" translate>Culture is required.</p> 
       </div>
     % endif
   </div>
   <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid }">
-    <label>Title</label>
+    <label translate>Title</label>
     <input type="text" name="title" ng-model="waypoint.locales[0].title" class="form-control" required ng-minlength="3" />
     <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched">
-      <p ng-message="required">Title is required.</p> 
-      <p ng-message="minlength">Title is too short.</p>
+      <p ng-message="required" translate>Title is required.</p> 
+      <p ng-message="minlength" translate>Title is too short.</p>
     </div>
   </div>
   <div id="waypoint_type-group" class="form-group" ng-class="{ 'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid }">
-    <label>Type</label>
+    <label translate>Type</label>
     <select name="waypoint_type" ng-options="type for type in ['${"','".join(waypoint_types) |n}']"
       ng-model="waypoint.waypoint_type" class="form-control" required>
     </select>
     <div class="help-block" ng-messages="editForm.waypoint_type.$error" ng-if="editForm.waypoint_type.$touched">
-      <p ng-message="required">Type is required.</p> 
+      <p ng-message="required" translate>Type is required.</p> 
     </div>
   </div>
   <div id="elevation-group" class="form-group" ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid }">
-    <label>Elevation</label>
+    <label translate>Elevation</label>
     <input type="number" name="elevation" ng-model="waypoint.elevation" class="form-control" required max="9999" /> m
     <div class="help-block" ng-messages="editForm.elevation.$error" ng-if="editForm.elevation.$touched">
-      <p ng-message="required">Elevation is required.</p> 
-      <p ng-message="max">Elevation must be smaller than 9999 m.</p>
+      <p ng-message="required" translate>Elevation is required.</p> 
+      <p ng-message="max" translate>Elevation must be smaller than 9999 m.</p>
     </div>
   </div>
   <div id="longitude-group" class="form-group" ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid }">
-    <label>Longitude</label>
+    <label translate>Longitude</label>
     <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" class="form-control" required min="-180" max="180" /> °E
     <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$touched">
-      <p ng-message="required">Longitude is required.</p>
-      <p ng-message="min">Longitude must be between -180° and 180°.</p>
-      <p ng-message="max">Longitude must be between -180° and 180°.</p>
+      <p ng-message="required" translate>Longitude is required.</p>
+      <p ng-message="min" translate>Longitude must be between -180° and 180°.</p>
+      <p ng-message="max" translate>Longitude must be between -180° and 180°.</p>
     </div>
   </div>
   <div id="latitude-group" class="form-group" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid }">
-    <label>Latitude</label>
+    <label translate>Latitude</label>
     <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" class="form-control" required required min="-90" max="90" /> °N
     <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$touched">
-      <p ng-message="required">Latitude is required.</p>
-      <p ng-message="min">Latitude must be between -90° and 90°.</p>
-      <p ng-message="max">Latitude must be between -90° and 90°.</p>
+      <p ng-message="required" translate>Latitude is required.</p>
+      <p ng-message="min" translate>Latitude must be between -90° and 90°.</p>
+      <p ng-message="max" translate>Latitude must be between -90° and 90°.</p>
     </div>
   </div>
   <div id="maps_info-group" class="form-group">
-    <label>Maps info</label>
+    <label translate>Maps info</label>
     <input type="text" name="maps_info" ng-model="waypoint.maps_info" class="form-control" />
   </div>
   <div id="description-group" class="form-group">
-    <label>Description</label>
-    <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="Describe here the WP"></textarea>
+    <label translate>Description</label>
+    <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the WP'|translate}}"></textarea>
   </div>
   % if updating_doc:
   <div id="message-group" class="form-group">
-    <label>Comment about the changes</label>
-    <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="Short description of the applied changes" />
+    <label translate>Comment about the changes</label>
+    <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes'|translate}}" />
   </div>
   % endif
   <p>
-    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid">Save</button>
+    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid" translate>Save</button>
     <%
     if updating_doc:
         cancel_url = request.route_url('waypoints_view', id=waypoint_id, culture=waypoint_culture)
     else:
         cancel_url = request.route_url('waypoints_index')
     %>
-    <a href="${cancel_url}">Cancel</a>
+    <a href="${cancel_url}" translate>Cancel</a>
   </p>
   <app-map app-map-edit-ctrl="editCtrl"></app-map>
 </form>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -75,7 +75,7 @@ FIXME: Adding/editing page title
   </div>
   <div id="description-group" class="form-group">
     <label translate>Description</label>
-    <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the WP'|translate}}"></textarea>
+    <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the waypoint'|translate}}"></textarea>
   </div>
   % if updating_doc:
   <div id="message-group" class="form-group">

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -2,10 +2,7 @@
 <%
 updating_doc = waypoint_id and waypoint_culture
 %>\
-
-<%block name="pagetitle">
-FIXME: Adding/editing page title
-</%block>
+<%block name="pagetitle">FIXME: Adding/editing page title</%block>
 
 <h1>${self.pagetitle()}</h1>
 <form app-document-editing="waypoints" app-document-editing-model="waypoint"

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -29,7 +29,7 @@ module.value('mapFeatureCollection', {
 % if len(waypoints):
   <app-map></app-map>
 % endif
-<p>${total} waypoints</p>
+<p translate ng-init="nbItems = ${total}">{{nbItems}} waypoints</p>
 <ul>
   <li><a href="${request.route_url('waypoints_add')}" translate>Add a waypoint</a></li>
 % for waypoint in waypoints:

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,8 +1,5 @@
-<%inherit file="../base.html"/>\
-
-<%block name="pagetitle">
-Waypoints 
-</%block>\
+<%inherit file="../base.html"/>
+<%block name="pagetitle">Waypoints</%block>\
 
 <%block name="moduleConstantsValues">
 % if len(waypoints):

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -31,7 +31,7 @@ module.value('mapFeatureCollection', {
 % endif
 <p>${total} waypoints</p>
 <ul>
-  <li><a href="${request.route_url('waypoints_add')}">Add a waypoint</a></li>
+  <li><a href="${request.route_url('waypoints_add')}" translate>Add a waypoint</a></li>
 % for waypoint in waypoints:
   <li>
   % for locale in waypoint['locales']:

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -5,10 +5,8 @@ waypoint_id = waypoint['document_id']
 other_cultures = filter(lambda l: l != culture, waypoint['available_cultures'])
 geometry4326 = transform(geometry, 'epsg:3857', 'epsg:4326')
 %>\
-
-<%block name="pagetitle">
-${locale['title']}
-</%block>\
+<%block name="pagelang">lang="${culture}"</%block>
+<%block name="pagetitle">${locale['title']}</%block>
 
 <%block name="moduleConstantsValues">
 module.value('mapFeatureCollection', {

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -30,17 +30,14 @@ module.value('mapFeatureCollection', {
 <h1>${self.pagetitle()}</h1>
 <ul>
   <li>Id: ${waypoint_id}</li>
-  <li>Culture: ${culture}</li>
-  <li>Type: ${waypoint['waypoint_type']}</li>
-  % if waypoint['waypoint_type'] != 'climbing_outdoor':
-  <li>Elevation: ${waypoint['elevation']} m</li>
-  % endif
-  <li>Coordinates: ${geometry4326.x} °E / ${geometry4326.y} °N</li>
-  <li>Maps info: ${get_attr(waypoint, 'maps_info')}</li>
-  <li>Description: ${get_attr(locale, 'description')}</li>
+  <li><span translate>Culture</span> : ${culture}</li>
+  <li><span translate>Elevation</span> : ${waypoint['elevation']} m</li>
+  <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>
+  <li><span translate>Maps info</span> : ${get_attr(waypoint, 'maps_info')}</li>
+  <li><span translate>Description</span> : ${get_attr(locale, 'description')}</li>
 </ul>
 % if other_cultures:
-  <p>View in other culture:</p>
+  <p translate>View in other culture:</p>
   <ul>
   % for l in other_cultures:
     <li><a href="${request.route_url('waypoints_view', id=waypoint_id, culture=l)}">${l}</a></li>
@@ -50,5 +47,5 @@ module.value('mapFeatureCollection', {
 <app-map></app-map>
 <ul>
   <li>History (TODO)</li>
-  <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}">Edit</a></li>
+  <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}" translate>Edit</a></li>
 </ul>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -30,7 +30,7 @@ module.value('mapFeatureCollection', {
 <h1>${self.pagetitle()}</h1>
 <ul>
   <li>Id: ${waypoint_id}</li>
-  <li><span translate>Culture</span> : ${culture}</li>
+  <li><span translate>Culture</span> : {{translate('${culture}')}}</li>
   <li><span translate>Elevation</span> : ${waypoint['elevation']} m</li>
   <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>
   <li><span translate>Maps info</span> : ${get_attr(waypoint, 'maps_info')}</li>

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -21,6 +21,7 @@ class Document(object):
         self.settings = request.registry.settings
         self.template_input = {
             'debug': 'debug' in self.request.params,
+            'default_cultures': default_cultures,
             'api_url': self.settings['api_url']
         }
 

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -1,4 +1,5 @@
 from pyramid.view import view_config
+from c2corg_common.attributes import default_cultures
 
 
 @view_config(route_name='index',
@@ -6,5 +7,6 @@ from pyramid.view import view_config
 def index(request):
     return {
         'debug': 'debug' in request.params,
+        'default_cultures': default_cultures,
         'api_url': request.registry.settings['api_url']
     }

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -1,7 +1,7 @@
 from pyramid.view import view_config
 
 from c2corg_ui.views.document import Document
-from c2corg_common.attributes import default_cultures, activities, route_types
+from c2corg_common.attributes import activities, route_types
 
 
 class Route(Document):
@@ -37,7 +37,6 @@ class Route(Document):
     def edit(self):
         id, culture = self._validate_id_culture()
         self.template_input.update({
-            'default_cultures': default_cultures,
             'activities': activities,
             'route_types': route_types,
             'route_culture': culture,

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -1,7 +1,7 @@
 from pyramid.view import view_config
 
 from c2corg_ui.views.document import Document
-from c2corg_common.attributes import default_cultures, waypoint_types
+from c2corg_common.attributes import waypoint_types
 
 
 class Waypoint(Document):
@@ -39,7 +39,6 @@ class Waypoint(Document):
     def edit(self):
         id, culture = self._validate_id_culture()
         self.template_input.update({
-            'default_cultures': default_cultures,
             'waypoint_types': waypoint_types,
             'waypoint_culture': culture,
             'waypoint_id': id

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -3,3 +3,9 @@
 .map {
   height: 400px;
 }
+
+.culture-selector {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}


### PR DESCRIPTION
Use built-in angular-gettext [1] to translate the interface strings in french.

Some points still need to be fixed:
* [x] form input placeholders or logo title
* [ ] ng-messages (form validation errors)
* [x] values of ng-repeat combos (for ex in editing form)
* [x] strings containing Mako variables (for ex ``${total} waypoints``) 
* [x] use doc culture as ``<html lang="{lang}">`` instead of interface culture
* [x] add interface culture selector

Related to https://github.com/c2corg/v6_ui/issues/6

[1] https://angular-gettext.rocketeer.be/dev-guide/getting-started/