### PR TITLE
Add summary field to waypoints and routes

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -25,13 +25,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgid "Routes"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr ""
 
@@ -187,7 +187,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -319,8 +319,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -489,6 +489,8 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -29,13 +29,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgid "Routes"
 msgstr "Itineraris"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -316,8 +316,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -485,7 +485,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -30,13 +30,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Routes"
 msgstr "Routen"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr "Speichern"
 
@@ -189,7 +189,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -317,8 +317,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -486,7 +486,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -30,13 +30,13 @@ msgid "Browse site in"
 msgstr "Browse site in"
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr "Cancel"
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr "Comment about the changes"
 
@@ -61,7 +61,7 @@ msgstr "Culture"
 msgid "Describe here the gear needed for this route"
 msgstr "Describe here the gear needed for this route"
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr "Describe here the waypoint"
 
@@ -176,7 +176,7 @@ msgid "Routes"
 msgstr "Routes"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr "Save"
 
@@ -189,7 +189,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr "Short description of the applied changes"
 
@@ -318,8 +318,8 @@ msgstr "de"
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr "Description"
 
@@ -487,7 +487,8 @@ msgstr "snow_ice_mixed"
 msgid "snowshoeing"
 msgstr "snowshoeing"
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -30,13 +30,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Routes"
 msgstr "Itinerarios"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr ""
 
@@ -189,7 +189,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -317,8 +317,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -486,7 +486,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -29,13 +29,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgid "Routes"
 msgstr "Ibilbideak"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -316,8 +316,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -485,7 +485,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -27,13 +27,13 @@ msgid "Browse site in"
 msgstr "Naviguer en"
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr "Annuler"
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr "Courte description des changements"
 
@@ -58,7 +58,7 @@ msgstr "Langue"
 msgid "Describe here the gear needed for this route"
 msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr "Décrivez ici l'itinéraire"
 
@@ -175,7 +175,7 @@ msgid "Routes"
 msgstr "Itinéraires"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -188,7 +188,7 @@ msgid "See the latest version"
 msgstr "Voir la dernière version"
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr "Courte description des changements appliqués"
 
@@ -316,8 +316,8 @@ msgstr "allemand"
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr "Description"
 
@@ -485,7 +485,8 @@ msgstr "alpinisme neige, glace et mixte"
 msgid "snowshoeing"
 msgstr "raquette"
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr "résumé"
 

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -30,13 +30,13 @@ msgid "Browse site in"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:77
-#: c2corg_ui/templates/waypoint/edit.html:93
+#: c2corg_ui/templates/waypoint/edit.html:97
 msgid "Cancel"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html:29
 #: c2corg_ui/templates/route/edit.html:67
-#: c2corg_ui/templates/waypoint/edit.html:83
+#: c2corg_ui/templates/waypoint/edit.html:87
 msgid "Comment about the changes"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Describe here the gear needed for this route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html:79
+#: c2corg_ui/templates/waypoint/edit.html:83
 msgid "Describe here the waypoint"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Routes"
 msgstr "Itinerari"
 
 #: c2corg_ui/templates/route/edit.html:72
-#: c2corg_ui/templates/waypoint/edit.html:88
+#: c2corg_ui/templates/waypoint/edit.html:92
 msgid "Save"
 msgstr ""
 
@@ -189,7 +189,7 @@ msgid "See the latest version"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:68
-#: c2corg_ui/templates/waypoint/edit.html:84
+#: c2corg_ui/templates/waypoint/edit.html:88
 msgid "Short description of the applied changes"
 msgstr ""
 
@@ -317,8 +317,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html:58
 #: c2corg_ui/templates/route/view.html:34
-#: c2corg_ui/templates/waypoint/edit.html:78
-#: c2corg_ui/templates/waypoint/view.html:59
+#: c2corg_ui/templates/waypoint/edit.html:82
+#: c2corg_ui/templates/waypoint/view.html:60
 msgid "description"
 msgstr ""
 
@@ -486,7 +486,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html:68
+#: c2corg_ui/templates/i18n.html:68 c2corg_ui/templates/waypoint/edit.html:78
+#: c2corg_ui/templates/waypoint/view.html:59
 msgid "summary"
 msgstr ""
 

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -54,6 +54,10 @@ updating_doc = route_id and route_culture
       ng-model="route.route_type" class="form-control">
     </select>
   </div>
+  <div id="summary-group" class="form-group">
+    <label translate>summary</label>
+    <textarea name="summary" ng-model="route.locales[0].summary" class="form-control"></textarea>
+  </div>
   <div id="description-group" class="form-group">
     <label translate>description</label>
     <textarea name="description" ng-model="route.locales[0].description" class="form-control"></textarea>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="add_pagination_links"/>
+<%namespace file="../helpers.html" import="get_attr, add_pagination_links"/>
 <%block name="pagetitle">Routes</%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
@@ -19,6 +19,7 @@ ${add_pagination_links('routes', routes, total, filter_params)}
     % if route['elevation_max'] is not None:
       - ${route['elevation_max']} m
     % endif
+    ${get_attr(locale, 'summary')}
   </li>
 % endfor
 </ul>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -31,6 +31,7 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
 </ul>
 <ul>
   <li><span translate>height_diff_up</span> : ${route['height_diff_up']} m</li>
+  <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
   <li><span translate>description</span> : ${get_attr(locale, 'description')}</li>
   <li><span translate>gear</span> : ${get_attr(locale, 'gear')}</li>
 </ul>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -74,6 +74,10 @@ updating_doc = waypoint_id and waypoint_culture
     <label translate>maps_info</label>
     <input type="text" name="maps_info" ng-model="waypoint.maps_info" class="form-control" />
   </div>
+  <div id="summary-group" class="form-group">
+    <label translate>summary</label>
+    <textarea name="summary" ng-model="waypoint.locales[0].summary" class="form-control"></textarea>
+  </div>
   <div id="description-group" class="form-group">
     <label translate>description</label>
     <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the waypoint'|translate}}"></textarea>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="add_pagination_links"/>
+<%namespace file="../helpers.html" import="get_attr, add_pagination_links"/>
 <%block name="pagetitle">Waypoints</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
@@ -56,6 +56,7 @@ ${add_pagination_links('waypoints', waypoints, total, filter_params)}
     % if waypoint['elevation'] is not None:
       - ${waypoint['elevation']} m
     % endif
+    ${get_attr(locale, 'summary')} 
   </li>
 % endfor
 </ul>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -56,6 +56,7 @@ module.value('mapFeatureCollection', {
   <li><span translate>elevation</span> : ${waypoint['elevation']} m</li>
   <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>
   <li><span translate>maps_info</span> : ${get_attr(waypoint, 'maps_info')}</li>
+  <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
   <li><span translate>description</span> : ${get_attr(locale, 'description')}</li>
 </ul>
 <app-map></app-map>


### PR DESCRIPTION
Fixes #91

6156e9a is only line number changes in PO files caused by the new HTML added in the templates. Would be cool if we could omit those line numbers => we wouldn't have those quite useless commits about the PO files.