### PR TITLE
[WIP] Add slug to document URLs

### DIFF
--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -16,12 +16,12 @@ def main(global_config, **settings):
     config.add_route('index', '/')
 
     config.add_route('waypoints_index', '/waypoints')
-    config.add_route('waypoints_view', '/waypoints/{id}/{culture}')
+    config.add_route('waypoints_view', '/waypoints/{id}/{culture}/{slug}')
     config.add_route('waypoints_add', '/waypoints/add')
     config.add_route('waypoints_edit', '/waypoints/edit/{id}/{culture}')
 
     config.add_route('routes_index', '/routes')
-    config.add_route('routes_view', '/routes/{id}/{culture}')
+    config.add_route('routes_view', '/routes/{id}/{culture}/{slug}')
     config.add_route('routes_add', '/routes/add')
     config.add_route('routes_edit', '/routes/edit/{id}/{culture}')
 

--- a/c2corg_ui/templates/helpers.mako
+++ b/c2corg_ui/templates/helpers.mako
@@ -1,3 +1,12 @@
 <%def name="get_attr(obj, key)">\
 ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
 </%def>
+
+<%!
+from slugify import Slugify
+custom_slugify = Slugify(to_lower=True)
+%>
+
+<%def name="slugify(str)">\
+${custom_slugify(str)}\
+</%def>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,4 +1,5 @@
 <%inherit file="../base.html"/>
+<%namespace file="../helpers.mako" import="slugify"/>
 <%block name="pagetitle">Waypoints</%block>\
 
 <%block name="moduleConstantsValues">
@@ -33,7 +34,7 @@ module.value('mapFeatureCollection', {
 % for waypoint in waypoints:
   <li>
   % for locale in waypoint['locales']:
-    <a href="${request.route_url('waypoints_view', id=waypoint['document_id'], culture=locale['culture'])}">${locale['title']}</a> (${locale['culture']})
+    <a href="${request.route_url('waypoints_view', id=waypoint['document_id'], culture=locale['culture'], slug=custom_slugify(locale['title']))}">${locale['title']}</a> (${locale['culture']})
   % endfor
   - ${waypoint['elevation']} m</li>
 % endfor

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requires = [
     'shapely',
     'pyproj',
     'functools32',
+    'awesome-slugify',
     ]
 
 setup(name='c2corg_ui',


### PR DESCRIPTION
v5 URLs have slugs to improve the SEO. 

This PR adds a mako helper based upon awesome-slugify [1]. As for now this code does not work as expected. I push it to github to keep track of it.

[1] https://github.com/dimka665/awesome-slugify
Another python slug tool:
https://github.com/un33k/python-slugify