### PR TITLE
Do not use http://pypi.camptocamp.net/pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---index-url http://pypi.camptocamp.net/pypi
 -e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
 
 pyramid==1.5.7


### PR DESCRIPTION
Using it was not necessary and produced security warnings.