### PR TITLE
Internal api url

### DIFF
--- a/c2corg_ui/tests/views/__init__.py
+++ b/c2corg_ui/tests/views/__init__.py
@@ -14,28 +14,28 @@ class BaseTestUi(BaseTestCase):
         self.settings = settings
 
     def _test_pages(self):
-        response = self.app.get(self._prefix, status=200)
+        route = '/%s' % self._prefix
+        response = self.app.get(route, status=200)
         self.assertEqual(response.content_type, 'text/html')
 
-        route = '%s/add' % self._prefix
+        route = '/%s/add' % self._prefix
         response = self.app.get(route, status=200)
         self.assertEqual(response.content_type, 'text/html')
 
         # ask for a non existing culture foo
-        route = '%s/1/foo' % self._prefix
+        route = '/%s/1/foo' % self._prefix
         response = self.app.get(route, status=400)
 
         # ask for a non integer document id foo
-        route = '%s/foo/fr' % self._prefix
+        route = '/%s/foo/fr' % self._prefix
         response = self.app.get(route, status=400)
 
         # ask for a non existing document
-        route = '%s/9999999999/fr' % self._prefix
+        route = '/%s/9999999999/fr' % self._prefix
         response = self.app.get(route, status=404)
 
     def _test_api_call(self):
-        url = '%s%s' % (self.settings['api_url'], self._prefix)
-        resp, content = self.view._call_api(url)
+        resp, content = self.view._call_api(self._prefix)
         self.assertEqual(resp['status'], '200')
         self.assertTrue('total' in content)
         self.assertTrue('documents' in content)

--- a/c2corg_ui/tests/views/test_route.py
+++ b/c2corg_ui/tests/views/test_route.py
@@ -5,7 +5,7 @@ from c2corg_ui.views.route import Route
 class TestRouteUi(BaseTestUi):
 
     def setUp(self):  # noqa
-        self.set_prefix("/routes")
+        self.set_prefix("routes")
         BaseTestUi.setUp(self)
         self.view = Route(request=self.request)
 

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -6,7 +6,7 @@ from shapely.geometry import Point
 class TestWaypointUi(BaseTestUi):
 
     def setUp(self):  # noqa
-        self.set_prefix("/waypoints")
+        self.set_prefix("waypoints")
         BaseTestUi.setUp(self)
         self.view = Waypoint(request=self.request)
 

--- a/common.ini.in
+++ b/common.ini.in
@@ -4,6 +4,8 @@
 use = egg:c2corg_ui
 
 api_url = {api_url}
+api_url_internal = {api_url_internal}
+api_url_host = {api_url_host}
 
 pyramid.default_locale_name = fr
 

--- a/config/default
+++ b/config/default
@@ -9,6 +9,8 @@ export elasticsearch_host = ...
 host = c2corgv6.demo-camptocamp.com
 url = http://$(host)
 
-export api_url = http://$(host)/main
+export api_url = http://c2corgv6-api.demo-camptocamp.com
+export api_url_internal =
+export api_url_host =
 
 export logging_level = WARNING

--- a/config/main
+++ b/config/main
@@ -4,3 +4,5 @@ export debug_port = 6553
 export instanceid = ui
 export base_url = /
 export api_url = http://c2corgv6-api.demo-camptocamp.com
+export api_url_internal = http://localhost
+export api_url_host = c2corgv6-api


### PR DESCRIPTION
Fixes #18

The default behaviour is unchanged => should work as is on dev instances.
If a ``api_url_internal`` is set in the config, it is used instead of ``api_url`` when the UI server requests the API. In that case, one may specify a Host header by setting ``api_url_host``.