### PR TITLE
Archived document view page does not link to other doc languages

### DIFF
--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -2,7 +2,8 @@
 <%namespace file="../helpers.html" import="get_attr, show_archive_data"/>
 <%
 route_id = route['document_id']
-other_cultures = filter(lambda l: l != culture, route['available_cultures'])
+other_cultures = filter(lambda l: l != culture, route['available_cultures']) \
+    if 'available_cultures' in route else None
 %>\
 <%block name="pagelang">lang="${culture}"</%block>
 <%block name="pagetitle">${locale['title']}</%block>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -2,7 +2,8 @@
 <%namespace file="../helpers.html" import="get_attr, show_archive_data"/>
 <%
 waypoint_id = waypoint['document_id']
-other_cultures = filter(lambda l: l != culture, waypoint['available_cultures'])
+other_cultures = filter(lambda l: l != culture, waypoint['available_cultures']) \
+    if 'available_cultures' in waypoint else None
 geometry4326 = transform(geometry, 'epsg:3857', 'epsg:4326')
 %>\
 <%block name="pagelang">lang="${culture}"</%block>


### PR DESCRIPTION
Oops, for some reason I didn't pay attention that "available_cultures" data is not available when viewing an archived doc version and it made the templates crash.