### PR TITLE
Fix list + editing page titles

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -12,6 +12,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -47,6 +51,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -62,6 +74,14 @@ msgstr ""
 #: c2corg_ui/templates/route/view.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -163,6 +183,7 @@ msgid "Revision as of"
 msgstr ""
 
 #: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr ""
 
@@ -216,7 +237,12 @@ msgid "View in other culture:"
 msgstr ""
 
 #: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -49,6 +53,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -63,6 +75,14 @@ msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -161,7 +181,7 @@ msgstr ""
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Itineraris"
 
@@ -210,8 +230,12 @@ msgstr ""
 msgid "View in other culture:"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -50,6 +54,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -64,6 +76,14 @@ msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -162,7 +182,7 @@ msgstr ""
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Routen"
 
@@ -211,9 +231,13 @@ msgstr ""
 msgid "View in other culture:"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
 msgstr "Waypoints"
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
+msgstr ""
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,11 @@ msgstr "Add a route"
 msgid "Add a waypoint"
 msgstr "Add a waypoint"
 
+#: c2corg_ui/templates/auth.html
+#, fuzzy
+msgid "Authentication"
+msgstr "weather_station"
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -50,6 +55,14 @@ msgstr "Coordinates"
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr "Culture"
@@ -65,6 +78,14 @@ msgstr "Describe here the waypoint"
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Edit"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
+msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Elevation must be smaller than 9999 m."
@@ -162,7 +183,7 @@ msgstr "Remember me"
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Routes"
 
@@ -212,9 +233,13 @@ msgstr ""
 msgid "View in other culture:"
 msgstr "View in other culture:"
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
 msgstr "Waypoints"
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
+msgstr ""
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -50,6 +54,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -64,6 +76,14 @@ msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -162,7 +182,7 @@ msgstr ""
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Itinerarios"
 
@@ -211,8 +231,12 @@ msgstr ""
 msgid "View in other culture:"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -49,6 +53,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -63,6 +75,14 @@ msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -161,7 +181,7 @@ msgstr ""
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Ibilbideak"
 
@@ -210,8 +230,12 @@ msgstr ""
 msgid "View in other culture:"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -14,6 +14,10 @@ msgstr "Ajouter un itinéraire"
 msgid "Add a waypoint"
 msgstr "Ajouter un point de passage"
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr "Connexion"
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr "Auteur"
@@ -47,6 +51,16 @@ msgstr "Coordonnées"
 msgid "Created on"
 msgstr "Créée le"
 
+#: c2corg_ui/templates/route/edit.html
+#, fuzzy
+msgid "Creating a route"
+msgstr "Edition d'un itinéraire"
+
+#: c2corg_ui/templates/waypoint/edit.html
+#, fuzzy
+msgid "Creating a waypoint"
+msgstr "Edition d'un point de passage"
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr "Langue"
@@ -62,6 +76,14 @@ msgstr "Décrivez ici l'itinéraire"
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Modifier"
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr "Edition d'un itinéraire"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
+msgstr "Edition d'un point de passage"
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Elevation must be smaller than 9999 m."
@@ -161,7 +183,7 @@ msgstr "Se souvenir de moi"
 msgid "Revision as of"
 msgstr "Version du"
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Itinéraires"
 
@@ -210,9 +232,13 @@ msgstr "Version 2 en"
 msgid "View in other culture:"
 msgstr "Afficher dans une autre langue:"
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
 msgstr "Points de passage"
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
+msgstr "Bienvenue"
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/auth.html
+msgid "Authentication"
+msgstr ""
+
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -50,6 +54,14 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: c2corg_ui/templates/route/edit.html
+msgid "Creating a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Creating a waypoint"
+msgstr ""
+
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Culture"
 msgstr ""
@@ -64,6 +76,14 @@ msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "Editing a route"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Editing a waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
@@ -162,7 +182,7 @@ msgstr ""
 msgid "Revision as of"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/route/index.html
 msgid "Routes"
 msgstr "Itinerari"
 
@@ -211,8 +231,12 @@ msgstr ""
 msgid "View in other culture:"
 msgstr ""
 
-#: c2corg_ui/templates/base.html
+#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -1,4 +1,5 @@
 <%inherit file="base.html"/>
+<%block name="pagetitle">{{'Authentication' | translate}}</%block>\
 
 <div ng-init="showRegisterForm=false">
   <h1 translate>Login</h1>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -9,10 +9,9 @@ closure_library_path = settings.get('closure_library_path')
 <!DOCTYPE html>
 <html <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
-    <title><%block name="pagetitle">Camptocamp.org</%block></title>
+    <title><%block name="pagetitle">{{'Welcome' | translate}}</%block> - Camptocamp.org</title>
     <meta charset="utf-8">
-    <meta name="viewport"
-          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%block name="metarobots"><meta name="robots" content="index,follow"></%block>
 % if debug:

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -5,7 +5,7 @@ from c2corg_common.attributes import default_cultures
 <%
 updating_doc = route_id and route_culture
 %>\
-<%block name="pagetitle">FIXME: Adding/editing page title</%block>
+<%block name="pagetitle">${"{{'Editing a route' | translate}}" if route_id and route_culture else "{{'Creating a route' | translate}}"}</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
 
 <h1>${self.pagetitle()}</h1>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,6 +1,6 @@
 <%inherit file="../base.html"/>
 <%namespace file="../helpers.html" import="get_attr, add_pagination_links"/>
-<%block name="pagetitle">Routes</%block>
+<%block name="pagetitle">{{'Routes' | translate}}</%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
 <div class="text-center">

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -5,7 +5,7 @@ from c2corg_common.attributes import default_cultures
 <%
 updating_doc = waypoint_id and waypoint_culture
 %>\
-<%block name="pagetitle">FIXME: Adding/editing page title</%block>
+<%block name="pagetitle">${"{{'Editing a waypoint' | translate}}" if waypoint_id and waypoint_culture else "{{'Creating a waypoint' | translate}}"}</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
 
 <h1>${self.pagetitle()}</h1>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,6 +1,6 @@
 <%inherit file="../base.html"/>
 <%namespace file="../helpers.html" import="get_attr, add_pagination_links"/>
-<%block name="pagetitle">Waypoints</%block>\
+<%block name="pagetitle">{{'Waypoints' | translate}}</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
 <%block name="moduleConstantsValues">


### PR DESCRIPTION
I am not fully satisfied of this PR:
* with the bracket notation (``{{'Some title' | translate}}``), brackets appear until the translation is done (not very discrete for the page title!). The standard ``<span translate>Some title</span>`` avoids this but cannot be used inside a ``<title>`` element (the contained tags appear) => perhaps we should use the ``translate`` attribute directly in ``<title>``.
* the ``pagetitle`` block is defined in the parent ``base.html`` template. It seems then mako variables such as ``updating_doc`` (a boolean set in the child template) are not available in the block. As a result https://github.com/c2corg/v6_ui/blob/b7f9956dfce9f7dceb77193abc7130f2cdc5302e/c2corg_ui/templates/waypoint/edit.html#L8 always produces "Creating a waypoint" even though an existing document is edited.