### PR TITLE
Add an action feedback system

### DIFF
--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -54,3 +54,13 @@ appx.SearchDocument;
  * }}
  */
 appx.SearchDocumentLocale;
+
+
+/**
+ * @typedef {{
+ *  msg: string,
+ *  type: ?string,
+ *  timeout: ?number
+ * }}
+ */
+appx.AlertMessage;

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -40,7 +40,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr ""
 
@@ -82,8 +82,12 @@ msgid "Forgotten password?"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -111,6 +115,10 @@ msgstr ""
 #: c2corg_ui/templates/auth.html:26
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
@@ -146,6 +154,10 @@ msgstr ""
 #: c2corg_ui/templates/auth.html:36
 #: c2corg_ui/templates/auth.html:61
 msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
@@ -215,7 +227,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr ""
 
@@ -237,6 +249,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:36
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
@@ -290,7 +306,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -301,12 +317,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -393,7 +409,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -518,7 +534,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -8,20 +8,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: c2corg_ui/templates/document/diff.html:45
+msgid "${field_diff.field}"
+msgstr ""
+
 #: c2corg_ui/templates/route/index.html:11
 msgid "Add a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/document/history.html:28
-msgid "Author"
-msgstr ""
-
-#: c2corg_ui/templates/base.html:27
-msgid "Back to homepage"
 msgstr ""
 
 #: c2corg_ui/templates/base.html:45
@@ -44,7 +40,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -65,7 +61,7 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr ""
 
@@ -86,8 +82,12 @@ msgid "Forgotten password?"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -114,6 +114,10 @@ msgstr ""
 #: c2corg_ui/static/partials/user.html:1 c2corg_ui/templates/auth.html:26
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
@@ -147,6 +151,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html:36 c2corg_ui/templates/auth.html:61
 msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
@@ -212,7 +220,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr ""
 
@@ -234,6 +242,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:36
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
@@ -287,7 +299,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -298,12 +310,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -390,7 +402,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -515,7 +527,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -13,16 +13,8 @@ msgstr ""
 msgid "Add a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/document/history.html:28
-msgid "Author"
-msgstr ""
-
-#: c2corg_ui/templates/base.html:27
-msgid "Back to homepage"
 msgstr ""
 
 #: c2corg_ui/templates/base.html:45
@@ -45,7 +37,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -66,7 +58,7 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr ""
 
@@ -87,8 +79,12 @@ msgid "Forgotten password?"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -116,6 +112,10 @@ msgstr ""
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
 msgstr "Anmelden"
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
+msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
 msgid "Logout"
@@ -148,6 +148,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html:36 c2corg_ui/templates/auth.html:61
 msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
@@ -213,7 +217,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr ""
 
@@ -235,6 +239,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:36
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
@@ -288,7 +296,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -299,12 +307,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -391,7 +399,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -477,7 +485,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:28
 #: c2corg_ui/templates/waypoint/edit.html:28
-#, fuzzy
 msgid "title"
 msgstr "Titel"
 
@@ -502,9 +509,8 @@ msgid "waterpoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:36
-#, fuzzy
 msgid "waypoint_type"
-msgstr "Waypoints"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html:53
 msgid "weather_station"
@@ -518,7 +524,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -13,7 +13,7 @@ msgstr ""
 msgid "Add a route"
 msgstr "Add a route"
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
 msgstr "Add a waypoint"
 
@@ -45,7 +45,7 @@ msgstr "Comment about the changes"
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr "Coordinates"
 
@@ -66,7 +66,7 @@ msgid "Describe here the waypoint"
 msgstr "Describe here the waypoint"
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr "Edit"
 
@@ -87,8 +87,12 @@ msgid "Forgotten password?"
 msgstr "Forgotten password?"
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -116,6 +120,10 @@ msgstr ""
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
 msgstr "Sign in"
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
+msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
 msgid "Logout"
@@ -149,6 +157,10 @@ msgstr "Previous"
 #: c2corg_ui/templates/auth.html:36 c2corg_ui/templates/auth.html:61
 msgid "Register"
 msgstr "Sign up"
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
+msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
 msgid "Remember me"
@@ -213,7 +225,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr "View in other culture:"
 
@@ -231,12 +243,15 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html:49
 msgid "access"
-msgstr "access"
+msgstr "Access"
 
 #: c2corg_ui/templates/route/edit.html:36
-#, fuzzy
 msgid "activities"
 msgstr "Activities"
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
 msgid "base_camp"
@@ -289,8 +304,7 @@ msgstr "confluence"
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr "Culture"
 
@@ -301,14 +315,12 @@ msgstr "de"
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr "Elevation"
 
@@ -395,8 +407,7 @@ msgid "loop_hut"
 msgstr "loop_hut"
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr "Maps info"
 
@@ -453,9 +464,8 @@ msgid "rock_climbing"
 msgstr "rock_climbing"
 
 #: c2corg_ui/templates/route/edit.html:49
-#, fuzzy
 msgid "route_types"
-msgstr "Route type"
+msgstr "Route types"
 
 #: c2corg_ui/templates/i18n.html:46
 msgid "shelter"
@@ -474,9 +484,8 @@ msgid "snowshoeing"
 msgstr "snowshoeing"
 
 #: c2corg_ui/templates/i18n.html:68
-#, fuzzy
 msgid "summary"
-msgstr "summit"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html:28
 msgid "summit"
@@ -484,7 +493,6 @@ msgstr "summit"
 
 #: c2corg_ui/templates/route/edit.html:28
 #: c2corg_ui/templates/waypoint/edit.html:28
-#, fuzzy
 msgid "title"
 msgstr "Title"
 
@@ -509,9 +517,8 @@ msgid "waterpoint"
 msgstr "waterpoint"
 
 #: c2corg_ui/templates/waypoint/edit.html:36
-#, fuzzy
 msgid "waypoint_type"
-msgstr "Waypoints"
+msgstr "Type"
 
 #: c2corg_ui/templates/i18n.html:53
 msgid "weather_station"
@@ -525,19 +532,10 @@ msgstr "webcam"
 msgid "{{nbItems}} routes"
 msgstr "{{nbItems}} routes"
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr "{{nbItems}} waypoints"
 
 #: c2corg_ui/templates/document/diff.html:19
 msgid "← previous difference"
 msgstr ""
-
-#~ msgid "Gear"
-#~ msgstr "Gear"
-
-#~ msgid "Height"
-#~ msgstr "Height"
-
-#~ msgid "Type"
-#~ msgstr "Type"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -9,20 +9,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/document/diff.html:45
+msgid "${field_diff.field}"
+msgstr ""
+
 #: c2corg_ui/templates/route/index.html:11
 msgid "Add a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/document/history.html:28
-msgid "Author"
-msgstr ""
-
-#: c2corg_ui/templates/base.html:27
-msgid "Back to homepage"
 msgstr ""
 
 #: c2corg_ui/templates/base.html:45
@@ -45,7 +41,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -66,7 +62,7 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr ""
 
@@ -87,8 +83,12 @@ msgid "Forgotten password?"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -115,6 +115,10 @@ msgstr ""
 #: c2corg_ui/static/partials/user.html:1 c2corg_ui/templates/auth.html:26
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
@@ -148,6 +152,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html:36 c2corg_ui/templates/auth.html:61
 msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
@@ -213,7 +221,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr ""
 
@@ -235,6 +243,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:36
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
@@ -288,7 +300,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -299,12 +311,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -391,7 +403,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -516,7 +528,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -12,16 +12,8 @@ msgstr ""
 msgid "Add a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/document/history.html:28
-msgid "Author"
-msgstr ""
-
-#: c2corg_ui/templates/base.html:27
-msgid "Back to homepage"
 msgstr ""
 
 #: c2corg_ui/templates/base.html:45
@@ -44,7 +36,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -236,6 +228,10 @@ msgstr ""
 msgid "activities"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html:48
 msgid "base_camp"
 msgstr ""
@@ -287,7 +283,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -298,12 +294,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -390,7 +386,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -515,7 +511,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -6,11 +6,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: c2corg_ui/templates/route/index.html:7
+msgid "{{nbItems}} routes"
+msgstr "{{nbItems}} itinéraires trouvés"
+
+#: c2corg_ui/templates/waypoint/index.html:31
+msgid "{{nbItems}} waypoints"
+msgstr "{{nbItems}} points de passage trouvés"
+
 #: c2corg_ui/templates/route/index.html:11
 msgid "Add a route"
 msgstr "Ajouter un itinéraire"
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
 msgstr "Ajouter un point de passage"
 
@@ -42,7 +50,7 @@ msgstr "Courte description des changements"
 msgid "Compare selected versions"
 msgstr "Comparer les versions sélectionnées"
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr "Coordonnées"
 
@@ -63,7 +71,7 @@ msgid "Describe here the waypoint"
 msgstr "Décrivez ici l'itinéraire"
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr "Modifier"
 
@@ -84,9 +92,13 @@ msgid "Forgotten password?"
 msgstr "Mot de passe oublié ?"
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
 msgstr "Versions"
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
+msgstr "Adresse email invalide"
 
 #: c2corg_ui/templates/helpers.html:42
 msgid "Last"
@@ -103,7 +115,7 @@ msgstr "La latitude doit être comprise en -90° et 90°."
 
 #: c2corg_ui/templates/document/diff.html:63
 msgid "Legend:"
-msgstr ""
+msgstr "Légende :"
 
 #: c2corg_ui/templates/document/history.html:9
 msgid "List of versions for language:"
@@ -113,6 +125,10 @@ msgstr "Liste des versions pour la langue :"
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
 msgstr "Se connecter"
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
+msgstr "Identifiant ou mot de passe incorrects"
 
 #: c2corg_ui/static/partials/user.html:4
 msgid "Logout"
@@ -147,6 +163,10 @@ msgstr "Précédent"
 msgid "Register"
 msgstr "S'inscrire"
 
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
+msgstr "Merci pour votre inscription ! Vous allez bientôt recevoir un email de validation."
+
 #: c2corg_ui/templates/auth.html:22
 msgid "Remember me"
 msgstr "Se souvenir de moi"
@@ -154,7 +174,7 @@ msgstr "Se souvenir de moi"
 #: c2corg_ui/templates/document/diff.html:13
 #: c2corg_ui/templates/document/diff.html:27
 msgid "Revision as of"
-msgstr ""
+msgstr "Version du"
 
 #: c2corg_ui/templates/base.html:30
 msgid "Routes"
@@ -203,14 +223,14 @@ msgstr "Identifiant"
 
 #: c2corg_ui/templates/document/diff.html:63
 msgid "Version 1 in"
-msgstr ""
+msgstr "Version 1 en"
 
 #: c2corg_ui/templates/document/diff.html:64
 msgid "Version 2 in"
-msgstr ""
+msgstr "Version 2 en"
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr "Afficher dans une autre langue:"
 
@@ -231,9 +251,12 @@ msgid "access"
 msgstr "accès"
 
 #: c2corg_ui/templates/route/edit.html:36
-#, fuzzy
 msgid "activities"
 msgstr "Activités"
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
+msgstr "Cet identifiant est déjà utilisé."
 
 #: c2corg_ui/templates/i18n.html:48
 msgid "base_camp"
@@ -286,8 +309,7 @@ msgstr "confluent"
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr "Langue"
 
@@ -298,14 +320,12 @@ msgstr "allemand"
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr "Altitude"
 
@@ -392,8 +412,7 @@ msgid "loop_hut"
 msgstr "boucle avec retour au refuge"
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
-#, fuzzy
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr "Références cartographiques"
 
@@ -411,7 +430,7 @@ msgstr "VTT"
 
 #: c2corg_ui/templates/document/diff.html:33
 msgid "next difference →"
-msgstr ""
+msgstr "différence suivante →"
 
 #: c2corg_ui/templates/i18n.html:23
 msgid "paragliding"
@@ -439,7 +458,7 @@ msgstr "raid"
 
 #: c2corg_ui/templates/document/diff.html:63
 msgid "red"
-msgstr ""
+msgstr "rouge"
 
 #: c2corg_ui/templates/i18n.html:59
 msgid "return_same_way"
@@ -450,7 +469,6 @@ msgid "rock_climbing"
 msgstr "escalade"
 
 #: c2corg_ui/templates/route/edit.html:49
-#, fuzzy
 msgid "route_types"
 msgstr "Type d'itinéraire"
 
@@ -471,9 +489,8 @@ msgid "snowshoeing"
 msgstr "raquette"
 
 #: c2corg_ui/templates/i18n.html:68
-#, fuzzy
 msgid "summary"
-msgstr "sommet"
+msgstr "résumé"
 
 #: c2corg_ui/templates/i18n.html:28
 msgid "summit"
@@ -481,7 +498,6 @@ msgstr "sommet"
 
 #: c2corg_ui/templates/route/edit.html:28
 #: c2corg_ui/templates/waypoint/edit.html:28
-#, fuzzy
 msgid "title"
 msgstr "Titre"
 
@@ -506,9 +522,8 @@ msgid "waterpoint"
 msgstr "point d'eau/source"
 
 #: c2corg_ui/templates/waypoint/edit.html:36
-#, fuzzy
 msgid "waypoint_type"
-msgstr "Points de passage"
+msgstr "Type"
 
 #: c2corg_ui/templates/i18n.html:53
 msgid "weather_station"
@@ -518,23 +533,6 @@ msgstr "station météo"
 msgid "webcam"
 msgstr "webcam"
 
-#: c2corg_ui/templates/route/index.html:8
-msgid "{{nbItems}} routes"
-msgstr "{{nbItems}} itinéraires trouvés"
-
-#: c2corg_ui/templates/waypoint/index.html:42
-msgid "{{nbItems}} waypoints"
-msgstr "{{nbItems}} points de passage trouvés"
-
 #: c2corg_ui/templates/document/diff.html:19
 msgid "← previous difference"
-msgstr ""
-
-#~ msgid "Gear"
-#~ msgstr "Matériel"
-
-#~ msgid "Height"
-#~ msgstr "Dénivelé"
-
-#~ msgid "Type"
-#~ msgstr "Type"
+msgstr "← différence précédente"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -9,20 +9,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/document/diff.html:45
+msgid "${field_diff.field}"
+msgstr ""
+
 #: c2corg_ui/templates/route/index.html:11
 msgid "Add a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:45
+#: c2corg_ui/templates/waypoint/index.html:35
 msgid "Add a waypoint"
-msgstr ""
-
-#: c2corg_ui/templates/document/history.html:28
-msgid "Author"
-msgstr ""
-
-#: c2corg_ui/templates/base.html:27
-msgid "Back to homepage"
 msgstr ""
 
 #: c2corg_ui/templates/base.html:45
@@ -45,7 +41,7 @@ msgstr ""
 msgid "Compare selected versions"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html:46
+#: c2corg_ui/templates/waypoint/view.html:44
 msgid "Coordinates"
 msgstr ""
 
@@ -66,7 +62,7 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:40
-#: c2corg_ui/templates/waypoint/view.html:61
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "Edit"
 msgstr ""
 
@@ -87,8 +83,12 @@ msgid "Forgotten password?"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:39
-#: c2corg_ui/templates/waypoint/view.html:60
+#: c2corg_ui/templates/waypoint/view.html:58
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:72
+msgid "Invalid email address"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html:42
@@ -115,6 +115,10 @@ msgstr ""
 #: c2corg_ui/static/partials/user.html:1 c2corg_ui/templates/auth.html:26
 #: c2corg_ui/templates/auth.html:4
 msgid "Login"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:71
+msgid "Login failed"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html:4
@@ -148,6 +152,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html:36 c2corg_ui/templates/auth.html:61
 msgid "Register"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:74
+msgid "Register success"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html:22
@@ -213,7 +221,7 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html:30
-#: c2corg_ui/templates/waypoint/view.html:51
+#: c2corg_ui/templates/waypoint/view.html:49
 msgid "View in other culture:"
 msgstr ""
 
@@ -235,6 +243,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:36
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html:73
+msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:48
@@ -288,7 +300,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:15
 #: c2corg_ui/templates/route/view.html:24
-#: c2corg_ui/templates/waypoint/view.html:44
+#: c2corg_ui/templates/waypoint/view.html:42
 msgid "culture"
 msgstr ""
 
@@ -299,12 +311,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html:55
 #: c2corg_ui/templates/route/view.html:26
 #: c2corg_ui/templates/waypoint/edit.html:75
-#: c2corg_ui/templates/waypoint/view.html:48
+#: c2corg_ui/templates/waypoint/view.html:46
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:45
-#: c2corg_ui/templates/waypoint/view.html:45
+#: c2corg_ui/templates/waypoint/view.html:43
 msgid "elevation"
 msgstr ""
 
@@ -391,7 +403,7 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html:71
-#: c2corg_ui/templates/waypoint/view.html:47
+#: c2corg_ui/templates/waypoint/view.html:45
 msgid "maps_info"
 msgstr ""
 
@@ -516,7 +528,7 @@ msgstr ""
 msgid "{{nbItems}} routes"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/index.html:42
+#: c2corg_ui/templates/waypoint/index.html:32
 msgid "{{nbItems}} waypoints"
 msgstr ""
 

--- a/c2corg_ui/static/js/alerts.js
+++ b/c2corg_ui/static/js/alerts.js
@@ -1,0 +1,107 @@
+goog.provide('app.AlertController');
+goog.provide('app.AlertsController');
+goog.provide('app.alertDirective');
+goog.provide('app.alertsDirective');
+
+goog.require('app');
+goog.require('app.Alerts');
+goog.require('app.trustAsHtmlFilter');
+
+
+/**
+ * This directive is used to display feedbacks to user actions.
+ * Inspired by angular-ui boostrap alert:
+ * https://github.com/angular-ui/bootstrap/blob/master/src/alert/alert.js
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.alertsDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'AppAlertsController',
+    controllerAs: 'alertsCtrl',
+    bindToController: true,
+    templateUrl: '/static/partials/alerts.html'
+  };
+};
+
+
+app.module.directive('appAlerts', app.alertsDirective);
+
+
+
+/**
+ * @constructor
+ * @param {app.Alerts} appAlerts Alert service.
+ * @export
+ * @ngInject
+ */
+app.AlertsController = function(appAlerts) {
+
+  /**
+   * @type {Array.<appx.AlertMessage>}
+   * @export
+   */
+  this.alerts = appAlerts.get();
+};
+
+
+/**
+ * @param {number} index Index of alert to close.
+ * @export
+ */
+app.AlertsController.prototype.close = function(index) {
+  this.alerts.splice(index, 1);
+};
+
+
+app.module.controller('AppAlertsController', app.AlertsController);
+
+
+/**
+ * This directive is used to display one alert message.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.alertDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'AppAlertController',
+    controllerAs: 'alertCtrl',
+    bindToController: true,
+    templateUrl: '/static/partials/alert.html',
+    scope: {
+      'type': '@',
+      'close': '&',
+      'timeout': '@',
+      'msg': '@'
+    }
+  };
+};
+
+
+app.module.directive('appAlert', app.alertDirective);
+
+
+
+/**
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @constructor
+ * @ngInject
+ * @export
+ */
+app.AlertController = function($timeout) {
+  if (this['timeout'] && this['close']) {
+    var timeout = parseInt(this['timeout'], 10);
+    if (timeout) {
+      $timeout(goog.bind(function() {
+        this['close']();
+      }, this), timeout);
+    }
+  }
+};
+
+
+app.module.controller('AppAlertController', app.AlertController);

--- a/c2corg_ui/static/js/alerts.js
+++ b/c2corg_ui/static/js/alerts.js
@@ -96,9 +96,9 @@ app.AlertController = function($timeout) {
   if (this['timeout'] && this['close']) {
     var timeout = parseInt(this['timeout'], 10);
     if (timeout) {
-      $timeout(goog.bind(function() {
+      $timeout((function() {
         this['close']();
-      }, this), timeout);
+      }).bind(this), timeout);
     }
   }
 };

--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -1,0 +1,54 @@
+goog.provide('app.Alerts');
+
+
+goog.require('app');
+
+
+
+/**
+ * @constructor
+ * @export
+ */
+app.Alerts = function() {
+
+  /**
+   * @type {Array.<appx.AlertMessage>}
+   * @private
+   */
+  this.alerts_ = [];
+};
+
+
+/**
+ * @param {string|appx.AlertMessage} msg Alert data.
+ * @export
+ */
+app.Alerts.prototype.add = function(msg) {
+  if (typeof msg == 'string') {
+    msg = {'msg': msg, 'type': null, 'timeout': null};
+  }
+  this.alerts_.push({
+    type: msg['type'] || 'warning',
+    msg: msg['msg'],
+    timeout: msg['timeout'] || 0
+  });
+};
+
+
+/**
+ * @return {Array.<appx.AlertMessage>}
+ * @export
+ */
+app.Alerts.prototype.get = function() {
+  return this.alerts_;
+};
+
+
+/**
+ * @private
+ * @return {app.Alerts}
+ */
+app.AlertsFactory_ = function() {
+  return new app.Alerts();
+};
+app.module.factory('appAlerts', app.AlertsFactory_);

--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -20,13 +20,10 @@ app.Alerts = function() {
 
 
 /**
- * @param {string|appx.AlertMessage} msg Alert data.
+ * @param {appx.AlertMessage} msg Alert data.
  * @export
  */
 app.Alerts.prototype.add = function(msg) {
-  if (typeof msg == 'string') {
-    msg = {'msg': msg, 'type': null, 'timeout': null};
-  }
   this.alerts_.push({
     type: msg['type'] || 'warning',
     msg: msg['msg'],

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -176,21 +176,30 @@ app.AuthController.prototype.errorRegister_ = function(response) {
  * @private
  */
 app.AuthController.prototype.formatErrorMsg_ = function(response) {
-  // TODO: i18n
-  // TODO: filter strings from response using $sanitize or another tool
   var errors = response['data']['errors'],
       len = errors.length,
       msg = '';
   if (len == 1) {
-    msg = errors[0]['description'];
+    msg = this.filterStr_(errors[0]['description']);
   } else if (len > 0) {
     msg += '<ul>';
     for (var i = 0; i < len; i++) {
-      msg += '<li>' + errors[i]['description'] + '</li>';
+      msg += '<li>' + this.filterStr_(errors[i]['description']) + '</li>';
     }
     msg += '</ul>';
   }
   return msg;
+};
+
+
+/**
+ * @param {string} str String to filter.
+ * @return {string}
+ * @private
+ */
+app.AuthController.prototype.filterStr_ = function(str) {
+  // TODO: i18n
+  return goog.string.htmlEscape(str);
 };
 
 

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -2,6 +2,7 @@ goog.provide('app.AuthController');
 goog.provide('app.authDirective');
 
 goog.require('app');
+goog.require('app.Alerts');
 goog.require('app.Authentication');
 goog.require('ngeo.Location');
 
@@ -33,12 +34,13 @@ app.module.directive('appAuth', app.authDirective);
  * @param {string} apiUrl Base URL of the API.
  * @param {app.Authentication} appAuthentication
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {app.Alerts} appAlerts
  * @constructor
  * @export
  * @ngInject
  */
 app.AuthController = function($scope, $http, apiUrl, appAuthentication,
-    ngeoLocation) {
+    ngeoLocation, appAlerts) {
 
   /**
    * @type {angular.Scope}
@@ -69,6 +71,12 @@ app.AuthController = function($scope, $http, apiUrl, appAuthentication,
    * @private
    */
   this.ngeoLocation_ = ngeoLocation;
+
+  /**
+   * @type {app.Alerts}
+   * @private
+   */
+  this.alerts_ = appAlerts;
 };
 
 
@@ -111,10 +119,11 @@ app.AuthController.prototype.successLogin_ = function(remember, response) {
  * @private
  */
 app.AuthController.prototype.errorLogin_ = function(response) {
-  // TODO
-  alert('login error');
-  console.log('login error');
-  console.log(response);
+  this.alerts_.add({
+    'type': 'danger',
+    'msg': this.formatErrorMsg_(response),
+    'timeout': 5000
+  });
 };
 
 
@@ -139,10 +148,12 @@ app.AuthController.prototype.register = function() {
  * @private
  */
 app.AuthController.prototype.successRegister_ = function(response) {
-  // TODO
-  alert('register success');
-  console.log('register success');
-  console.log(response);
+  // TODO: i18n
+  this.alerts_.add({
+    'type': 'success',
+    'msg': 'Register success',
+    'timeout': 5000
+  });
 };
 
 
@@ -151,10 +162,35 @@ app.AuthController.prototype.successRegister_ = function(response) {
  * @private
  */
 app.AuthController.prototype.errorRegister_ = function(response) {
-  // TODO
-  alert('register error');
-  console.log('register error');
-  console.log(response);
+  this.alerts_.add({
+    'type': 'danger',
+    'msg': this.formatErrorMsg_(response),
+    'timeout': 5000
+  });
+};
+
+
+/**
+ * @param {Object} response Response from the API server.
+ * @return {string}
+ * @private
+ */
+app.AuthController.prototype.formatErrorMsg_ = function(response) {
+  // TODO: i18n
+  // TODO: filter strings from response using $sanitize or another tool
+  var errors = response['data']['errors'],
+      len = errors.length,
+      msg = '';
+  if (len == 1) {
+    msg = errors[0]['description'];
+  } else if (len > 0) {
+    msg += '<ul>';
+    for (var i = 0; i < len; i++) {
+      msg += '<li>' + errors[i]['description'] + '</li>';
+    }
+    msg += '</ul>';
+  }
+  return msg;
 };
 
 

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -35,12 +35,13 @@ app.module.directive('appAuth', app.authDirective);
  * @param {app.Authentication} appAuthentication
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {app.Alerts} appAlerts
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @constructor
  * @export
  * @ngInject
  */
 app.AuthController = function($scope, $http, apiUrl, appAuthentication,
-    ngeoLocation, appAlerts) {
+    ngeoLocation, appAlerts, gettextCatalog) {
 
   /**
    * @type {angular.Scope}
@@ -77,6 +78,12 @@ app.AuthController = function($scope, $http, apiUrl, appAuthentication,
    * @private
    */
   this.alerts_ = appAlerts;
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
 };
 
 
@@ -148,10 +155,9 @@ app.AuthController.prototype.register = function() {
  * @private
  */
 app.AuthController.prototype.successRegister_ = function(response) {
-  // TODO: i18n
   this.alerts_.add({
     'type': 'success',
-    'msg': 'Register success',
+    'msg': this.filterStr_('Register success'),
     'timeout': 5000
   });
 };
@@ -198,8 +204,8 @@ app.AuthController.prototype.formatErrorMsg_ = function(response) {
  * @private
  */
 app.AuthController.prototype.filterStr_ = function(str) {
-  // TODO: i18n
-  return goog.string.htmlEscape(str);
+  str = goog.string.htmlEscape(str);
+  return this.gettextCatalog_.getString(str);
 };
 
 

--- a/c2corg_ui/static/js/filters.js
+++ b/c2corg_ui/static/js/filters.js
@@ -1,0 +1,18 @@
+goog.provide('app.trustAsHtmlFilter');
+
+goog.require('app');
+
+
+/**
+ * @param {angular.$sce} $sce Angular sce service.
+ * @export
+ * @ngInject
+ * @return {function(angular.$sce):string}
+ */
+app.trustAsHtmlFilter = function($sce) {
+  return function(text) {
+    return $sce.trustAsHtml(text);
+  };
+};
+
+app.module.filter('appTrustAsHtml', app.trustAsHtmlFilter);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -7,6 +7,7 @@
 goog.provide('app.main');
 
 goog.require('app.MainController');
+goog.require('app.alertsDirective');
 goog.require('app.authDirective');
 goog.require('app.diffMapDirective');
 goog.require('app.documentEditingDirective');

--- a/c2corg_ui/static/partials/alert.html
+++ b/c2corg_ui/static/partials/alert.html
@@ -1,0 +1,8 @@
+<div class="alert" ng-class="['alert-' + alertCtrl.type, 'alert-dismissible', 'fade', 'in']" role="alert">
+  <button type="button" class="close" ng-click="alertCtrl.close({$event: $event})">
+    <span aria-hidden="true">&times;</span>
+    <span class="sr-only">Close</span>
+  </button>
+  <div ng-bind-html="alertCtrl.msg | appTrustAsHtml"></div>
+</div>
+

--- a/c2corg_ui/static/partials/alerts.html
+++ b/c2corg_ui/static/partials/alerts.html
@@ -1,0 +1,1 @@
+<app-alert ng-repeat="alert in alertsCtrl.alerts" type="{{alert.type}}" close="alertsCtrl.close($index)" timeout="{{alert.timeout}}" msg="{{alert.msg}}"></app-alert>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -48,6 +48,8 @@ closure_library_path = settings.get('closure_library_path')
       </div>
     </div>
 
+    <app-alerts></app-alerts>
+
 % if debug:
     <script>
       // We should really use the empty string for CLOSURE_BASE_PATH for there

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -66,3 +66,9 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <!-- fields (used in the diff view) -->
 <span translate>geometry</span>
 <span translate>summary</span>
+
+<!-- auth -->
+<span translate>Login failed</span>
+<span translate>Invalid email address</span>
+<span translate>already used username</span>
+<span translate>Register success</span>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -54,3 +54,9 @@
     }
   }
 }
+
+app-alerts {
+  position: absolute;
+  bottom: 10px;
+  width: 100%;
+}


### PR DESCRIPTION
I was not happy with PR #64 since I had troubles having alert messages that
* autoclosed after some timeout
* had a close button
* supported any HTML content

In addition I am not that sure we needed a ``ControllerHub`` service: we could simply have an alert service to which controllers could pass their alerts.

This new PR no longer uses Angular-UI Boostrap alert directive. It rather uses app-specific directives that somehow mimic the ones from Angular-UI Boostrap but with changes that support the 3 points above.

Related to #8