### PR TITLE
Only authenticated users should have access to editing pages

### DIFF
--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -42,6 +42,32 @@ app.Alerts.prototype.add = function(data) {
 
 
 /**
+ * @param {(string|Object)} msg
+ * @export
+ */
+app.Alerts.prototype.addSuccess = function(msg) {
+  this.add({
+    'type': 'success',
+    'msg': msg,
+    'timeout': 5000
+  });
+};
+
+
+/**
+ * @param {(string|Object)} msg
+ * @export
+ */
+app.Alerts.prototype.addError = function(msg) {
+  this.add({
+    'type': 'danger',
+    'msg': msg,
+    'timeout': 5000
+  });
+};
+
+
+/**
  * @return {Array.<appx.AlertMessage>}
  * @export
  */

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -129,11 +129,7 @@ app.AuthController.prototype.successLogin_ = function(remember, response) {
  * @private
  */
 app.AuthController.prototype.errorLogin_ = function(response) {
-  this.alerts_.add({
-    'type': 'danger',
-    'msg': response,
-    'timeout': 5000
-  });
+  this.alerts_.addError(response);
 };
 
 
@@ -158,11 +154,7 @@ app.AuthController.prototype.register = function() {
  * @private
  */
 app.AuthController.prototype.successRegister_ = function(response) {
-  this.alerts_.add({
-    'type': 'success',
-    'msg': 'Register success',
-    'timeout': 5000
-  });
+  this.alerts_.addSuccess('Register success');
 };
 
 
@@ -171,11 +163,7 @@ app.AuthController.prototype.successRegister_ = function(response) {
  * @private
  */
 app.AuthController.prototype.errorRegister_ = function(response) {
-  this.alerts_.add({
-    'type': 'danger',
-    'msg': response,
-    'timeout': 5000
-  });
+  this.alerts_.addError(response);
 };
 
 

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -244,11 +244,7 @@ app.DocumentEditingController.prototype.successRead_ = function(response) {
  * @private
  */
 app.DocumentEditingController.prototype.errorRead_ = function(response) {
-  this.alerts_.add({
-    'type': 'danger',
-    'msg': response,
-    'timeout': 5000
-  });
+  this.alerts_.addError(response);
 };
 
 
@@ -258,20 +254,12 @@ app.DocumentEditingController.prototype.errorRead_ = function(response) {
  */
 app.DocumentEditingController.prototype.submitForm = function(isValid) {
   if (!isValid) {
-    this.alerts_.add({
-      'type': 'danger',
-      'msg': 'Form is not valid',
-      'timeout': 5000
-    });
+    this.alerts_.addError('Form is not valid');
     return;
   }
 
   if (!this.auth_.isAuthenticated()) {
-    this.alerts_.add({
-      'type': 'danger',
-      'msg': 'You have no permission to modify this document',
-      'timeout': 5000
-    });
+    this.alerts_.addError('You have no permission to modify this document');
     return;
   }
 
@@ -370,11 +358,7 @@ app.DocumentEditingController.prototype.errorSave_ = function(response) {
   } else {
     msg = 'Failed saving the changes';
   }
-  this.alerts_.add({
-    'type': 'danger',
-    'msg': msg,
-    'timeout': 5000
-  });
+  this.alerts_.addError(msg);
 };
 
 

--- a/c2corg_ui/static/js/editbutton.js
+++ b/c2corg_ui/static/js/editbutton.js
@@ -1,0 +1,72 @@
+goog.provide('app.EditButtonController');
+goog.provide('app.editButtonDirective');
+
+goog.require('app');
+
+
+/**
+ * This directive is used to display a button that, when clicked, opens
+ * a document editing page if user's permissions fit, else opens the
+ * authentication page.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.editButtonDirective = function() {
+  return {
+    restrict: 'E',
+    scope: {
+      'url': '@appEditButtonUrl'
+    },
+    controller: 'AppEditButtonController',
+    controllerAs: 'ebCtrl',
+    bindToController: true,
+    transclude: true,
+    template: '<button class="btn btn-primary" type="button" ' +
+        'ng-click="ebCtrl.redirect()">' +
+        '<div ng-transclude></div></button>'
+  };
+};
+
+
+app.module.directive('appEditButton', app.editButtonDirective);
+
+
+/**
+ * @param {app.Authentication} appAuthentication
+ * @param {string} authUrl Base URL of the authentication page.
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.EditButtonController = function(appAuthentication, authUrl) {
+
+  /**
+   * @type {app.Authentication}
+   * @private
+   */
+  this.auth_ = appAuthentication;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.authUrl_ = authUrl;
+};
+
+
+/**
+ * @export
+ */
+app.EditButtonController.prototype.redirect = function() {
+  if (this.auth_.isAuthenticated()) {
+    window.location.href = this['url'];
+  } else {
+    window.location.href = '{authUrl}?from={redirect}'
+        .replace('{authUrl}', this.authUrl_)
+        .replace('{redirect}', encodeURIComponent(this['url']));
+  }
+};
+
+
+app.module.controller('AppEditButtonController', app.EditButtonController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -11,6 +11,7 @@ goog.require('app.alertsDirective');
 goog.require('app.authDirective');
 goog.require('app.diffMapDirective');
 goog.require('app.documentEditingDirective');
+goog.require('app.editButtonDirective');
 goog.require('app.langDirective');
 goog.require('app.mapDirective');
 goog.require('app.searchDirective');

--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -112,11 +112,7 @@ app.UserController.prototype.logout = function() {
  */
 app.UserController.prototype.successLogout_ = function(response) {
   this.auth.removeUserData();
-  this.alerts_.add({
-    'type': 'success',
-    'msg': 'You have been disconnected',
-    'timeout': 5000
-  });
+  this.alerts_.addSuccess('You have been disconnected');
 };
 
 
@@ -126,11 +122,7 @@ app.UserController.prototype.successLogout_ = function(response) {
  */
 app.UserController.prototype.errorLogout_ = function(response) {
   this.auth.removeUserData();
-  this.alerts_.add({
-    'type': 'danger',
-    'msg': response,
-    'timeout': 5000
-  });
+  this.alerts_.addError(response);
 };
 
 

--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -16,9 +16,6 @@ goog.require('ngeo.Location');
 app.userDirective = function() {
   return {
     restrict: 'E',
-    scope: {
-      'loginUrl': '@appUserLoginUrl'
-    },
     controller: 'AppUserController',
     controllerAs: 'userCtrl',
     bindToController: true,
@@ -36,12 +33,13 @@ app.module.directive('appUser', app.userDirective);
  * @param {string} apiUrl Base URL of the API.
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {app.Alerts} appAlerts
+ * @param {string} authUrl Base URL of the authentication page.
  * @constructor
  * @export
  * @ngInject
  */
 app.UserController = function($http, appAuthentication, apiUrl, ngeoLocation,
-    appAlerts) {
+    appAlerts, authUrl) {
 
   /**
    * @type {angular.$http}
@@ -60,6 +58,12 @@ app.UserController = function($http, appAuthentication, apiUrl, ngeoLocation,
    * @private
    */
   this.apiUrl_ = apiUrl;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.authUrl_ = authUrl;
 
   /**
    * @type {ngeo.Location}
@@ -81,7 +85,7 @@ app.UserController = function($http, appAuthentication, apiUrl, ngeoLocation,
 app.UserController.prototype.showLogin = function() {
   var current_url = this.ngeoLocation_.getUriString();
   window.location.href = '{login}?from={current}'
-      .replace('{login}', this['loginUrl'])
+      .replace('{login}', this.authUrl_)
       .replace('{current}', encodeURIComponent(current_url));
 };
 

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -43,7 +43,7 @@ closure_library_path = settings.get('closure_library_path')
         <app-search app-search-map=""></app-search>
       </div>
       <div class="lang-user">
-        <app-user app-user-login-url="${request.route_url('auth')}"></app-user>
+        <app-user></app-user>
         <div class="culture-selector">
           <label translate>Browse site in</label>
           <app-lang app-lang-cultures="['${"','".join(default_cultures) |n}']"></app-lang>
@@ -84,6 +84,7 @@ closure_library_path = settings.get('closure_library_path')
          var module = angular.module('app');
          module.constant('langUrlTemplate', '${request.static_url('c2corg_ui:static/build/locale/__lang__/c2corg_ui.json')}');
          module.constant('apiUrl', '${api_url}');
+         module.constant('authUrl', '${request.route_url('auth')}');
          module.constant('cultures', ['${"','".join(default_cultures) |n}']);
          <%block name="moduleConstantsValues">
          module.value('mapFeatureCollection', null);

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -66,11 +66,9 @@ ${obj[key] if obj and key in obj and obj[key] is not None else ''}\
 
 <%def name="show_missing_cultures_links(module, document, missing_cultures)">\
 % if missing_cultures:
-  <p translate>Translate into an other culture:</p>
-  <ul>
+  <p><span translate>Translate into an other culture:</span>
   % for l in missing_cultures:
-    <li><a href="${request.route_url(module + '_edit', id=document['document_id'], culture=l)}">{{mainCtrl.translate('${l}')}}</a></li>
+    <app-edit-button app-edit-button-url="${request.route_url(module + '_edit', id=document['document_id'], culture=l)}">{{mainCtrl.translate('${l}')}}</app-edit-button>
   % endfor
-  </ul>
 % endif
 </%def>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -8,10 +8,10 @@
 </div>
 <section id="routes_section">
   <div class="add_route text-center">
-  <button class="btn btn-success">
-    <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
-    <a href="${request.route_url('routes_add')}" translate>Add a route</a>
-  </button>
+    <app-edit-button app-edit-button-url="${request.route_url('routes_add')}">
+      <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+      <span translate>Add a route</span>
+    </app-edit-button>
     ${add_pagination_links('routes', routes, total, filter_params)}
   </div>
   <div id="routes">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -27,8 +27,8 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
 % endif
 <ul>
   <li><a href="${request.route_url('routes_history', id=route_id, culture=culture)}" translate>History</a></li>
-  <li><a href="${request.route_url('routes_edit', id=route_id, culture=culture)}" translate>Edit</a></li>
 </ul>
+<app-edit-button app-edit-button-url="${request.route_url('routes_edit', id=route_id, culture=culture)}"><translate>Edit</translate></app-edit-button>
 <ul>
   <li><span translate>height_diff_up</span> : ${route['height_diff_up']} m</li>
   <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -41,9 +41,10 @@ module.value('mapFeatureCollection', {
 <div class="text-center"><h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}}) </h3></div class="text-center">
 <section id="waypoints_section">
   <div class="add_waypoint text-center">
-    <button class='btn btn-success'> <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
-      <a href="${request.route_url('waypoints_add')}" translate>Add a waypoint</a>
-    </button>
+    <app-edit-button app-edit-button-url="${request.route_url('waypoints_add')}">
+      <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+      <span translate>Add a waypoint</span>
+    </app-edit-button>
     ${add_pagination_links('waypoints', waypoints, total, filter_params)}
   </div>
   <div id="waypoints">

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -50,8 +50,8 @@ module.value('mapFeatureCollection', {
 % endif
 <ul>
   <li><a href="${request.route_url('waypoints_history', id=waypoint_id, culture=culture)}" translate>History</a></li>
-  <li><a href="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}" translate>Edit</a></li>
 </ul>
+<app-edit-button app-edit-button-url="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}"><translate>Edit</translate></app-edit-button>
 <ul>
   <li><span translate>elevation</span> : ${waypoint['elevation']} m</li>
   <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>


### PR DESCRIPTION
Fixes #103 

* [x] Redirect unauthenticated users to auth page before giving them access to the editing pages
 * [x] View page > edit current doc
 * [x] View page > translate current doc (x ? other cultures)
 * [x] List page > add a new doc
* [x] When loading the editing page (form) => check if user is auth. If yes => nothing to do. If no:
 * [x] disable the AJAX request feeding the form
 * [x] redirect to auth page
 * [x] show alert message when user tries to save editing form while no longer authenticated
* [ ] Editing page: what if user logs out while on the editing page => form should become inactive?!