### PR TITLE
Switch to Python 3.4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,16 @@
+{
+  "extends": "openlayers",
+  "globals": {
+    "app": false,
+    "goog": false,
+    "ol": false,
+    "ngeoModule": false,
+    "angular": false,
+    "$": false,
+    "Bloodhound": false
+  },
+  "rules": {
+    "no-console": 1,
+    "valid-jsdoc": 0
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 
 python:
-- 2.7
+- 3.4
 
 addons:
   postgresql: "9.4"

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ $(EXTERNS_ANGULAR_HTTP_PROMISE):
 
 .build/venv:
 	mkdir -p $(dir $@)
-	virtualenv --no-site-packages $@
+	virtualenv --no-site-packages -p python3 $@
 
 $(SITE_PACKAGES)/c2corg_ui.egg-link: .build/venv requirements.txt setup.py
 	.build/venv/bin/pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ flake8: .build/venv/bin/flake8
 	.build/venv/bin/flake8 c2corg_ui
 
 .PHONY: lint
-lint: .build/venv/bin/gjslint .build/node_modules.timestamp .build/gjslint.timestamp .build/jshint.timestamp
+lint: .build/node_modules.timestamp .build/eslint.timestamp
 
 .PHONY: install
 install: build install-dev-egg template .build/node_modules.timestamp
@@ -156,15 +156,9 @@ $(EXTERNS_ANGULAR_HTTP_PROMISE):
 	npm install
 	touch $@
 
-.build/gjslint.timestamp: $(APP_JS_FILES)
-	.build/venv/bin/gjslint --jslint_error=all --strict --custom_jsdoc_tags=event,fires,function,classdesc,api,observable,example,ngdoc,ngname $?
+.build/eslint.timestamp: $(APP_JS_FILES)
+	./node_modules/.bin/eslint $?
 	touch $@
-
-.build/jshint.timestamp: $(APP_JS_FILES)
-	./node_modules/.bin/jshint --verbose $?
-	touch $@
-
-.build/venv/bin/gjslint: .build/dev-requirements.timestamp
 
 .build/venv/bin/flake8: .build/dev-requirements.timestamp
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ UI Application for camptocamp.org v6
 Requirements
 ------------
 
- * Python 2.7
+ * Python 3.4
  * Node (0.10.x or higher, there are known issues with 0.10.29)
  * Java (1.7 or higher)
  * gettext (0.18 or higher)

--- a/c2corg_ui/diff/differ.py
+++ b/c2corg_ui/diff/differ.py
@@ -73,11 +73,11 @@ def _stringify(val):
     if val is None:
         return None
     elif type(val) is list:
-        return u', '.join(map(lambda e: _stringify(e), val))
-    elif isinstance(val, basestring):
+        return ', '.join([_stringify(e) for e in val])
+    elif isinstance(val, str):
         return val
     else:
-        return unicode(val)
+        return str(val)
 
 
 class FieldDiff(object):

--- a/c2corg_ui/static/js/alerts.js
+++ b/c2corg_ui/static/js/alerts.js
@@ -30,7 +30,6 @@ app.alertsDirective = function() {
 app.module.directive('appAlerts', app.alertsDirective);
 
 
-
 /**
  * @constructor
  * @param {app.Alerts} appAlerts Alert service.
@@ -83,7 +82,6 @@ app.alertDirective = function() {
 
 
 app.module.directive('appAlert', app.alertDirective);
-
 
 
 /**

--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -4,7 +4,6 @@ goog.provide('app.Alerts');
 goog.require('app');
 
 
-
 /**
  * @constructor
  * @export

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -27,7 +27,6 @@ app.authDirective = function() {
 app.module.directive('appAuth', app.authDirective);
 
 
-
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.$http} $http

--- a/c2corg_ui/static/js/auth/authservice.js
+++ b/c2corg_ui/static/js/auth/authservice.js
@@ -3,7 +3,6 @@ goog.provide('app.Authentication');
 goog.require('app');
 
 
-
 /**
  * @param {string} apiUrl URL to the API.
  * @param {angular.Scope} $rootScope
@@ -111,7 +110,7 @@ app.Authentication.prototype.removeUserData = function() {
     // Make sure that user data are removed from all possible storages
     window.localStorage.removeItem(this.USER_DATA_KEY_);
     window.sessionStorage.removeItem(this.USER_DATA_KEY_);
-  } catch (e) {}
+  } catch (e) {} // eslint-disable-line no-empty
   this.userData = null;
 };
 

--- a/c2corg_ui/static/js/diffmap.js
+++ b/c2corg_ui/static/js/diffmap.js
@@ -40,7 +40,6 @@ app.diffMapDirective = function() {
 app.module.directive('appDiffMap', app.diffMapDirective);
 
 
-
 /**
  * @param {?GeoJSONFeatureCollection} mapFeatureCollection FeatureCollection
  *    of features

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -40,7 +40,6 @@ app.documentEditingDirective = function() {
 app.module.directive('appDocumentEditing', app.documentEditingDirective);
 
 
-
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.JQLite} $element Element.
@@ -264,7 +263,7 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
   }
 
   var config = {
-    'headers': { 'Content-Type': 'application/json' }
+    'headers': {'Content-Type': 'application/json'}
   };
   if (this.id_) {
     // updating an existing document

--- a/c2corg_ui/static/js/lang.js
+++ b/c2corg_ui/static/js/lang.js
@@ -32,7 +32,6 @@ app.langDirective = function() {
 app.module.directive('appLang', app.langDirective);
 
 
-
 /**
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string} langUrlTemplate Language URL template.

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -4,7 +4,6 @@ goog.require('app');
 goog.require('app.HttpAuthenticationInterceptor');
 
 
-
 /**
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @constructor

--- a/c2corg_ui/static/js/map.js
+++ b/c2corg_ui/static/js/map.js
@@ -42,7 +42,6 @@ app.mapDirective = function() {
 app.module.directive('appMap', app.mapDirective);
 
 
-
 /**
  * @param {angular.Scope} $scope Directive scope.
  * @param {?GeoJSONFeatureCollection} mapFeatureCollection FeatureCollection of

--- a/c2corg_ui/static/js/search.js
+++ b/c2corg_ui/static/js/search.js
@@ -36,7 +36,6 @@ app.searchDirective = function() {
 app.module.directive('appSearch', app.searchDirective);
 
 
-
 /**
  * @constructor
  * @param {angular.Scope} $rootScope Angular root scope.

--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -29,7 +29,6 @@ app.userDirective = function() {
 app.module.directive('appUser', app.userDirective);
 
 
-
 /**
  * @param {angular.$http} $http
  * @param {app.Authentication} appAuthentication

--- a/c2corg_ui/static/js/versions.js
+++ b/c2corg_ui/static/js/versions.js
@@ -28,7 +28,6 @@ app.versionsDirective = function() {
 app.module.directive('appVersions', app.versionsDirective);
 
 
-
 /**
  * @param {angular.Scope} $scope Scope.
  * @constructor

--- a/c2corg_ui/templates/templatecache.js
+++ b/c2corg_ui/templates/templatecache.js
@@ -10,8 +10,8 @@
   import htmlmin
   _partials = {}
   for p in partials.strip().split():
-      f = file(p)
-      content = unicode(f.read().decode('utf8'))
+      f = open(p, encoding="utf-8")
+      content = str(f.read())
       content = re.sub(r"'", "\\'", content)
       content = htmlmin.minify(content, remove_comments=True)
       # remove module name from partial path

--- a/c2corg_ui/tests/diff/test_differ.py
+++ b/c2corg_ui/tests/diff/test_differ.py
@@ -96,11 +96,17 @@ class TestDiffer(unittest.TestCase):
         }
         diff_fields = diff_documents(doc1, doc2)
         self.assertEqual(len(diff_fields), 5)
-        self.assertEqual(diff_fields[0].field, 'parking_fee')
-        self.assertEqual(diff_fields[1].field, 'lift_access')
-        self.assertEqual(diff_fields[2].field, 'description')
-        self.assertEqual(diff_fields[3].field, 'snow_clearance_rating')
-        self.assertEqual(diff_fields[4].field, 'geometry')
+        self.assertContainsField(diff_fields, 'lift_access')
+        self.assertContainsField(diff_fields, 'parking_fee')
+        self.assertContainsField(diff_fields, 'snow_clearance_rating')
+        self.assertContainsField(diff_fields, 'description')
+        self.assertContainsField(diff_fields, 'geometry')
+
+    def assertContainsField(self, fields, name):  # noqa
+        self.assertTrue(
+            any(e.field == name for e in fields),
+            '{0} not in list'.format(name)
+        )
 
 
 def create_debug_file(table):

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -2,7 +2,7 @@ from c2corg_ui.diff.differ import diff_documents
 from shapely.geometry import asShape
 from shapely.ops import transform
 from functools import partial
-from urllib import urlencode
+from urllib.parse import urlencode
 import httplib2
 import pyproj
 import json
@@ -37,7 +37,7 @@ class Document(object):
             resp, content = http.request(
                 url, method=method, body=body, headers=headers
             )
-            return resp, json.loads(content)
+            return resp, json.loads(content.decode('utf-8'))
         except Exception:
             # TODO: return error message as the second item
             return {'status': '500'}, {}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
 flake8==2.2.2
 pep8-naming==0.2.2
 nose==1.3.7

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "ngeo": "git://github.com/camptocamp/ngeo#f1d44f790b48959342e55db63118aca864cbf7fa",
     "less": "~2.0.0",
     "less-plugin-clean-css": "~1.1.0",
-    "jshint": "~2.5.1",
     "nomnom": "~1.6.2",
     "typeahead.js": "0.11.1",
-    "jquery": "^1.9.1"
+    "jquery": "^1.9.1",
+    "eslint": "git://github.com/eslint/eslint.git#4356532469ec1b9d4977aff05a03c3e167922ffa",
+    "eslint-config-openlayers": "^2.0.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ waitress==0.8.10
 httplib2==0.9.2
 Shapely==1.5.13
 pyproj==1.9.4
-functools32==3.2.3-2
 htmlmin==0.1.10
 
 # c2corg_common project


### PR DESCRIPTION
See https://github.com/c2corg/v6_api/pull/124

The only Python package that does not support Python 3 is closure-linter. Because the package is only needed to run the linter, I simply create a second virtualenv with Python 2.7 and install closure-linter in there. There are [no plans](https://github.com/google/closure-linter/issues/81#issuecomment-170260192) to add support for Python 3, so in the long run we have to find a replacement for closure-linter.