### PR TITLE
Advanced search pages: filter components

### DIFF
--- a/build.json
+++ b/build.json
@@ -10,6 +10,7 @@
     "closure_entry_point": "app.main",
     "externs": [
       "c2corg_ui/externs/appx.js",
+      "c2corg_ui/externs/bootstrap-slider.js",
       "node_modules/openlayers/externs/bingmaps.js",
       "node_modules/openlayers/externs/closure-compiler.js",
       "node_modules/openlayers/externs/esrijson.js",

--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -64,3 +64,13 @@ appx.SearchDocumentLocale;
  * }}
  */
 appx.AlertMessage;
+
+
+/**
+ * @typedef {{
+ *  min: number,
+ *  max: number,
+ *  value: Array.<number>
+ * }}
+ */
+appx.BootstrapSliderValues;

--- a/c2corg_ui/externs/bootstrap-slider.js
+++ b/c2corg_ui/externs/bootstrap-slider.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Externs for bootstrap-slider
+ *
+ * @externs
+ */
+
+
+/**
+ * @constructor
+ */
+function Slider(arg1, arg2) {};
+
+
+/**
+ * @param {appx.BootstrapSliderValues} arg
+ * @return {!jQuery}
+ */
+$.prototype.slider = function(arg) {};
+

--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -12,6 +12,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -59,10 +63,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -84,14 +84,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -104,8 +96,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html
@@ -125,16 +117,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -158,16 +146,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -176,6 +172,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -216,6 +216,10 @@ msgstr ""
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
@@ -229,7 +233,24 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -265,6 +286,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -274,6 +299,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -331,6 +357,8 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -347,6 +375,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -394,6 +423,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -523,6 +553,7 @@ msgid "summary"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -61,10 +65,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -85,14 +85,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -105,8 +97,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
@@ -125,16 +117,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -157,16 +145,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -175,6 +171,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -213,6 +213,10 @@ msgstr "Cerca ..."
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr ""
@@ -223,7 +227,23 @@ msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -258,6 +278,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Benvingut/da a Camptocamp.org!"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -267,6 +291,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -323,6 +348,8 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -338,6 +365,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -383,6 +411,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -509,7 +538,7 @@ msgstr ""
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -62,10 +66,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -86,14 +86,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -106,8 +98,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
@@ -126,16 +118,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -158,16 +146,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -176,6 +172,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -214,6 +214,10 @@ msgstr "Suchen ..."
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr ""
@@ -224,7 +228,23 @@ msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -259,6 +279,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Willkommen bei Camptocamp.org"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -268,6 +292,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -324,6 +349,8 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -339,6 +366,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -384,6 +412,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -510,7 +539,7 @@ msgstr ""
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -17,10 +17,13 @@ msgstr "Add a route"
 msgid "Add a waypoint"
 msgstr "Add a waypoint"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
-#, fuzzy
 msgid "Authentication"
-msgstr "weather_station"
+msgstr "Authentication"
 
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
@@ -63,10 +66,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr "Culture"
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr "Describe here the gear needed for this route"
@@ -87,15 +86,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-#, fuzzy
-msgid "Elevation must be a number."
-msgstr "Elevation must be smaller than 9999 m."
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr "Elevation must be smaller than 9999 m."
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -108,10 +98,9 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr "Forgotten password?"
 
-#: c2corg_ui/templates/route/edit.html
-#, fuzzy
-msgid "Height difference up must be a number."
-msgstr "Latitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
+msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
@@ -129,18 +118,12 @@ msgstr ""
 msgid "Latitude"
 msgstr "Latitude"
 
-#: c2corg_ui/templates/waypoint/edit.html
-#, fuzzy
-msgid "Latitude  must be a number."
-msgstr "Latitude must be a number."
-
-#: c2corg_ui/templates/waypoint/edit.html
-#, fuzzy
-msgid "Latitude must be between -90° and 90°."
-msgstr "Latitude must be between -90° and 90°."
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -163,19 +146,25 @@ msgstr "Sign out"
 msgid "Longitude"
 msgstr "Longitude"
 
-#: c2corg_ui/templates/waypoint/edit.html
-#, fuzzy
-msgid "Longitude must be a number."
-msgstr "Latitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
+msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-#, fuzzy
-msgid "Longitude must be between -180° and 180°."
-msgstr "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr "My account"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
+msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
 msgstr "Next"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
+msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "No account yet?"
@@ -184,6 +173,10 @@ msgstr "No account yet?"
 #: c2corg_ui/templates/auth.html
 msgid "Password"
 msgstr "Password"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
+msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Previous"
@@ -221,6 +214,10 @@ msgstr ""
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr "Short description of the applied changes"
@@ -231,7 +228,23 @@ msgid "This field is required."
 msgstr "This field is required."
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr "This field must be a number."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -266,6 +279,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Welcome to Camptocamp.org"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr "Yes"
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -275,6 +292,7 @@ msgid "access"
 msgstr "Access"
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr "Activities"
 
@@ -331,6 +349,8 @@ msgid "confluence"
 msgstr "confluence"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr "Culture"
@@ -346,6 +366,7 @@ msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr "Elevation"
@@ -391,6 +412,7 @@ msgid "green"
 msgstr "green"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr "Height difference up"
 
@@ -517,7 +539,7 @@ msgstr "snowshoeing"
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr "summit"
 
@@ -547,16 +569,12 @@ msgstr "waterpoint"
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "waypoint_type"
-msgstr "Type"
+msgstr "waypoint type"
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
-msgstr "weather_station"
+msgstr "weather station"
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
-
-#, fuzzy
-#~ msgid "This field must be smaller than 9999 m."
-#~ msgstr "Elevation must be smaller than 9999 m."

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -62,10 +66,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -86,14 +86,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -106,8 +98,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
@@ -126,16 +118,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -158,16 +146,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -176,6 +172,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -214,6 +214,10 @@ msgstr "Búsqueda ..."
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr ""
@@ -224,7 +228,23 @@ msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -259,6 +279,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "¡Bienvenido/a a Camptocamp.org!"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -268,6 +292,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -324,6 +349,8 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -339,6 +366,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -384,6 +412,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -510,7 +539,7 @@ msgstr ""
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -61,10 +65,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -85,14 +85,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -105,8 +97,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
@@ -125,16 +117,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -157,16 +145,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -175,6 +171,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -213,6 +213,10 @@ msgstr "Bilatu ..."
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr ""
@@ -223,7 +227,23 @@ msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -258,6 +278,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Ongi etorri Camptocamp.org-era!"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -267,6 +291,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -323,6 +348,8 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -338,6 +365,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -383,6 +411,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -509,7 +538,7 @@ msgstr ""
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -14,6 +14,10 @@ msgstr "Ajouter un itinéraire"
 msgid "Add a waypoint"
 msgstr "Ajouter un point de passage"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr "Autour de"
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr "Connexion"
@@ -59,10 +63,6 @@ msgstr "Création d'un itinéraire"
 msgid "Creating a waypoint"
 msgstr "Création d'un point de passage"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr "Langue"
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr "Indiquez ici le matériel nécessaire pour cet itinéraire."
@@ -95,6 +95,10 @@ msgstr "Début"
 msgid "Forgotten password?"
 msgstr "Mot de passe oublié ?"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
+msgstr "Géoréferencé"
+
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr "Versions"
@@ -114,6 +118,10 @@ msgstr "Latitude"
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
 msgstr "Légende :"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
+msgstr ""
 
 #: c2corg_ui/templates/document/history.html
 msgid "List of versions for language:"
@@ -135,9 +143,25 @@ msgstr "Se déconnecter"
 msgid "Longitude"
 msgstr "Longitude"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
+msgstr ""
+
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr "Mon compte"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
+msgstr "Ma position"
+
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
 msgstr "Suivant"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
+msgstr "Non"
 
 #: c2corg_ui/templates/auth.html
 msgid "No account yet?"
@@ -146,6 +170,10 @@ msgstr "Pas encore de compte ?"
 #: c2corg_ui/templates/auth.html
 msgid "Password"
 msgstr "Mot de passe"
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
+msgstr "Endroit"
 
 #: c2corg_ui/templates/helpers.html
 msgid "Previous"
@@ -185,6 +213,10 @@ msgstr "Rechercher ..."
 msgid "See the latest version"
 msgstr "Voir la dernière version"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr "Sélectionner"
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr "Courte description des changements appliqués"
@@ -195,8 +227,24 @@ msgid "This field is required."
 msgstr "Ce champ est obligatoire."
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
-msgstr ""
+msgid "This field must be a number."
+msgstr "Ce champ doit être un nombre."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr "Ce champ doit être compris entre -180° et 180°."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr "Ce champ doit être compris entre -90° and 90°.."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr "Ce champ doit être inférieur à 9999m."
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
+msgstr "Le titre doit comporter au moins 3 caractères."
 
 #: c2corg_ui/templates/helpers.html
 msgid "Translate into an other culture:"
@@ -230,6 +278,10 @@ msgstr "Bienvenue"
 msgid "Welcome to Camptocamp.org"
 msgstr "Bienvenue sur Camptocamp.org"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr "Oui"
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr "Vous consultez une ancienne version de ce document."
@@ -239,6 +291,7 @@ msgid "access"
 msgstr "accès"
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr "Activités"
 
@@ -295,6 +348,8 @@ msgid "confluence"
 msgstr "confluent"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr "Langue"
@@ -310,6 +365,7 @@ msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr "Altitude"
@@ -355,6 +411,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr "Dénivelé"
 
@@ -481,7 +538,7 @@ msgstr "raquette"
 msgid "summary"
 msgstr "Résumé"
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr "sommet"
 
@@ -520,12 +577,3 @@ msgstr "station météo"
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
-
-msgid "This field must be a number."
-msgstr "Ce champ doit être un nombre."
-
-msgid "This field must be smaller than 9999 m."
-msgstr "Ce champ doit être inférieur à 9999m."
-
-msgid "Title must have at least 3 characters."
-msgstr "Le titre doit comporter au moins 3 caractères."

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Add a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Around"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html
 msgid "Authentication"
 msgstr ""
@@ -62,10 +66,6 @@ msgstr ""
 msgid "Creating a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Culture"
-msgstr ""
-
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
 msgstr ""
@@ -86,14 +86,6 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Elevation must be smaller than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -106,8 +98,8 @@ msgstr ""
 msgid "Forgotten password?"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
-msgid "Height difference up must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Georeferenced"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
@@ -126,16 +118,12 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude  must be a number."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Latitude must be between -90° and 90°."
-msgstr ""
-
 #: c2corg_ui/templates/document/diff.html
 msgid "Legend:"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Less Filters"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -158,16 +146,24 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be a number."
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "More Filters"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude must be between -180° and 180°."
+#: c2corg_ui/static/partials/user.html
+msgid "My account"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "My position"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
 msgid "Next"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "No"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -176,6 +172,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Place"
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -214,6 +214,10 @@ msgstr "Cerca ..."
 msgid "See the latest version"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Select"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr ""
@@ -224,7 +228,23 @@ msgid "This field is required."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-msgid "Title is too short."
+msgid "This field must be a number."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -180° and 180°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be smaller than 9999 m."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+msgid "Title must have at least 3 characters."
 msgstr ""
 
 #: c2corg_ui/templates/helpers.html
@@ -259,6 +279,10 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Benvenuti a Camptocamp.org"
 
+#: c2corg_ui/templates/waypoint/filters.html
+msgid "Yes"
+msgstr ""
+
 #: c2corg_ui/templates/helpers.html
 msgid "You are viewing an archived version of this document."
 msgstr ""
@@ -268,6 +292,7 @@ msgid "access"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr ""
 
@@ -324,6 +349,8 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "culture"
 msgstr ""
@@ -339,6 +366,7 @@ msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
@@ -384,6 +412,7 @@ msgid "green"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/filters.html
 msgid "height_diff_up"
 msgstr ""
 
@@ -510,7 +539,7 @@ msgstr ""
 msgid "summary"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/filters.html
 msgid "summit"
 msgstr ""
 

--- a/c2corg_ui/static/js/filters.js
+++ b/c2corg_ui/static/js/filters.js
@@ -16,3 +16,16 @@ app.trustAsHtmlFilter = function($sce) {
 };
 
 app.module.filter('appTrustAsHtml', app.trustAsHtmlFilter);
+
+
+/**
+ * @export
+ * @return {function(string):string}
+ */
+app.capitalize = function() {
+  return function(token) {
+    return token.charAt(0).toUpperCase() + token.slice(1);
+  }
+}
+
+app.module.filter('capitalize', app.capitalize);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -15,5 +15,6 @@ goog.require('app.editButtonDirective');
 goog.require('app.langDirective');
 goog.require('app.mapDirective');
 goog.require('app.searchDirective');
+goog.require('app.searchFiltersDirective');
 goog.require('app.userDirective');
 goog.require('app.versionsDirective');

--- a/c2corg_ui/static/js/searchfilters.js
+++ b/c2corg_ui/static/js/searchfilters.js
@@ -1,0 +1,162 @@
+goog.provide('app.searchFiltersDirective');
+goog.provide('app.SearchFiltersController');
+
+goog.require('app');
+
+
+/**
+ * Provides the 'searchFiltersDirective' directive, which is used to enrich
+ * filtering components in the documents listing pages.
+ * 
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.searchFiltersDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'appSearchFiltersController',
+    bindToController: true,
+    scope: true,
+    controllerAs: 'searchFiltersCtrl',
+    link: function(scope, element, attrs, ctrl) {
+      // Init sliders
+      $('.range-between').slider({min: 0, max: 9999, value: [0, 9999]});
+      
+      var elevationFilter = $('#elevation-filter');
+      var heightFilter = $('#height-filter');
+
+      // Update elevation slider values
+      elevationFilter.on('slide', function(slideEvt) {
+        ctrl.elevation.min = slideEvt.value[0];
+        ctrl.elevation.max = slideEvt.value[1];
+        scope.$apply();
+      });
+
+      // Update height diff slider values
+      heightFilter.on('slide', function(slideEvt) {
+        ctrl.height_diff_up.min = slideEvt.value[0];
+        ctrl.height_diff_up.max = slideEvt.value[1];
+        scope.$apply();
+      });
+    }
+  }
+};
+
+
+app.module.directive('appSearchFilters', app.searchFiltersDirective);
+
+
+/**
+ * @param {angular.Scope} $scope Scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.Attributes} $attrs Attributes.
+ * @constructor
+ * @ngInject
+ * @export
+ */
+app.SearchFiltersController = function($scope, $element, $attrs) {
+
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  // FIXME: not generic to all document types
+  // Init filters object
+  /**
+   * @type {Array<string>}
+   * @export
+   */
+  this.activities = [];
+
+
+  /**
+   * @type {Array<string>}
+   * @export
+   */
+  this.waypoint_types = [];
+  
+ 
+  /**
+   * @type {string}
+   * @export
+   */
+  this.culture;
+
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.around;
+
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.height_diff_up = {min: 0, max: 9999};
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.elevation = {min : 0, max: 9999};
+};
+ 
+
+/**
+ * @param {string} option name
+ * @param {string} optionCategory category
+ * @param {jQuery.Event | goog.events.Event} e click
+ * @export
+ */
+app.SearchFiltersController.prototype.selectOption = function(option,
+    optionCategory, e) {
+
+  // Don't close the menu after selecting an option
+  e.stopPropagation();
+
+  // Shorthand
+  var optionCat = this[optionCategory];
+  var target = $(e.currentTarget);
+  var checkbox = target.find('input');
+  
+  // If this property doesn't exit in the scope, create an array and
+  // push the selected option.
+  if (!optionCat) {
+    optionCat = this[optionCategory] = [];
+  }
+  this.updateFilterArray_(optionCat, target, checkbox, option);
+};
+
+
+/**
+ * Push/remove the selected option into the scope property (scope_[optionCat])
+ * and check/uncheck the checkbox depending if the option is already
+ * in the array or not.
+ *
+ * @param {Array<string>} optionCat
+ * @param {jQuery} target
+ * @param {jQuery} checkbox
+ * @param {string} option
+ * @private
+ */
+app.SearchFiltersController.prototype.updateFilterArray_ = function(
+    optionCat, target, checkbox, option) {
+
+  if (optionCat.indexOf(option) === -1) {
+    optionCat.push(option);
+    checkbox.prop('checked', true);
+    target.addClass('option-selected');
+  } else {
+    optionCat.splice(optionCat.indexOf(option), 1);
+    checkbox.prop('checked', false);
+    target.removeClass('option-selected');
+  }
+};
+
+
+app.module.controller('appSearchFiltersController', app.SearchFiltersController);

--- a/c2corg_ui/static/partials/search.html
+++ b/c2corg_ui/static/partials/search.html
@@ -1,4 +1,4 @@
-  <span class="glyphicon glyphicon-search"></span>
+  <span class="glyphicon glyphicon-search" id="search-icon"></span>
   <input id="search" class="form-control" 
        type="search" placeholder="{{'Search ...'  | translate}}"
        ngeo-search="searchCtrl.options"

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -16,10 +16,12 @@ closure_library_path = settings.get('closure_library_path')
     <%block name="metarobots"><meta name="robots" content="index,follow"></%block>
 % if debug:
     <link rel="stylesheet" href="${request.static_url('%s/bootstrap/dist/css/bootstrap.css' % node_modules_path)}" type="text/css">
+    <link rel="stylesheet" href="${request.static_url('%s/bootstrap-slider/dist/css/bootstrap-slider.css' % node_modules_path)}" type="text/css">
     <link rel="stylesheet" href="${request.static_url('c2corg_ui:static/build/build.css')}" type="text/css">
 % else:
     ## FIXME add version to links?
     <link rel="stylesheet" href="${request.static_url('%s/bootstrap/dist/css/bootstrap.min.css' % node_modules_path)}" type="text/css">
+    <link rel="stylesheet" href="${request.static_url('%s/bootstrap-slider/dist/css/bootstrap-slider.css' % node_modules_path)}" type="text/css">
     <link rel="stylesheet" href="${request.static_url('c2corg_ui:static/build/build.min.css')}" type="text/css">
 % endif
   </head>
@@ -63,6 +65,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/jquery/dist/jquery.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular/angular.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/bootstrap/dist/js/bootstrap.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/bootstrap-slider/dist/bootstrap-slider.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-messages/angular-messages.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-cookies/angular-cookies.js' % node_modules_path)}"></script>
@@ -72,6 +75,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('c2corg_ui:static/js/main.js')}"></script>
 % else:
     <script src="${request.static_url('%s/jquery/dist/jquery.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/bootstrap-slider/dist/bootstrap-slider.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular/angular.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/bootstrap/dist/js/bootstrap.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.min.js' % node_modules_path)}"></script>

--- a/c2corg_ui/templates/waypoint/filters.html
+++ b/c2corg_ui/templates/waypoint/filters.html
@@ -1,0 +1,86 @@
+<%!
+from c2corg_common.attributes import default_cultures, waypoint_types, activities
+%>
+<form app-search-filters>
+  <div class="filters">
+    <div class="row">
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label translate>Around</label>
+        <select class="form-control" ng-model="searchFiltersCtrl.around"><option translate>My position</option><option translate>Place</option></select>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label>{{'summit' | translate | capitalize}}</label>
+        <input type="text" class="form-control">
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label translate>elevation</label><br>
+        <input type="range" id="elevation-filter" class="range-between" data-slider-tooltip="hide">
+        <span class="slider-min-max">
+          <p class="min-value">{{searchFiltersCtrl.elevation.min}} m</p>
+          <p>{{searchFiltersCtrl.elevation.max}} m</p>
+        </span>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label translate>height_diff_up</label><br>
+        <input type="range" class="range-between" id="height-filter" data-slider-tooltip="hide">
+        <span class="slider-min-max">
+          <p class="min-value">{{searchFiltersCtrl.height_diff_up.min}} m</p>
+          <p>{{searchFiltersCtrl.height_diff_up.max}} m</p>
+        </span>
+      </div>
+    </div>
+    <div class="row collapse" id="moreFilters">
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+          <label translate>activities</label><br>
+          <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+            <p><span translate>Select</span>
+              <span ng-if="searchFiltersCtrl.activities.length > 0"> ({{searchFiltersCtrl.activities.length}})</span>
+              <span class="caret"></span>
+            </p>
+          </button>
+         <ul class="dropdown-menu multiselect-box">
+           <li ng-repeat="activity in ['${"','".join(activities) |n}']">
+             <a data-value="{{activity}}" ng-click="searchFiltersCtrl.selectOption(activity, 'activities', $event)">
+               <input type="checkbox">
+               <span class="activity">{{mainCtrl.translate(activity) | capitalize}}</span>
+             </a>
+           </li>
+        </ul>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label>{{'type' | translate | capitalize }}</label><br>
+        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+            <p><span translate>Select</span>
+              <span ng-if="searchFiltersCtrl.waypoint_types.length > 0"> ({{searchFiltersCtrl.waypoint_types.length}})</span>
+              <span class="caret"></span>
+            </p>
+          </button>
+            <ul class="dropdown-menu multiselect-box type">
+              <li ng-repeat="type in ['${"','".join(waypoint_types) |n}']">
+                <a data-value="{{type}}" ng-click="searchFiltersCtrl.selectOption(type, 'waypoint_types', $event)">
+                  <input type="checkbox">
+                  <span class="activity">{{mainCtrl.translate(type) | capitalize}}</span>
+                </a>
+              </li>
+           </ul>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label translate>Georeferenced</label>
+        <select class="form-control" ng-model="searchFiltersCtrl.georef"><option translate>Yes</option><option translate>No</option></select>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3 filter">
+        <label translate>culture</label>
+        <select ng-model="searchFiltersCtrl.culture" class="form-control" ng-options="culture as (mainCtrl.translate(culture) | capitalize ) for culture in ['${"','".join(default_cultures) |n}'] | translate" ng-model="culture"></select>
+      </div>
+      <button class="btn btn-warning less-filters-btn" data-toggle="collapse" data-target="#moreFilters" 
+              aria-expanded="false" aria-controls="moreFilters">
+        <span class="glyphicon glyphicon-remove"></span>
+      </button>
+      <button class="btn btn-lg btn-default search-filters-btn" data-toggle="collapse" 
+              data-target="#moreFilters" aria-expanded="false" aria-controls="moreFilters" translate>Search 
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+    </div>
+    <button class="btn btn-info" data-toggle="collapse" data-target="#moreFilters" aria-expanded="false" aria-controls="moreFilters" translate>More filters</button>
+  </div>
+</form>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -37,8 +37,8 @@ module.value('mapFeatureCollection', {
 });
 % endif
 </%block>\
-
 <div class="text-center"><h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}}) </h3></div class="text-center">
+<%include file="filters.html" />
 <section id="waypoints-section">
   <div class="add-waypoint text-center">
     <app-edit-button app-edit-button-url="${request.route_url('waypoints_add')}">

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -9,6 +9,7 @@
 @tablet: ~"only screen and (min-width: 620px) and (max-width: 1099px)";
 @phone: ~"only screen and (min-width: 130px) and (max-width: 619px)";
 @lightgrey: #F0F0F0;
+@C2C-orange: #F7931D;
 
 html, body{
   min-height: 100%;
@@ -24,24 +25,129 @@ html, body{
 }
 
 .filters {
-  display: block;
-  overflow: auto;
-  padding: 0 4% 2% 4%;
+  text-align: center;
+  background-color: white;
   
-  
-  input {
-    margin-bottom: 1%;
-  }
-  .form-group {
-    display: flex;
-    align-items: center;
-  }
-}
+  #moreFilters {
+    z-index: 2;
+    position: absolute;
+    background-color: white;
+    width: 103%;
+    box-shadow: 0 14px 14px -14px #332;
+    -webkit-box-shadow:  0 14px 14px -14px #332;
+    -moz-box-shadow:     0 14px 14px -14px #332;
 
+    .less-filters-btn {
+      float: right;
+      margin-right: 20px;
+      top: 7px;
+      position: relative;
+    }
+    .search-filters-btn {
+      margin-left: 40px;
+      .glyphicon-search {
+        color: @C2C-orange;
+      }
+    }
+  }
+  .row {
+    padding: 0 2% 1% 2%;
+  }
+  .filter {
+    margin-bottom: 1%;
+    @media @phone {
+      padding: 0 8% 2% 8%;
+    }
+  }
+  .caret {
+    color: @C2C-orange;
+  }
+  .slider-min-max {
+    margin-left: -216px;
+    top: 25px;
+    position: relative;
+    display: inline-flex;
+  }
+  .min-value {
+    width: 160px;
+    text-align: left;
+  }
+  .slider-handle {
+    background-image: none;
+    background-color: @C2C-orange;
+  }
+  .slider-selection {
+    background: #BABABA;
+  }
+  .dropdown-toggle {
+    width: 100%;
+    .activity {
+      margin-left: 30px;
+    }
+    p {
+      margin: 0;
+    }
+    label {
+      font-family: inherit;
+    }
+  }
+ 
+  .multiselect-box {
+    
+    -webkit-columns: 2;
+    -moz-columns: 2;
+    columns: 2;
+    -webkit-column-gap: 4px;
+    -moz-column-gap: 4px;
+    column-gap: 4px;
+    -webkit-column-rule: 2px outset #CCC; /* Chrome, Safari, Opera */
+    -moz-column-rule: 2px outset #CCC; /* Firefox */
+    column-rule: 2px outset #CCC;
+    padding: 2%;
+    
+    @media @phone {
+     -webkit-columns: inherit;
+     -moz-columns: inherit;
+      overflow-x: hidden;
+      overflow-y: auto;
+      max-height : 250px;
+      width: 90%;
+      margin-left: 5%;
+    }
+    @media (min-width: @screen-xs-min){ /*bootstrap-defined*/
+      width: 95%;
+      margin-left: 5%;
+    }
+    @media (min-width: @screen-sm-min){ /*bootstrap-defined*/
+      width: auto;
+    }
+    @media (min-width: @screen-md-min){
+      width: auto;
+    }
+    span {
+      margin-left: 8px;
+      padding-right: 2%;
+      @media @phone {
+        margin-left: 5px;
+      }
+    }
+    a {
+      padding-left: 5%;
+      padding-right: 14px;
+      cursor: pointer;
+      transition: 0.3s;
+    }
+  }
+} /*filters */
+
+.option-selected {
+  background-color: #f7931d !important;
+  color: white !important;
+  transition: 0.3s;
+}
 h1 {
   font-size: 3em;
 }
-
 
 .form-control-feedback {
     position: relative;
@@ -90,12 +196,12 @@ h1 {
   }
 }
 
-.document-editing  {
+.document-editing {
   width: 70%;
   margin: auto;
 }
 
-.document-editing  {
+.document-editing {
   width: 70%;
   margin: auto;
 }
@@ -188,18 +294,18 @@ h1 {
     padding: 5%;
     display: block;
     transition: 0.2s;
-    
+
     .list-item-culture {
       opacity: 0.9;
       color: graytext;
       font-weight: normal;
     }
-    
+
     &:hover {
      text-decoration: none;
      color : #DB7D00;
     }
-    
+
     &:hover .list-item-title {
       text-decoration: underline;
     }
@@ -238,7 +344,7 @@ h3 {
       }
   }
    margin-left: 60%;
-   
+
    @media @tablet {
      margin-left: 55%;
    }
@@ -256,7 +362,7 @@ h3 {
   @media @tablet{
     width: 55%;
   }
-  
+
   @media @phone {
     width: 100%;
     float:none;
@@ -265,21 +371,21 @@ h3 {
 .tt-hint {
   z-index : -2;
 }
-.glyphicon-search{
+#search-icon {
   font-size: 1.8em;
   margin-right: 8px;
   margin-top: 5px;
-  
+
   @media @phone {
     cursor: pointer;
-/*    hover triggers the search input to appear in search.JS*/
+/*hover triggers the search input to appear in search.JS*/
   }
 }
 
-.login-text, .caret {
+.login-text {
   margin-bottom: 0;
   @media @phone {
-      display: none;
+    display: none;
   }
 }
 
@@ -289,12 +395,18 @@ h3 {
 
 app-user{
   text-align: center;
-  
+
   .login-out-button {
     span { 
       @media @phone {
         display: none;
   /*      shows no text on @phone, adds '.glyphicon-user' icon instead in user.js*/
+      }
+     }
+    }
+    .caret {
+      @media @phone {
+        display: none;
       }
     }
   }
@@ -303,19 +415,17 @@ app-user{
       display: none;
     }
   }
-}
 
 .show-search {
   -webkit-transition: all .5s ease-in-out !important;
   -moz-transition: all .5s ease-in-out !important;
   -o-transition: all .5s ease-in-out !important;
   transition: all .5s ease-in-out !important;
-  width: 163px !important;
+  width: 160px !important;
   visibility: visible !important;
   padding: 8px !important;
 }
 
-  
 #search {
   background-color: white !important;
   width : 103px;
@@ -356,7 +466,7 @@ app-lang{
 
 app-user {
   text-align: center;
-  
+
   .dropdown-toggle {
     min-height: 33px;
     align-items: center;
@@ -367,7 +477,7 @@ app-search {
   display: flex;
   display: -ms-flexbox;
   right: 0;
-  
+
   @media @phone {
     width: 40px;
   }
@@ -376,20 +486,20 @@ app-search {
 .page-header {
   position: absolute;
   top: 5px;
-  right: 15px;
+  right: -25px;
   margin-top: 10px !important;
   border: 0;
   display: flex;
   display: -ms-flexbox;
-  
+
   @media @phone {
-    margin-right: 0;
+    margin-right: -15px;
   }
 
   .quick-search {
     rigth: 0;
     position: relative;
-    
+
     @media @phone {
       z-index: 10;
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "BSD",
   "dependencies": {
     "async": "~0.2.10",
-    "bootstrap": "3.3.5"
+    "bootstrap": "3.3.5",
+    "bootstrap-slider": "6.0.9"
   },
   "devDependencies": {
     "angular": "1.4.8",
@@ -20,8 +21,8 @@
     "less-plugin-clean-css": "~1.1.0",
     "nomnom": "~1.6.2",
     "typeahead.js": "0.11.1",
-    "jquery": "^1.9.1",
+    "jquery": "1.12.0",
     "eslint": "git://github.com/eslint/eslint.git#4356532469ec1b9d4977aff05a03c3e167922ffa",
-    "eslint-config-openlayers": "^2.0.0"
+    "eslint-config-openlayers": "2.0.0"
   }
 }


### PR DESCRIPTION
- it's just a preview of what we could have as filters, for now only in /waypoints. 
It's using bootstrap-slider and bootstrap dropdown-menus.
- added 'capitalize' filter to filters.js that caps the first letter of a sentence.
- added 'search-icon' id in search.html



![screenshot from 2016-01-29 15 17 19](https://cloud.githubusercontent.com/assets/7814311/12677755/71d63c5a-c69b-11e5-90b0-8bad879d1505.png)
![screenshot from 2016-01-29 15 14 24](https://cloud.githubusercontent.com/assets/7814311/12677750/6b2aa0e4-c69b-11e5-883a-9fbe679f2e62.png)
![screenshot from 2016-01-29 15 15 23](https://cloud.githubusercontent.com/assets/7814311/12677753/6f3aa6c0-c69b-11e5-81ab-6005fdbb268b.png)
