### PR TITLE
Parse documents base markup syntaxes

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -71,9 +71,45 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -121,10 +157,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -147,7 +179,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -206,6 +238,12 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
 msgstr ""
 
 #: c2corg_ui/static/partials/search.html
@@ -440,6 +478,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -564,6 +606,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -73,8 +73,44 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -121,10 +157,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -146,7 +178,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -203,6 +235,12 @@ msgstr "Itineraris"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
 msgstr ""
 
 #: c2corg_ui/static/partials/search.html
@@ -428,6 +466,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -548,6 +590,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -74,8 +74,44 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -122,10 +158,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -147,7 +179,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -205,6 +237,12 @@ msgstr "Routen"
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
 msgstr "Speichern"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
+msgstr ""
 
 #: c2corg_ui/static/partials/search.html
 msgid "Search ..."
@@ -429,6 +467,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -549,6 +591,10 @@ msgstr "Titel"
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -74,9 +74,45 @@ msgstr "Describe here the gear needed for this route"
 msgid "Describe here the waypoint"
 msgstr "Describe here the waypoint"
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Edit"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Editing a route"
@@ -122,10 +158,6 @@ msgstr "Latitude"
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -147,7 +179,7 @@ msgid "Longitude"
 msgstr "Longitude"
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -205,6 +237,12 @@ msgstr "Routes"
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
 msgstr "Save"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
+msgstr ""
 
 #: c2corg_ui/static/partials/search.html
 msgid "Search ..."
@@ -429,6 +467,10 @@ msgid "ice_climbing"
 msgstr "ice climbing"
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr "italian"
 
@@ -550,6 +592,10 @@ msgstr "Title"
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr "traverse"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -74,8 +74,44 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -122,10 +158,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -147,7 +179,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -204,6 +236,12 @@ msgstr "Itinerarios"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
 msgstr ""
 
 #: c2corg_ui/static/partials/search.html
@@ -429,6 +467,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -549,6 +591,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -73,8 +73,44 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -121,10 +157,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -146,7 +178,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -203,6 +235,12 @@ msgstr "Ibilbideak"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
 msgstr ""
 
 #: c2corg_ui/static/partials/search.html
@@ -428,6 +466,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -548,6 +590,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -71,9 +71,45 @@ msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
 msgid "Describe here the waypoint"
 msgstr "Décrivez ici l'itinéraire"
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr "Le document a été verrouillé."
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr "Le document a été déverrouillé."
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Modifier"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr "Edition en catalan"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr "Edition en allemand"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr "Edition en anglais"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr "Edition en espagnol"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr "Edition en basque"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr "Edition en français"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
+msgstr "Edition en italien"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Editing a route"
@@ -119,10 +155,6 @@ msgstr "Latitude"
 msgid "Legend:"
 msgstr "Légende :"
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr "Liste des versions pour la langue :"
@@ -144,7 +176,7 @@ msgid "Longitude"
 msgstr "Longitude"
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -317,7 +349,7 @@ msgstr "bivouac"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "by"
-msgstr ""
+msgstr "par"
 
 #: c2corg_ui/templates/i18n.html
 msgid "ca"
@@ -408,7 +440,7 @@ msgstr "glacier"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "green"
-msgstr ""
+msgstr "vert"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -426,6 +458,10 @@ msgstr "refuge/cabane"
 #: c2corg_ui/templates/i18n.html
 msgid "ice_climbing"
 msgstr "cascade de glace"
+
+#: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr "Importé du site v4"
 
 #: c2corg_ui/templates/i18n.html
 msgid "it"
@@ -470,7 +506,7 @@ msgstr "VTT"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "next difference"
-msgstr "différence suivante →"
+msgstr "différence suivante"
 
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding"
@@ -549,6 +585,10 @@ msgstr "Titre"
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
 msgstr "traversée"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
+msgstr "type"
 
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -74,8 +74,44 @@ msgstr ""
 msgid "Describe here the waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been deprotected"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been protected"
+msgstr ""
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in ca"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in en"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in es"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in eu"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in fr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Edit in it"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -122,10 +158,6 @@ msgstr ""
 msgid "Legend:"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/filters.html
-msgid "Less Filters"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
 msgstr ""
@@ -147,7 +179,7 @@ msgid "Longitude"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "More Filters"
+msgid "More filters"
 msgstr ""
 
 #: c2corg_ui/static/partials/user.html
@@ -204,6 +236,12 @@ msgstr "Itinerari"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Save"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid ""
+"Search \n"
+"        <span class=\"glyphicon glyphicon-search\"></span>"
 msgstr ""
 
 #: c2corg_ui/static/partials/search.html
@@ -429,6 +467,10 @@ msgid "ice_climbing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "imported from v4"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "it"
 msgstr ""
 
@@ -549,6 +591,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/templates/document/diff.html
+++ b/c2corg_ui/templates/document/diff.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr"/>
+<%namespace file="../helpers.html" import="show_version_comment"/>
 <%block name="pagelang">lang="${culture}"</%block>
 <%block name="pagetitle">${title}</%block>
 
@@ -13,7 +13,7 @@
             version=version1['version_id'])}"><span translate>Revision as of</span> {{'${1000 * version1['written_at']}' | date:'medium'}}</a><br/>
       <span translate>by</span> <a href="#TODO profile for ${version1['user_id']}">${version1['username']}</a>
       % if version1['comment']:
-        <br/><span class="revision-comment">(${version1['comment']})</span>
+        <br/><span class="revision-comment">(${show_version_comment(version1)})</span>
       % endif
       % if previous_version_id:
         <br/><a href="${request.route_url(
@@ -27,7 +27,7 @@
             version=version2['version_id'])}"><span translate>Revision as of</span> {{'${1000 * version2['written_at']}' | date:'medium'}}</a><br/>
       <span translate>by</span> <a href="#TODO profile for ${version2['user_id']}">${version2['username']}</a>
       % if version2['comment']:
-        <br/><span class="revision-comment">(${version2['comment']})</span>
+        <br/><span class="revision-comment">(${show_version_comment(version2)})</span>
       % endif
       % if next_version_id:
         <br/><a href="${request.route_url(
@@ -39,7 +39,7 @@
 </table>
 
 % if not diffs:
-  <p class="bg-info">No content changes.</p>
+  <p class="bg-info" translate>No content changes.</p>
 % else:
   % for field_diff in diffs:
     <h3>{{mainCtrl.translate('${field_diff.field}')}}</h3>
@@ -60,7 +60,7 @@
     </%block>\
     <app-diff-map></app-diff-map>
     <p class="diff-map-legend">
-      <span translate>Legend:</span> <span translate>Version 1 in </span> <span class="diff-red" translate="">red</span>,
+      <span translate>Legend:</span> <span translate>Version 1 in </span> <span class="diff-red" translate>red</span>,
       <span translate>Version 2 in</span> <span class="diff-green" translate>green</span>
     </p>
     % else:

--- a/c2corg_ui/templates/document/history.html
+++ b/c2corg_ui/templates/document/history.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr"/>
+<%namespace file="../helpers.html" import="show_version_comment"/>
 <%block name="pagelang">lang="${culture}"</%block>\
 <%block name="pagetitle">${title}</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
@@ -49,7 +49,7 @@
         %>
         <td><a href="${version_url}">{{'${1000 * v['written_at']}' | date:'medium'}}</a></td>
         <td><a href="#TODO profile for ${v['user_id']}">${v['username']}</a></td>
-        <td>${v['comment']}</td>
+        <td>${show_version_comment(v)}</td>
       </tr>
     % endfor
   </table>

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -1,15 +1,13 @@
 <%!
-from c2corg_ui.templates.utils.format import parse_code, sanitize
+from c2corg_ui.templates.utils import get_attr
 %>
 
-<%def name="get_attr(obj, key, parse=False)">\
+<%def name="show_attr(obj, key, parse=True)">\
 <%
-    str = obj[key] if obj and key in obj and obj[key] is not None else ''
-    if str:
-        str = sanitize(str)
-        str = parse_code(str) if parse else str
+    attr = get_attr(obj, key, md=parse, bb=parse)
+    attr = attr if attr else ''
 %>
-${str | n}\
+${attr | n}\
 </%def>
 
 <%def name="add_pagination_links(module, documents, total, params)">\
@@ -49,7 +47,7 @@ ${str | n}\
         last['offset'] = total - last['limit']
         filters_str = '/' + '/'.join(['%s/%s' % (key, last[key]) for key in last])
     %>
-    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}" ><span translate>Last</span><span class="glyphicon glyphicon-step-forward"></span></a></li>
+    <li><a class="btn btn-primary" href="${request.route_url(module + '_index', filters=filters_str)}"><span translate>Last</span><span class="glyphicon glyphicon-step-forward"></span></a></li>
   % endif
   </ul>
 % endif
@@ -58,7 +56,7 @@ ${str | n}\
 <%def name="show_archive_data(module, document, locale, version)">\
   <ul class="archive-data">
     <li translate>You are viewing an archived version of this document.</li>
-    <li>{{'${1000 * version['written_at']}' | date:'medium'}} - <a href="#TODO">${version['username']}</a> - ${version['comment']}</li>
+    <li>{{'${1000 * version['written_at']}' | date:'medium'}} - <a href="#TODO">${version['username']}</a> - ${show_version_comment(version)}</li>
     <li><a href="${request.route_url(module + '_view', id=document['document_id'], culture=locale['culture'])}" translate>See the latest version</a></li>
   </ul>
 </%def>
@@ -90,5 +88,9 @@ ${str | n}\
         title = locale['title_prefix'] + ' : '
     title += locale['title']
 %>
-${sanitize(title)}
+${title}
+</%def>
+
+<%def name="show_version_comment(version)">\
+${'{{mainCtrl.translate(\'' + get_attr(version, 'comment', md=False) + '\')}}' if version['comment'] else '' | n}
 </%def>

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -1,12 +1,13 @@
 <%!
-from c2corg_ui.templates.utils.format import parse_code
+from c2corg_ui.templates.utils.format import parse_code, sanitize
 %>
 
 <%def name="get_attr(obj, key, parse=False)">\
 <%
     str = obj[key] if obj and key in obj and obj[key] is not None else ''
-    if str and parse:
-        str = parse_code(str)
+    if str:
+        str = sanitize(str)
+        str = parse_code(str) if parse else str
 %>
 ${str | n}\
 </%def>
@@ -89,5 +90,5 @@ ${str | n}\
         title = locale['title_prefix'] + ' : '
     title += locale['title']
 %>
-${title}
+${sanitize(title)}
 </%def>

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -1,5 +1,14 @@
-<%def name="get_attr(obj, key)">\
-${obj[key] if obj and key in obj and obj[key] is not None else ''}\
+<%!
+from c2corg_ui.templates.utils.format import parse_code
+%>
+
+<%def name="get_attr(obj, key, parse=False)">\
+<%
+    str = obj[key] if obj and key in obj and obj[key] is not None else ''
+    if str and parse:
+        str = parse_code(str)
+%>
+${str | n}\
 </%def>
 
 <%def name="add_pagination_links(module, documents, total, params)">\

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -72,3 +72,15 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <span translate>Invalid email address</span>
 <span translate>already used username</span>
 <span translate>Register success</span>
+
+<!-- history and diff -->
+<span translate>imported from v4</span>
+<span translate>Document has been protected</span>
+<span translate>Document has been deprotected</span>
+<span translate>Edit in fr</span>
+<span translate>Edit in de</span>
+<span translate>Edit in it</span>
+<span translate>Edit in en</span>
+<span translate>Edit in es</span>
+<span translate>Edit in eu</span>
+<span translate>Edit in ca</span>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr, add_pagination_links, show_route_title"/>
+<%namespace file="../helpers.html" import="show_attr, add_pagination_links, show_route_title"/>
 <%block name="pagetitle">{{'Routes' | translate}}</%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
@@ -29,7 +29,7 @@
           % if route['elevation_max'] is not None:
             <span class="list-item-elevation">Elevation: ${route['elevation_max']} m</span>
           % endif
-            <p class="text-justify">${locale['summary']}</p>
+            <p class="text-justify">${show_attr(locale, 'summary')}</p>
           </div>
         </a>
       </div>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -2,7 +2,7 @@
 from c2corg_ui.templates.utils import get_culture_lists
 %>\
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links, show_route_title"/>
+<%namespace file="../helpers.html" import="show_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links, show_route_title"/>
 <%
 route_id = route['document_id']
 other_cultures, missing_cultures = get_culture_lists(route, culture)
@@ -31,8 +31,8 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
 <app-edit-button app-edit-button-url="${request.route_url('routes_edit', id=route_id, culture=culture)}"><translate>Edit</translate></app-edit-button>
 <ul>
   <li><span translate>height_diff_up</span> : ${route['height_diff_up']} m</li>
-  <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
-  <li><span translate>description</span> : ${get_attr(locale, 'description', True)}</li>
-  <li><span translate>gear</span> : ${get_attr(locale, 'gear')}</li>
+  <li><span translate>summary</span> : ${show_attr(locale, 'summary')}</li>
+  <li><span translate>description</span> : ${show_attr(locale, 'description')}</li>
+  <li><span translate>gear</span> : ${show_attr(locale, 'gear')}</li>
 </ul>
 <app-map></app-map>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -32,7 +32,7 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
 <ul>
   <li><span translate>height_diff_up</span> : ${route['height_diff_up']} m</li>
   <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
-  <li><span translate>description</span> : ${get_attr(locale, 'description')}</li>
+  <li><span translate>description</span> : ${get_attr(locale, 'description', True)}</li>
   <li><span translate>gear</span> : ${get_attr(locale, 'gear')}</li>
 </ul>
 <app-map></app-map>

--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -1,4 +1,5 @@
 from c2corg_common.attributes import default_cultures
+from c2corg_ui.templates.utils.format import parse_code, sanitize
 
 
 def get_culture_lists(document, culture):
@@ -13,3 +14,15 @@ def get_culture_lists(document, culture):
         missing_cultures = list(set(default_cultures) - set(culture))
     missing_cultures.reverse()
     return other_cultures, missing_cultures
+
+
+def get_attr(obj, key, md=True, bb=True):
+    """Get attribute from passed object if exists.
+    md and bb are optional params that may be used to finetune
+    the text formating.
+    """
+    attr = obj[key] if key in obj else None
+    if attr and isinstance(attr, str):
+        attr = sanitize(attr)
+        attr = parse_code(attr, md, bb) if md or bb else attr
+    return attr

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -7,7 +7,10 @@ def sanitize(text):
     return html.escape(text)
 
 
-def parse_code(text):
-    text = markdown.markdown(text)
-    bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
-    return bbcode_parser.format(text)
+def parse_code(text, md=True, bb=True):
+    if md:
+        text = markdown.markdown(text, output_format='xhtml5')
+    if bb:
+        bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+        text = bbcode_parser.format(text)
+    return text

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -1,0 +1,5 @@
+from bbcode import render_html
+
+
+def parse_code(text):
+    return render_html(text)

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -1,5 +1,9 @@
-from bbcode import render_html
+import bbcode
+import markdown
 
 
 def parse_code(text):
-    return render_html(text)
+    text = markdown.markdown(text)
+    bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+    text = bbcode_parser.format(text)
+    return text

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -1,9 +1,13 @@
 import bbcode
 import markdown
+import html
+
+
+def sanitize(text):
+    return html.escape(text)
 
 
 def parse_code(text):
     text = markdown.markdown(text)
     bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
-    text = bbcode_parser.format(text)
-    return text
+    return bbcode_parser.format(text)

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr, add_pagination_links"/>
+<%namespace file="../helpers.html" import="show_attr, add_pagination_links"/>
 <%block name="pagetitle">{{'Waypoints' | translate}}</%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
@@ -37,7 +37,7 @@ module.value('mapFeatureCollection', {
 });
 % endif
 </%block>\
-<div class="text-center"><h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}}) </h3></div class="text-center">
+<div class="text-center"><h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}})</h3></div class="text-center">
 <%include file="filters.html" />
 <section id="waypoints-section">
   <div class="add-waypoint text-center">
@@ -53,7 +53,7 @@ module.value('mapFeatureCollection', {
       <% locale = waypoint['locales'][0] %>\
       <div class="list-item">
         <a href="${request.route_url('waypoints_view', id=waypoint['document_id'], culture=locale['culture'])}">
-          <span class="list-item-title ">${locale['title']}</span>
+          <span class="list-item-title ">${show_attr(locale, 'title', False)}</span>
           % if lang != locale['culture']:
           <span class="list-item-culture">(${locale['culture']})</span>
           <br>
@@ -63,9 +63,9 @@ module.value('mapFeatureCollection', {
             <span class="list-item-elevation">Elevation: ${waypoint['elevation']} m</span>
           % endif
             <span>
-              <p><img alt="waypoint type" src="${request.static_url('c2corg_ui:static/img/icons/' + waypoint['waypoint_type'] + '.png')}"> {{mainCtrl.translate('${waypoint['waypoint_type']}')}}</p>
+              <p><img alt="waypoint type" src="${request.static_url('c2corg_ui:static/img/icons/' + waypoint['waypoint_type'] + '.png')}">{{mainCtrl.translate('${waypoint['waypoint_type']}')}}</p>
             </span>
-            <p class="text-justify">${locale['summary']}</p>
+            <p class="text-justify">${show_attr(locale, 'summary')}</p>
           </div>
         </a>
       </div>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -2,7 +2,7 @@
 from c2corg_ui.templates.utils import get_culture_lists
 %>\
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="get_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links"/>
+<%namespace file="../helpers.html" import="show_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links"/>
 <%
 waypoint_id = waypoint['document_id']
 other_cultures, missing_cultures = get_culture_lists(waypoint, culture)
@@ -12,7 +12,7 @@ other_cultures, missing_cultures = get_culture_lists(waypoint, culture)
 geometry4326 = geometry
 %>\
 <%block name="pagelang">lang="${culture}"</%block>\
-<%block name="pagetitle">${locale['title']}</%block>\
+<%block name="pagetitle">${show_attr(locale, 'title', False)}</%block>\
 <%block name="metarobots">\
   % if version:
 <meta name="robots" content="noindex,follow">\
@@ -55,8 +55,8 @@ module.value('mapFeatureCollection', {
 <ul>
   <li><span translate>elevation</span> : ${waypoint['elevation']} m</li>
   <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>
-  <li><span translate>maps_info</span> : ${get_attr(waypoint, 'maps_info')}</li>
-  <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
-  <li><span translate>description</span> : ${get_attr(locale, 'description', True)}</li>
+  <li><span translate>maps_info</span> : ${show_attr(waypoint, 'maps_info', False)}</li>
+  <li><span translate>summary</span> : ${show_attr(locale, 'summary')}</li>
+  <li><span translate>description</span> : ${show_attr(locale, 'description')}</li>
 </ul>
 <app-map></app-map>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -57,6 +57,6 @@ module.value('mapFeatureCollection', {
   <li><span translate>Coordinates</span> : ${geometry4326.x} °E / ${geometry4326.y} °N</li>
   <li><span translate>maps_info</span> : ${get_attr(waypoint, 'maps_info')}</li>
   <li><span translate>summary</span> : ${get_attr(locale, 'summary')}</li>
-  <li><span translate>description</span> : ${get_attr(locale, 'description')}</li>
+  <li><span translate>description</span> : ${get_attr(locale, 'description', True)}</li>
 </ul>
 <app-map></app-map>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Shapely==1.5.13
 pyproj==1.9.4
 htmlmin==0.1.10
 bbcode==1.0.21
+Markdown==2.6.5
 
 # c2corg_common project
 # for development use a local checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ httplib2==0.9.2
 Shapely==1.5.13
 pyproj==1.9.4
 htmlmin==0.1.10
+bbcode==1.0.21
 
 # c2corg_common project
 # for development use a local checkout


### PR DESCRIPTION
Fixes #121 

Support the various markups (including custom ones)
* [x] BBcode
* [x] Markdown
* [x] Prevent user submitted HTML/JS from being interpreted