### PR TITLE
Disable form submit button when form is still untouched

### DIFF
--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -73,7 +73,7 @@ updating_doc = route_id and route_culture
   </div>
   % endif
   <p>
-    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid" translate>Save</button>
+    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$pristine || editForm.$invalid" translate>Save</button>
     <%
     view_url = request.route_url('routes_view', id=route_id, culture=route_culture) if updating_doc else ''
     index_url = request.route_url('routes_index_default')

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -89,7 +89,7 @@ updating_doc = waypoint_id and waypoint_culture
   </div>
   % endif
   <p>
-    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid" translate>Save</button>
+    <button type="submit" class="btn btn-primary" ng-disabled="editForm.$pristine || editForm.$invalid" translate>Save</button>
     <%
     view_url = request.route_url('waypoints_view', id=waypoint_id, culture=waypoint_culture) if updating_doc else ''
     index_url = request.route_url('waypoints_index_default')


### PR DESCRIPTION
The goal is to prevent that the form is submitted when no change has been applied yet.