### PR TITLE
List card layout

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -517,14 +517,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -505,14 +505,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -506,14 +506,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -507,14 +507,6 @@ msgstr "weather_station"
 msgid "webcam"
 msgstr "webcam"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr "{{nbItems}} routes"
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr "{{nbItems}} waypoints"
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -506,14 +506,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -505,14 +505,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -505,14 +505,6 @@ msgstr "station météo"
 msgid "webcam"
 msgstr "webcam"
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr "{{nbItems}} itinéraires trouvés"
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr "{{nbItems}} points de passage trouvés"
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr "← différence précédente"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -506,14 +506,6 @@ msgstr ""
 msgid "webcam"
 msgstr ""
 
-#: c2corg_ui/templates/route/index.html
-msgid "{{nbItems}} routes"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/index.html
-msgid "{{nbItems}} waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "← previous difference"
 msgstr ""

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -17,7 +17,7 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
             first.pop('offset')
         filters_str = '/' + '/'.join(['%s/%s' % (key, first[key]) for key in first])
     %>
-    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-step-backward"></span><span translate>First</span></a></li>
+    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-step-backward"></span><span translate>First</span></a></li>
     <%
         prev = params.copy()
         prev['offset'] -= prev['limit']
@@ -25,22 +25,22 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
             prev.pop('offset')
         filters_str = '/' + '/'.join(['%s/%s' % (key, prev[key]) for key in prev])
     %>
-    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-menu-left" ></span><span translate>Previous</span></a></li>
+    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-menu-left" ></span><span translate>Previous</span></a></li>
   % endif
   % if offset + params['limit'] < total:
-   <%
+    <%
         next = params.copy()
         next['offset'] = offset + next['limit']
         filters_str = '/' + '/'.join(['%s/%s' % (key, next[key]) for key in next])
-   %>
-   <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span translate>Next</span><span class="glyphicon glyphicon-menu-right"></span></a></li>
-  <%
+    %>
+    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span translate>Next</span><span class="glyphicon glyphicon-menu-right"></span></a></li>
+    <%
         last = params.copy()
         last['offset'] = total - last['limit']
         filters_str = '/' + '/'.join(['%s/%s' % (key, last[key]) for key in last])
     %>
-    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}" ><span translate>Last</span><span class="glyphicon glyphicon-step-forward"></span></a></li>
-     % endif
+    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}" ><span translate>Last</span><span class="glyphicon glyphicon-step-forward"></span></a></li>
+  % endif
   </ul>
 % endif
 </%def>

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -9,7 +9,7 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
       params = {k: int(params[k]) if k == 'offset' or k == 'limit' else params[k] for k in params}
       offset = params['offset'] if 'offset' in params else 0
   %>
-  <ul>
+  <ul id="pagination">
   % if offset > 0:
     <%
         first = params.copy()
@@ -17,7 +17,7 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
             first.pop('offset')
         filters_str = '/' + '/'.join(['%s/%s' % (key, first[key]) for key in first])
     %>
-    <li><a href="${request.route_url(module + '_index', filters=filters_str)}" translate>First</a></li>
+    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-step-backward"></span><span translate>First</span></a></li>
     <%
         prev = params.copy()
         prev['offset'] -= prev['limit']
@@ -25,22 +25,22 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
             prev.pop('offset')
         filters_str = '/' + '/'.join(['%s/%s' % (key, prev[key]) for key in prev])
     %>
-    <li><a href="${request.route_url(module + '_index', filters=filters_str)}" translate>Previous</a></li>
+    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span class="glyphicon glyphicon-menu-left" ></span><span translate>Previous</span></a></li>
   % endif
   % if offset + params['limit'] < total:
-    <%
+   <%
         next = params.copy()
         next['offset'] = offset + next['limit']
         filters_str = '/' + '/'.join(['%s/%s' % (key, next[key]) for key in next])
-    %>
-    <li><a href="${request.route_url(module + '_index', filters=filters_str)}" translate>Next</a></li>
-    <%
+   %>
+   <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span translate>Next</span><span class="glyphicon glyphicon-menu-right"></span></a></li>
+  <%
         last = params.copy()
         last['offset'] = total - last['limit']
         filters_str = '/' + '/'.join(['%s/%s' % (key, last[key]) for key in last])
     %>
-    <li><a href="${request.route_url(module + '_index', filters=filters_str)}" translate>Last</a></li>
-  % endif
+    <li ><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}" ><span translate>Last</span><span class="glyphicon glyphicon-step-forward"></span></a></li>
+     % endif
   </ul>
 % endif
 </%def>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -3,23 +3,42 @@
 <%block name="pagetitle">Routes</%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
-<h1>${self.pagetitle()}</h1>
-<app-map></app-map>
-<p translate ng-init="nbItems = ${total}">{{nbItems}} routes</p>
-${add_pagination_links('routes', routes, total, filter_params)}
-<ul>
-  <li><a href="${request.route_url('routes_add')}" translate>Add a route</a></li>
-% for route in routes:
-  <li>
-    <% locale = route['locales'][0] %>\
-    <a href="${request.route_url('routes_view', id=route['document_id'], culture=locale['culture'])}">${locale['title']}</a>
-    % if lang != locale['culture']:
-      (${locale['culture']})
-    % endif
-    % if route['elevation_max'] is not None:
-      - ${route['elevation_max']} m
-    % endif
-    ${get_attr(locale, 'summary')}
-  </li>
-% endfor
-</ul>
+<div class="text-center">
+  <h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}})</h3>
+</div>
+<section id="routes_section">
+  <div class="add_route text-center">
+  <button class="btn btn-success">
+    <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+    <a href="${request.route_url('routes_add')}" translate>Add a route</a>
+  </button>
+    ${add_pagination_links('routes', routes, total, filter_params)}
+  </div>
+  <div id="routes">
+    <div class="list">
+      % for route in routes:
+      <% locale = route['locales'][0] %>\
+      <div class="list_item">
+        <a href="${request.route_url('routes_view', id=route['document_id'], culture=locale['culture'])}">
+          <span class="list_item_title">${locale['title']}</span>
+          % if lang != locale['culture']:
+          <span class="list_item_culture"> (${locale['culture']}) </span>
+          <br>
+          % endif
+          <div class="list_item_info">
+          % if route['elevation_max'] is not None:
+            <span class="list_item_elevation">Elevation: ${route['elevation_max']} m</span>
+          % endif
+            <p class="text-justify">${locale['summary']}</p>
+          </div>
+        </a>
+      </div>
+      % endfor
+    </div>
+  </div>
+</section>
+% if len(routes):
+<div class="map_right">
+  <app-map></app-map>
+</div>
+% endif

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -38,25 +38,42 @@ module.value('mapFeatureCollection', {
 % endif
 </%block>\
 
-<h1>${self.pagetitle()}</h1>
+<div class="text-center"><h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}}) </h3></div class="text-center">
+<section id="waypoints_section">
+  <div class="add_waypoint text-center">
+    <button class='btn btn-success'> <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+      <a href="${request.route_url('waypoints_add')}" translate>Add a waypoint</a>
+    </button>
+    ${add_pagination_links('waypoints', waypoints, total, filter_params)}
+  </div>
+  <div id="waypoints">
+    <div class="list">
+      % for waypoint in waypoints:
+      <% locale = waypoint['locales'][0] %>\
+      <div class="list_item">
+        <a href="${request.route_url('waypoints_view', id=waypoint['document_id'], culture=locale['culture'])}">
+          <span class="list_item_title ">${locale['title']}</span>
+          % if lang != locale['culture']:
+          <span class="list_item_culture">(${locale['culture']})</span>
+          <br>
+          % endif
+          <div class="list_item_info">
+          % if waypoint['elevation'] is not None:
+            <span class="list_item_elevation">Elevation: ${waypoint['elevation']} m</span>
+          % endif
+            <span>
+              <p><img alt="waypoint type" src="${request.static_url('c2corg_ui:static/img/icons/' + waypoint['waypoint_type'] + '.png')}"> {{mainCtrl.translate('${waypoint['waypoint_type']}')}}</p>
+            </span>
+            <p class="text-justify">${locale['summary']}</p>
+          </div>
+        </a>
+      </div>
+      % endfor
+    </div>
+  </div>
+</section>
 % if len(waypoints):
+<div class="map_right">
   <app-map></app-map>
+</div>
 % endif
-<p translate ng-init="nbItems = ${total}">{{nbItems}} waypoints</p>
-${add_pagination_links('waypoints', waypoints, total, filter_params)}
-<ul>
-  <li><a href="${request.route_url('waypoints_add')}" translate>Add a waypoint</a></li>
-% for waypoint in waypoints:
-  <li>
-    <% locale = waypoint['locales'][0] %>\
-    <a href="${request.route_url('waypoints_view', id=waypoint['document_id'], culture=locale['culture'])}">${locale['title']}</a>
-    % if lang != locale['culture']:
-      (${locale['culture']})
-    % endif
-    % if waypoint['elevation'] is not None:
-      - ${waypoint['elevation']} m
-    % endif
-    ${get_attr(locale, 'summary')} 
-  </li>
-% endfor
-</ul>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -3,8 +3,232 @@
 @import "search.less";
 @import "diff.less";
 
+@big: ~"only screen and (min-width: 1400px) and (max-width: 3000px)";
+@desktop: ~"only screen and (min-width: 1100px) and (max-width: 1399px)";
+@tablet: ~"only screen and (min-width: 620px) and (max-width: 1099px)";
+@phone: ~"only screen and (min-width: 130px) and (max-width: 619px)";
+@lightgrey: #F0F0F0;
+
+ul {
+  list-style: none;
+  
+  li {
+    display: inline-block;
+  }
+}
+html, body{
+  min-height: 100%;
+}
+.add_waypoint, .add_route {
+  margin: 1% 0 1% 0;
+  
+  a {
+    color:white;
+  }
+}
+.filters {
+  display: block;
+  overflow: auto;
+  border-top: 1px solid lightgrey;
+  border-bottom: 1px solid lightgrey;
+  
+  input {
+    margin-bottom: 1%;
+  }
+  
+  form  div {
+    width: 30%;
+    float: left;
+
+    @media @phone {
+      width: 100%;
+    }
+    @media @tablet {
+      width: 46%;
+    }
+  }
+}
+
+#waypoints, #routes {
+  padding-right: 2%;
+  margin-bottom: 2%;
+  margin-left: 2%;
+  width:98%;
+  min-height:100px;
+  height: 69vh;
+  overflow-y: scroll;
+  
+  @media @phone {
+    height: 45vh;
+  }
+}
+
+#pagination {
+  margin-top:1%;
+  
+  li {
+    display:inline-block;
+
+    a {
+      color:white;
+    }
+  }
+}
+
+.list {
+  width:100%;
+  padding-left: 0;
+  -webkit-column-count:3;
+  -moz-column-count:3;
+ 
+  @media @tablet {
+    -moz-column-count: 2;
+    -webkit-column-count:2;
+  }
+  @media @phone {
+    margin: auto;
+    -moz-column-count: 1;
+    -webkit-column-count: 1;
+  }
+  @media @big {
+    -webkit-column-count: 3;
+    -moz-column-count: 3;
+  }
+}
+
+.list_item_title {
+  font-size: 1.2em;
+  font-weight: bold;
+
+  @media @phone {
+    font-weight: normal;
+    font-size: 1.5em;
+  }
+}
+
+.list_item_elevation {
+  margin-bottom: 1%;
+}
+
+.list_item_info {
+  text-decoration: none;
+  color: black;
+  font-weight: normal;
+  margin-top:1%;
+  margin-bottom: 1%;
+  
+  @media @phone {
+    font-size: 1.3em;
+  }
+}
+
+.list_item {
+  position: relative;
+  cursor: pointer;
+  
+  background-color: white;
+  max-height: auto;
+  min-height: 100px;
+  width:100%;
+  margin-right: 3%;
+  margin-bottom: 5%;
+  
+  border-radius: 20px;
+  -moz-border-radius: 20px;
+  -webkit-border-radius: 20px;
+  
+  border: 1px solid #dbdbdb;
+  display: inline-table;
+  position:relative;
+  
+  transition: .4s;
+
+  a {
+    padding: 5%;
+    display: block;
+    transition: 0.2s;
+    
+    .list_item_culture {
+      opacity: 0.9;
+      color: graytext;
+      font-weight: normal;
+    }
+    
+    &:hover {
+     text-decoration: none;
+     color : #DB7D00;
+    }
+    
+    &:hover .list_item_title {
+      text-decoration: underline;
+    }
+  }
+  
+  &:active {
+    -webkit-box-shadow: inset 2px 3px 19px -4px rgba(0,0,0,0.75);
+    -moz-box-shadow: inset 2px 3px 19px -4px rgba(0,0,0,0.75);
+    box-shadow: inset 2px 3px 19px -4px rgba(0,0,0,0.75);
+    -webkit-transition: .5s;
+    transition: 0.5s;
+  }
+
+  @media @tablet {
+    padding:5%;
+    margin-right:-1%;
+  }
+  @media @phone {
+    padding:3%;
+    font-size:0.9em;
+  }
+} /* list_item*/
+
+.line-separator{
+  height:1px;
+  background:#717171;
+  border-bottom:1px solid @lightgrey;
+  opacity: 0.9;
+  margin: 3% 0 3% 0;
+}
+h3 {
+  margin-top: 0;
+}
+
 .map {
-  height: 400px;
+  margin:0;
+}
+
+.map_right {
+  
+  .map {
+      height: 81vh;
+      @media @phone {
+        height: 40vh;
+      }
+  }
+   margin-left: 60%;
+   
+   @media @tablet {
+     margin-left: 55%;
+   }
+   @media @phone{
+     margin-left:0;
+   }
+}
+
+#routes_section, #waypoints_section {
+  background-color: @lightgrey;
+  width: 60%;
+  height: 100%;
+  float: left;
+
+  @media @tablet{
+    width: 55%;
+  }
+  
+  @media @phone {
+    width: 100%;
+    float:none;
+  }
 }
 
 .page-header {
@@ -23,6 +247,7 @@
     width: 400px;
     float: right;
     text-align: right;
+    font-weight: bold;
   }
 
   .culture-selector {
@@ -31,23 +256,28 @@
 }
 
 .page-content {
+  
   .archive-data {
     margin: 5px;
     padding: 5px;
     border: 1px solid red;
     background-color: rgba(255, 0, 0, 0.2);
   }
+  
   .versions-list {
     border: 1px solid black;
     margin-bottom: 10px;
     border-collapse: collapse;
+    
     th {
       padding: 5px;
       border: 1px solid black;
     }
+    
     td {
       padding: 5px;
       border: 1px solid black;
+      
       .hide-radio {
         visibility: hidden;
       }


### PR DESCRIPTION
Replaces #81 
NEW
* [x] Lists are on the left and map on the right (ass seen on AirBnB.fr)
* [x] layout changes described at https://github.com/c2corg/v6_ui/pull/81#issuecomment-170268261
* [x] code changes listed in the original PR #81 (indentation, blank spaces etc.)
* [x] change icons depending on waypoint type

TODO 
* [ ] search filters
* [ ] list & map should take whole screen's height (it's too short on large screens)

DONE
* [x] changed the simple waypoint list into a card layout, and it's responsive
* [x] Helpers buttons (pagination) are now stylized and have icons
* [x] same layout for routes
* [x] click on whole card in order to see details, and not only on ```<a>``` tag

