### PR TITLE
Templatecache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ c2corg_ui/static/build/locale/%/c2corg_ui.json: c2corg_ui/locale/%/LC_MESSAGES/c
 	node tools/compile-catalog $< > $@
 
 c2corg_ui/static/build/templatecache.js: c2corg_ui/templates/templatecache.js .build/venv/bin/mako-render $(APP_PARTIAL_FILES)
+	mkdir -p $(dir $@)
 	.build/venv/bin/mako-render --var "partials=$(APP_PARTIAL_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ help:
 check: flake8 lint build test
 
 .PHONY: build
-build: c2corg_ui/static/build/build.js c2corg_ui/static/build/templatecache.js c2corg_ui/static/build/build.css c2corg_ui/static/build/build.min.css compile-catalog
+build: c2corg_ui/static/build/build.js c2corg_ui/static/build/build.css c2corg_ui/static/build/build.min.css compile-catalog
 
 .PHONY: clean
 clean:
@@ -107,7 +107,7 @@ c2corg_ui/locale/c2corg_ui-client.pot: $(APP_HTML_FILES) $(APP_PARTIAL_FILES)
 c2corg_ui/locale/%/LC_MESSAGES/c2corg_ui-client.po: c2corg_ui/locale/c2corg_ui-client.pot
 	msgmerge --update $@ $<
 
-c2corg_ui/static/build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js .build/externs/angular-1.3-http-promise.js .build/node_modules.timestamp
+c2corg_ui/static/build/build.js: build.json c2corg_ui/static/build/templatecache.js $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js .build/externs/angular-1.3-http-promise.js .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ c2corg_ui/static/build/templatecache.js: c2corg_ui/templates/templatecache.js .b
 
 .build/venv/bin/nosetests: .build/dev-requirements.timestamp
 
+.build/venv/bin/mako-render: $(SITE_PACKAGES)/c2corg_ui.egg-link
+
 .build/dev-requirements.timestamp: .build/venv dev-requirements.txt
 	.build/venv/bin/pip install -r dev-requirements.txt
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ CLOSURE_COMPILER_PATH = $(shell node -e 'process.stdout.write(require("$(CLOSURE
 OL_JS_FILES = $(shell find node_modules/openlayers/src/ol -type f -name '*.js' 2> /dev/null)
 NGEO_JS_FILES = $(shell find node_modules/ngeo/src -type f -name '*.js' 2> /dev/null)
 APP_JS_FILES = $(shell find c2corg_ui/static/js -type f -name '*.js')
-APP_HTML_FILES = $(shell find c2corg_ui -type f -name '*.html')
+APP_HTML_FILES = $(shell find c2corg_ui/templates -type f -name '*.html')
+APP_PARTIAL_FILES = $(shell find c2corg_ui/static/partials -type f -name '*.html')
 LESS_FILES = $(shell find less -type f -name '*.less')
 
 # variables used in config files (*.in)
@@ -43,7 +44,7 @@ help:
 check: flake8 lint build test
 
 .PHONY: build
-build: c2corg_ui/static/build/build.js c2corg_ui/static/build/build.css c2corg_ui/static/build/build.min.css compile-catalog
+build: c2corg_ui/static/build/build.js c2corg_ui/static/build/templatecache.js c2corg_ui/static/build/build.css c2corg_ui/static/build/build.min.css compile-catalog
 
 .PHONY: clean
 clean:
@@ -100,7 +101,7 @@ upgrade-dev:
 c2corg_ui/closure/%.py: $(CLOSURE_LIBRARY_PATH)/closure/bin/build/%.py
 	cp $< $@
 
-c2corg_ui/locale/c2corg_ui-client.pot: $(APP_HTML_FILES)
+c2corg_ui/locale/c2corg_ui-client.pot: $(APP_HTML_FILES) $(APP_PARTIAL_FILES)
 	node tools/extract-messages.js $^ > $@
 
 c2corg_ui/locale/%/LC_MESSAGES/c2corg_ui-client.po: c2corg_ui/locale/c2corg_ui-client.pot
@@ -121,6 +122,9 @@ c2corg_ui/static/build/build.css: $(LESS_FILES) .build/node_modules.timestamp
 c2corg_ui/static/build/locale/%/c2corg_ui.json: c2corg_ui/locale/%/LC_MESSAGES/c2corg_ui-client.po
 	mkdir -p $(dir $@)
 	node tools/compile-catalog $< > $@
+
+c2corg_ui/static/build/templatecache.js: c2corg_ui/templates/templatecache.js .build/venv/bin/mako-render $(APP_PARTIAL_FILES)
+	.build/venv/bin/mako-render --var "partials=$(APP_PARTIAL_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:
 	mkdir -p $(dir $@)

--- a/build.json
+++ b/build.json
@@ -3,7 +3,8 @@
     "node_modules/openlayers/src/**/*.js",
     "node_modules/openlayers/build/ol.ext/**/*.js",
     "node_modules/ngeo/src/**/*.js",
-    "c2corg_ui/static/js/**/*.js"
+    "c2corg_ui/static/js/**/*.js",
+    "c2corg_ui/static/build/templatecache.js"
   ],
   "compile": {
     "closure_entry_point": "app.main",

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -3,18 +3,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -29,6 +17,203 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+#: c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -47,21 +232,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -80,61 +256,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -153,21 +280,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -176,11 +290,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -203,18 +312,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -223,34 +320,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-#: c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr ""
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -263,14 +338,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -289,28 +356,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -321,30 +372,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr ""
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -363,41 +392,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -412,10 +412,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -424,6 +420,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
 msgstr ""

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -8,18 +8,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -34,6 +22,189 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itineraris"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Cerca ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Benvingut/da a Camptocamp.org!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -52,20 +223,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -84,57 +247,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -153,20 +271,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -175,10 +281,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -201,18 +303,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -221,33 +311,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr ""
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -260,14 +329,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -286,28 +347,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -318,28 +363,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Itineraris"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr ""
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Cerca ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -358,37 +383,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -403,10 +403,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -415,6 +411,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Benvingut/da a Camptocamp.org!"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -9,18 +9,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -35,6 +23,189 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr "Anmelden"
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Routen"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr "Speichern"
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Suchen ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr "Titel"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr "Waypoints"
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Willkommen bei Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -53,20 +224,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -85,57 +248,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -154,20 +272,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -176,10 +282,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -202,18 +304,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -222,33 +312,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr "Anmelden"
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -261,14 +330,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -287,28 +348,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -319,28 +364,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Routen"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr "Speichern"
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Suchen ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -359,37 +384,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr "Titel"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -404,10 +404,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr "Waypoints"
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -416,6 +412,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Willkommen bei Camptocamp.org"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -9,18 +9,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr "{{nbItems}} routes"
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr "{{nbItems}} waypoints"
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr "access"
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr "Activities"
@@ -36,6 +24,189 @@ msgstr "Add a waypoint"
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
 msgstr "Back to homepage"
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr "Browse site in"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr "Cancel"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr "Comment about the changes"
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr "Coordinates"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr "Culture"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr "Describe here the gear needed for this route"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr "Describe here the waypoint"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr "Description"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr "Edit"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr "Elevation"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr "Elevation must be smaller than 9999 m."
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr "Forgotten password?"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr "Gear"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr "Height"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr "Latitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr "Latitude must be between -90° and 90°."
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr "Sign in"
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr "Sign out"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr "Longitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr "Longitude must be between -180° and 180°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr "Maps info"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr "Next"
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr "No account yet?"
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr "Password"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr "Previous"
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr "Sign up"
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr "Remember me"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr "Route type"
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Routes"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr "Save"
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr "Short description of the applied changes"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr "This field is required."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr "Title"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr "Title is too short."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr "Type"
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr "Username"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr "View in other culture:"
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr "Waypoints"
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Welcome to Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr "access"
 
 #: c2corg_ui/templates/i18n.html
 msgid "base_camp"
@@ -53,10 +224,6 @@ msgstr "bisse"
 msgid "bivouac"
 msgstr "bivouac"
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr "Browse site in"
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr "ca"
@@ -64,10 +231,6 @@ msgstr "ca"
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr "camp_site"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
-msgstr "Cancel"
 
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
@@ -85,58 +248,13 @@ msgstr "climbing_indoor"
 msgid "climbing_outdoor"
 msgstr "climbing_outdoor"
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr "Comment about the changes"
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr "confluence"
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr "Coordinates"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr "Culture"
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr "de"
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr "Describe here the gear needed for this route"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr "Describe here the waypoint"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr "Description"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr "Edit"
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr "Elevation"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr "Elevation must be smaller than 9999 m."
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
-msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "en"
@@ -154,21 +272,9 @@ msgstr "eu"
 msgid "expedition"
 msgstr "expedition"
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr "Forgotten password?"
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr "fr"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
-msgstr "Gear"
 
 #: c2corg_ui/templates/i18n.html
 msgid "gite"
@@ -177,10 +283,6 @@ msgstr "gite"
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
 msgstr "glacier"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
-msgstr "Height"
 
 #: c2corg_ui/templates/i18n.html
 msgid "hiking"
@@ -202,18 +304,6 @@ msgstr "it"
 msgid "lake"
 msgstr "lake"
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr "Latitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr "Latitude must be between -90° and 90°."
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr "local_product"
@@ -222,22 +312,6 @@ msgstr "local_product"
 msgid "locality"
 msgstr "locality"
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr "Sign in"
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr "Sign out"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr "Longitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr "Longitude must be between -180° and 180°."
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr "loop"
@@ -245,11 +319,6 @@ msgstr "loop"
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
 msgstr "loop_hut"
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
-msgstr "Maps info"
 
 #: c2corg_ui/templates/i18n.html
 msgid "misc"
@@ -262,14 +331,6 @@ msgstr "mountain_climbing"
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
 msgstr "moutain_biking"
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr "Next"
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
-msgstr "No account yet?"
 
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding"
@@ -287,29 +348,13 @@ msgstr "paragliding_takeoff"
 msgid "pass"
 msgstr "pass"
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr "Password"
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr "pit"
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr "Previous"
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
 msgstr "raid"
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr "Sign up"
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
-msgstr "Remember me"
 
 #: c2corg_ui/templates/i18n.html
 msgid "return_same_way"
@@ -319,29 +364,9 @@ msgstr "return_same_way"
 msgid "rock_climbing"
 msgstr "rock_climbing"
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr "Route type"
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Routes"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr "Save"
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr "shelter"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
-msgstr "Short description of the applied changes"
 
 #: c2corg_ui/templates/i18n.html
 msgid "skitouring"
@@ -359,38 +384,13 @@ msgstr "snowshoeing"
 msgid "summit"
 msgstr "summit"
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr "This field is required."
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr "Title"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr "Title is too short."
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr "traverse"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr "Type"
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr "Username"
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr "via_ferrata"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
-msgstr "View in other culture:"
 
 #: c2corg_ui/templates/i18n.html
 msgid "virtual"
@@ -404,10 +404,6 @@ msgstr "waterfall"
 msgid "waterpoint"
 msgstr "waterpoint"
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr "Waypoints"
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr "weather_station"
@@ -416,6 +412,10 @@ msgstr "weather_station"
 msgid "webcam"
 msgstr "webcam"
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Welcome to Camptocamp.org"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr "{{nbItems}} routes"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr "{{nbItems}} waypoints"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -9,18 +9,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -35,6 +23,189 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itinerarios"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Búsqueda ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "¡Bienvenido/a a Camptocamp.org!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -53,20 +224,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -85,57 +248,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -154,20 +272,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -176,10 +282,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -202,18 +304,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -222,33 +312,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr ""
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -261,14 +330,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -287,28 +348,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -319,28 +364,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Itinerarios"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr ""
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Búsqueda ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -359,37 +384,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -404,10 +404,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -416,6 +412,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "¡Bienvenido/a a Camptocamp.org!"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -8,18 +8,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -34,6 +22,189 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Ibilbideak"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Bilatu ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Ongi etorri Camptocamp.org-era!"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -52,20 +223,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -84,57 +247,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -153,20 +271,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -175,10 +281,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -201,18 +303,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -221,33 +311,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr ""
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -260,14 +329,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -286,28 +347,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -318,28 +363,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Ibilbideak"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr ""
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Bilatu ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -358,37 +383,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -403,10 +403,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -415,6 +411,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Ongi etorri Camptocamp.org-era!"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -6,18 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr "{{nbItems}} itinéraires trouvés"
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr "{{nbItems}} points de passage trouvés"
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr "accès"
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr "Activités"
@@ -33,6 +21,189 @@ msgstr "Ajouter un point de passage"
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
 msgstr "Retour à la page d'accueil"
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr "Naviguer en"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr "Annuler"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr "Courte description des changements"
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr "Coordonnées"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr "Langue"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr "Décrivez ici l'itinéraire"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr "Description"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr "Modifier"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr "Altitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr "L'altitude doit être inférieure à 9999m."
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr "Adresse email"
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr "Début"
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr "Mot de passe oublié ?"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr "Matériel"
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr "Dénivelé"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr "Fin"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr "Latitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr "La latitude doit être comprise en -90° et 90°."
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr "Se connecter"
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr "Se déconnecter"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr "Longitude"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr "La longitude doit être comprise en -180° et 180°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr "Références cartographiques"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr "Suivant"
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr "Pas encore de compte ?"
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr "Mot de passe"
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr "Précédent"
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr "S'inscrire"
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr "Se souvenir de moi"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr "Type d'itinéraire"
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itinéraires"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr "Enregistrer"
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Rechercher ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr "Courte description des changements appliqués"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr "Ce champ est obligatoire."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr "Titre"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr "Le titre doit comporter au moins 3 caractères."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr "Type"
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr "Identifiant"
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr "Afficher dans une autre langue:"
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr "Points de passage"
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Bienvenue sur Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
+msgstr "accès"
 
 #: c2corg_ui/templates/i18n.html
 msgid "base_camp"
@@ -50,10 +221,6 @@ msgstr "bisse"
 msgid "bivouac"
 msgstr "bivouac"
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr "Naviguer en"
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr "catalan"
@@ -61,10 +228,6 @@ msgstr "catalan"
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr "camping"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
-msgstr "Annuler"
 
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
@@ -82,58 +245,13 @@ msgstr "SAE"
 msgid "climbing_outdoor"
 msgstr "site de couenne/bloc"
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr "Courte description des changements"
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr "confluent"
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr "Coordonnées"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr "Langue"
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr "allemand"
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr "Décrivez ici l'itinéraire"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr "Description"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr "Modifier"
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr "Altitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr "L'altitude doit être inférieure à 9999m."
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
-msgstr "Adresse email"
 
 #: c2corg_ui/templates/i18n.html
 msgid "en"
@@ -151,21 +269,9 @@ msgstr "basque"
 msgid "expedition"
 msgstr "expédition"
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr "Début"
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr "Mot de passe oublié ?"
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr "français"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
-msgstr "Matériel"
 
 #: c2corg_ui/templates/i18n.html
 msgid "gite"
@@ -174,10 +280,6 @@ msgstr "gite"
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
 msgstr "glacier"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
-msgstr "Dénivelé"
 
 #: c2corg_ui/templates/i18n.html
 msgid "hiking"
@@ -199,18 +301,6 @@ msgstr "italien"
 msgid "lake"
 msgstr "lac"
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr "Fin"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr "Latitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr "La latitude doit être comprise en -90° et 90°."
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr "produit local/commerce"
@@ -219,22 +309,6 @@ msgstr "produit local/commerce"
 msgid "locality"
 msgstr "lieu-dit"
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr "Se connecter"
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr "Se déconnecter"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr "Longitude"
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr "La longitude doit être comprise en -180° et 180°."
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr "boucle avec retour au pied de la voie"
@@ -242,11 +316,6 @@ msgstr "boucle avec retour au pied de la voie"
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
 msgstr "boucle avec retour au refuge"
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
-msgstr "Références cartographiques"
 
 #: c2corg_ui/templates/i18n.html
 msgid "misc"
@@ -259,14 +328,6 @@ msgstr "rocher haute montagne"
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
 msgstr "VTT"
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr "Suivant"
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
-msgstr "Pas encore de compte ?"
 
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding"
@@ -284,29 +345,13 @@ msgstr "décollage parapente"
 msgid "pass"
 msgstr "col"
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr "Mot de passe"
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr "gouffre"
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr "Précédent"
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
 msgstr "raid"
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr "S'inscrire"
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
-msgstr "Se souvenir de moi"
 
 #: c2corg_ui/templates/i18n.html
 msgid "return_same_way"
@@ -316,29 +361,9 @@ msgstr "aller-retour"
 msgid "rock_climbing"
 msgstr "escalade"
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr "Type d'itinéraire"
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Itinéraires"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr "Enregistrer"
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Rechercher ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr "abri"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
-msgstr "Courte description des changements appliqués"
 
 #: c2corg_ui/templates/i18n.html
 msgid "skitouring"
@@ -356,38 +381,13 @@ msgstr "raquette"
 msgid "summit"
 msgstr "sommet"
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr "Ce champ est obligatoire."
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr "Titre"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr "Le titre doit comporter au moins 3 caractères."
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr "traversée"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr "Type"
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr "Identifiant"
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr "via ferrata"
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
-msgstr "Afficher dans une autre langue:"
 
 #: c2corg_ui/templates/i18n.html
 msgid "virtual"
@@ -401,10 +401,6 @@ msgstr "cascade"
 msgid "waterpoint"
 msgstr "point d'eau/source"
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr "Points de passage"
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr "station météo"
@@ -413,6 +409,10 @@ msgstr "station météo"
 msgid "webcam"
 msgstr "webcam"
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Bienvenue sur Camptocamp.org"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr "{{nbItems}} itinéraires trouvés"
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr "{{nbItems}} points de passage trouvés"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -9,18 +9,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "access"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Activities"
 msgstr ""
@@ -35,6 +23,189 @@ msgstr ""
 
 #: c2corg_ui/templates/base.html
 msgid "Back to homepage"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Browse site in"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Cancel"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Comment about the changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Coordinates"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Culture"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Describe here the gear needed for this route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe here the waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/route/view.html
+msgid "Description"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Elevation"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Elevation must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Email"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "First"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Forgotten password?"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Gear"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+msgid "Height"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Last"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Latitude must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
+msgid "Login"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "Logout"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Longitude must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
+msgid "Maps info"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "No account yet?"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/helpers.html
+msgid "Previous"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Remember me"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Route type"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Routes"
+msgstr "Itinerari"
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Save"
+msgstr ""
+
+#: c2corg_ui/static/partials/search.html
+msgid "Search ..."
+msgstr "Cerca ..."
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/auth.html
+msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html c2corg_ui/templates/route/edit.html
+msgid "Title is too short."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Type"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Username"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/view.html c2corg_ui/templates/route/view.html
+msgid "View in other culture:"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/index.html
+msgid "Welcome to Camptocamp.org"
+msgstr "Benvenuti a Camptocamp.org"
+
+#: c2corg_ui/templates/i18n.html
+msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -53,20 +224,12 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Browse site in"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "camp_site"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -85,57 +248,12 @@ msgstr ""
 msgid "climbing_outdoor"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Comment about the changes"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Coordinates"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "de"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html
-msgid "Describe here the gear needed for this route"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Describe here the waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Description"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "Edit"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Email"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -154,20 +272,8 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "First"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Forgotten password?"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Gear"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -176,10 +282,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "glacier"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/route/edit.html
-msgid "Height"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -202,18 +304,6 @@ msgstr ""
 msgid "lake"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Last"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
 msgstr ""
@@ -222,33 +312,12 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/static/partials/user.html
-msgid "Login"
-msgstr ""
-
-#: c2corg_ui/static/partials/user.html
-msgid "Logout"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "loop_hut"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Maps info"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -261,14 +330,6 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "moutain_biking"
-msgstr ""
-
-#: c2corg_ui/templates/helpers.html
-msgid "Next"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "No account yet?"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -287,28 +348,12 @@ msgstr ""
 msgid "pass"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Password"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
 msgstr ""
 
-#: c2corg_ui/templates/helpers.html
-msgid "Previous"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Register"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Remember me"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -319,28 +364,8 @@ msgstr ""
 msgid "rock_climbing"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Route type"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Routes"
-msgstr "Itinerari"
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Save"
-msgstr ""
-
-#: c2corg_ui/static/partials/search.html
-msgid "Search ..."
-msgstr "Cerca ..."
-
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Short description of the applied changes"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -359,37 +384,12 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title"
-msgstr ""
-
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Type"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "Username"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
-msgstr ""
-
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
-msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -404,10 +404,6 @@ msgstr ""
 msgid "waterpoint"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
 msgstr ""
@@ -416,6 +412,10 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/index.html
-msgid "Welcome to Camptocamp.org"
-msgstr "Benvenuti a Camptocamp.org"
+#: c2corg_ui/templates/route/index.html
+msgid "{{nbItems}} routes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/index.html
+msgid "{{nbItems}} waypoints"
+msgstr ""

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -70,6 +70,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/angular-messages/angular-messages.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('c2corg_ui:static/build/build.js')}"></script>
+    <script src="${request.static_url('c2corg_ui:static/build/templatecache.js')}"></script>
 % endif
     <script>
       (function() {

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -70,7 +70,6 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/angular-messages/angular-messages.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('c2corg_ui:static/build/build.js')}"></script>
-    <script src="${request.static_url('c2corg_ui:static/build/templatecache.js')}"></script>
 % endif
     <script>
       (function() {

--- a/c2corg_ui/templates/templatecache.js
+++ b/c2corg_ui/templates/templatecache.js
@@ -1,0 +1,36 @@
+## -*- coding: utf-8 -*-
+<%doc>
+    This is a Mako template that generates Angular code putting the contents of
+    HTML partials into Angular's $templateCache. The generated code is then built
+    with the rest of JavaScript code. The generated script is not used at all in
+    development mode, where HTML partials are loaded through Ajax.
+</%doc>\
+<%
+  import re
+  import htmlmin
+  _partials = {}
+  for p in partials.strip().split():
+      f = file(p)
+      content = unicode(f.read().decode('utf8'))
+      content = re.sub(r"'", "\\'", content)
+      content = htmlmin.minify(content, remove_comments=True)
+      # remove module name from partial path
+      partial = re.sub(r'c2corg_ui', '', p, 1)
+      _partials[partial] = content
+%>\
+/**
+ * @fileoverview AngularJS template cache.
+ * GENERATED FILE. DO NOT EDIT.
+ */
+(function() {
+  /**
+   * @param {angular.$cacheFactory.Cache} $templateCache
+   * @ngInject
+   */
+  var runner = function($templateCache) {
+  % for partial in _partials:
+    $templateCache.put('${partial}', '${_partials[partial]}');
+  %endfor
+  };
+  angular.module('app').run(runner);
+})();

--- a/c2corg_ui/templates/templatecache.js
+++ b/c2corg_ui/templates/templatecache.js
@@ -22,6 +22,9 @@
  * @fileoverview AngularJS template cache.
  * GENERATED FILE. DO NOT EDIT.
  */
+
+goog.require('app');
+
 (function() {
   /**
    * @param {angular.$cacheFactory.Cache} $templateCache

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requires = [
     'shapely',
     'pyproj',
     'functools32',
+    'htmlmin',
     ]
 
 setup(name='c2corg_ui',


### PR DESCRIPTION
This PR introduces the "templatecache" system used in ngeo [1] and Schweizmobil [2] for caching the directives partials.

[1] https://github.com/camptocamp/ngeo/blob/master/buildtools/templatecache.mako.js
[2] https://github.com/camptocamp/schweizmobil_re3/blob/master/templatecache.mako.js

It should hopefully solve by the way the path problem observed on the demo server (that has a "/ui/" path in the URL, breaking the partials loading).

There's probably something still missing because partials are still loaded the standard way instead of using the cache. Working on it...