### PR TITLE
Make sure that user data are removed from all possible storages when …

### DIFF
--- a/c2corg_ui/static/js/auth/authservice.js
+++ b/c2corg_ui/static/js/auth/authservice.js
@@ -107,10 +107,10 @@ app.Authentication.prototype.removeUserData = function() {
   if (!this.userData) {
     return;
   }
-  var storage = this.userData.remember ? window.localStorage :
-      window.sessionStorage;
   try {
-    storage.removeItem(this.USER_DATA_KEY_);
+    // Make sure that user data are removed from all possible storages
+    window.localStorage.removeItem(this.USER_DATA_KEY_);
+    window.sessionStorage.removeItem(this.USER_DATA_KEY_);
   } catch (e) {}
   this.userData = null;
 };


### PR DESCRIPTION
…logging out

In my instance I observed that I was always automatically reauthenticated even after pressing the "log out" button. I finally found out that for some reason "userData" was set both in localStorage and in sessionStorage while I had not checked the "remember me" box => using sessionStorage. Perhaps the localStorage was set from an old attempt?

Anyway to avoid that kind of problem I think we should make sure that "userData" is removed from both localStorage and sessionStorage (even though only one storage is actually used) when logging out.