### PR TITLE
Make sure empty other_cultures block is not displayed in view pages

### DIFF
--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -4,7 +4,7 @@ from c2corg_common.attributes import default_cultures
 def get_culture_lists(document, culture):
     if 'available_cultures' in document:
         available_cultures = document['available_cultures']
-        other_cultures = filter(lambda l: l != culture, available_cultures)
+        other_cultures = [l for l in available_cultures if l != culture]
         missing_cultures = list(
           set(default_cultures) - set(available_cultures)
         )


### PR DESCRIPTION
Using ``filter()``, ``if other_cultures:`` is always evaluated to ``True`` even though the doc is available in no other culture. In addition the list comprehension is a bit more readable. :P 