### PR TITLE
title with brackets resolved (kinda)

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -21,10 +21,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -56,11 +52,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -113,11 +109,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -137,8 +133,13 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
+#: c2corg_ui/templates/route/view.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -314,12 +315,7 @@ msgid "View in other culture"
 msgstr ""
 
 #: c2corg_ui/templates/base.html
-#: c2corg_ui/templates/waypoint/index.html
 msgid "Waypoints"
-msgstr ""
-
-#: c2corg_ui/templates/base.html
-msgid "Welcome"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -24,10 +24,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -57,11 +53,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -113,11 +109,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -137,8 +133,12 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -306,12 +306,8 @@ msgstr ""
 msgid "View in other culture"
 msgstr ""
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/base.html
-msgid "Welcome"
+msgid "Waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -25,10 +25,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -58,11 +54,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -114,11 +110,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -138,8 +134,12 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -307,13 +307,9 @@ msgstr ""
 msgid "View in other culture"
 msgstr ""
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
+#: c2corg_ui/templates/base.html
 msgid "Waypoints"
 msgstr "Waypoints"
-
-#: c2corg_ui/templates/base.html
-msgid "Welcome"
-msgstr ""
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -25,10 +25,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr "Authentication"
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -58,11 +54,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -114,11 +110,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -138,8 +134,12 @@ msgstr "Forgotten password?"
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -307,13 +307,9 @@ msgstr ""
 msgid "View in other culture"
 msgstr "View in other culture"
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
+#: c2corg_ui/templates/base.html
 msgid "Waypoints"
 msgstr "Waypoints"
-
-#: c2corg_ui/templates/base.html
-msgid "Welcome"
-msgstr ""
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"
@@ -635,3 +631,6 @@ msgstr "weather station"
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
+
+#~ msgid "Authentication"
+#~ msgstr "Authentication"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -25,10 +25,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -58,11 +54,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -114,11 +110,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -138,8 +134,12 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -307,12 +307,8 @@ msgstr ""
 msgid "View in other culture"
 msgstr ""
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/base.html
-msgid "Welcome"
+msgid "Waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -24,10 +24,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -57,11 +53,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -113,11 +109,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -137,8 +133,12 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -306,12 +306,8 @@ msgstr ""
 msgid "View in other culture"
 msgstr ""
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/base.html
-msgid "Welcome"
+msgid "Waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -22,10 +22,6 @@ msgstr "Ajouter aux favoris"
 msgid "Around"
 msgstr "Autour de"
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr "Connexion"
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr "Auteur"
@@ -55,11 +51,11 @@ msgstr "Comparer les versions sélectionnées"
 msgid "Created on"
 msgstr "Créée le"
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr "Création d'un itinéraire"
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr "Création d'un point de passage"
 
@@ -73,11 +69,11 @@ msgstr "Décrivez ici l'itinéraire"
 
 #: c2corg_ui/templates/i18n.html
 msgid "Document has been deprotected"
-msgstr ""
+msgstr "Le document a été déverrouillé."
 
 #: c2corg_ui/templates/i18n.html
 msgid "Document has been protected"
-msgstr "Le document a été déverrouillé."
+msgstr "Le document a été verrouillé."
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
@@ -111,11 +107,11 @@ msgstr "Edition en français"
 msgid "Edit in it"
 msgstr "Modifier en italien"
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr "Edition d'un itinéraire"
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr "Edition d'un point de passage"
 
@@ -135,9 +131,13 @@ msgstr "Mot de passe oublié ?"
 msgid "Georeferenced"
 msgstr "Géoréferencé"
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr "Versions"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
+msgstr "Accueil"
 
 #: c2corg_ui/templates/i18n.html
 msgid "Invalid email address"
@@ -177,7 +177,7 @@ msgstr "Longitude"
 
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "More filters"
-msgstr ""
+msgstr "Plus de filtres"
 
 #: c2corg_ui/static/partials/user.html
 msgid "My account"
@@ -201,7 +201,7 @@ msgstr "Pas encore de compte ?"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "No content changes."
-msgstr ""
+msgstr "Pas de changement."
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
@@ -288,7 +288,7 @@ msgstr "Le titre doit comporter au moins 3 caractères."
 
 #: c2corg_ui/templates/helpers.html
 msgid "Translate into an other culture"
-msgstr ""
+msgstr "Traduire dans une autre langue"
 
 #: c2corg_ui/templates/auth.html
 msgid "Username"
@@ -304,15 +304,11 @@ msgstr "Version 2 en"
 
 #: c2corg_ui/templates/helpers.html
 msgid "View in other culture"
-msgstr ""
-
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
-msgid "Waypoints"
-msgstr "Points de passage"
+msgstr "Voir dans une autre langue"
 
 #: c2corg_ui/templates/base.html
-msgid "Welcome"
-msgstr "Bienvenue"
+msgid "Waypoints"
+msgstr "Points de passage"
 
 #: c2corg_ui/templates/index.html
 msgid "Welcome to Camptocamp.org"
@@ -560,7 +556,7 @@ msgstr "escalade"
 
 #: c2corg_ui/templates/route/view.html
 msgid "route"
-msgstr ""
+msgstr "itinéraire"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "route_types"
@@ -621,7 +617,7 @@ msgstr "point d'eau/source"
 
 #: c2corg_ui/templates/waypoint/view.html
 msgid "waypoint"
-msgstr ""
+msgstr "point de passage"
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "waypoint_type"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -25,10 +25,6 @@ msgstr ""
 msgid "Around"
 msgstr ""
 
-#: c2corg_ui/templates/auth.html
-msgid "Authentication"
-msgstr ""
-
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
 msgstr ""
@@ -58,11 +54,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr ""
 
@@ -114,11 +110,11 @@ msgstr ""
 msgid "Edit in it"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a route"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/i18n.html
 msgid "Editing a waypoint"
 msgstr ""
 
@@ -138,8 +134,12 @@ msgstr ""
 msgid "Georeferenced"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "History"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -307,12 +307,8 @@ msgstr ""
 msgid "View in other culture"
 msgstr ""
 
-#: c2corg_ui/templates/base.html c2corg_ui/templates/waypoint/index.html
-msgid "Waypoints"
-msgstr ""
-
 #: c2corg_ui/templates/base.html
-msgid "Welcome"
+msgid "Waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/index.html

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -29,5 +29,13 @@ app.MainController.prototype.translate = function(str) {
   return this.gettextCatalog_.getString(str);
 };
 
+/**
+ * @param {string} title String page title
+ * @return {string} concatenated and translated page title
+ * @export
+ */
+app.MainController.prototype.page_title = function(title) {
+  return this.translate(title) + ' - Camptocamp.org';
+};
 
 app.module.controller('MainController', app.MainController);

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -1,5 +1,6 @@
 <%inherit file="base.html"/>
-<%block name="pagetitle">{{'Authentication' | translate}}</%block>\
+<%namespace file="helpers.html" import="show_title"/>
+<%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Authentication')">${show_title('Authentication')}</title></%block>
 
 <div ng-init="showRegisterForm=false">
   <h1 translate>Login</h1>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -6,10 +6,11 @@ settings = request.registry.settings
 node_modules_path = settings.get('node_modules_path')
 closure_library_path = settings.get('closure_library_path')
 %>\
+<%namespace file="helpers.html" import="show_title"/>
 <!DOCTYPE html>
 <html <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
-    <title><%block name="pagetitle">{{'Welcome' | translate}}</%block> - Camptocamp.org</title>
+    <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Home')">${show_title('Home')}</title></%block>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/c2corg_ui/templates/document/history.html
+++ b/c2corg_ui/templates/document/history.html
@@ -1,11 +1,10 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="show_version_comment"/>
+<%namespace file="../helpers.html" import="show_version_comment, show_title"/>
 <%block name="pagelang">lang="${culture}"</%block>\
-<%block name="pagetitle">${title}</%block>\
+<%block name="pagetitle"><title ng-bind="'${title} - '+ mainCtrl.page_title('History')">${title} - ${show_title('History')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
 
 <h1>${self.pagetitle()}</h1>
-
 <p><span translate>List of versions for language:</span> <strong>{{mainCtrl.translate('${culture}')}}</strong></p>
 
 <%

--- a/c2corg_ui/templates/helpers.html
+++ b/c2corg_ui/templates/helpers.html
@@ -93,16 +93,20 @@ ${attr | n}\
 % endif
 </%def>
 
-<%def name="show_route_title(locale)">\
+<%def name="show_route_title(locale, is_tab_title=False)">\
 <%
     title = ''
     if 'title_prefix' in locale and locale['title_prefix']:
         title = locale['title_prefix'] + ' : '
     title += locale['title']
-%>
-${title}
+%>\
+${title}${' - Camptocamp.org' if is_tab_title else ''}\
 </%def>
 
 <%def name="show_version_comment(version)">\
 ${'{{mainCtrl.translate(\'' + get_attr(version, 'comment', md=False) + '\')}}' if version['comment'] else '' | n}
+</%def>
+
+<%def name="show_title(title)">\
+${title + ' - ' if title else ''}Camptocamp.org\
 </%def>

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -84,3 +84,12 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <span translate>Edit in es</span>
 <span translate>Edit in eu</span>
 <span translate>Edit in ca</span>
+
+<!-- edit -->
+<span translate>Creating a route</span>
+<span translate>Editing a route</span>
+<span translate>Creating a waypoint</span>
+<span translate>Editing a waypoint</span> 
+
+<!-- home -->
+<span translate>Home</span>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -5,10 +5,11 @@ from c2corg_common.attributes import default_cultures
 <%
 updating_doc = route_id and route_culture
 %>\
-<%block name="pagetitle">${"{{'Editing a route' | translate}}" if route_id and route_culture else "{{'Creating a route' | translate}}"}</%block>\
+<%namespace file="../helpers.html" import="show_title"/>
+<%block name="pagetitle"><title ng-init="id=${route_id if route_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a route') : mainCtrl.page_title('Creating a route')">${show_title('Create/edit route')}</title></%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
 
-<h1>${self.pagetitle()}</h1>
+<h1 ng-cloak ng-init="id=${route_id if route_id else 0}" ng-bind="id ? ('Editing a route' | translate) : ('Creating a route' | translate)" class="text-center"></h1>
 <form app-document-editing="routes" app-document-editing-model="route" 
 % if updating_doc:
   app-document-editing-id="${route_id}" app-document-editing-culture="${route_culture}"

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,10 +1,10 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="show_attr, add_pagination_links, show_route_title"/>
-<%block name="pagetitle">{{'Routes' | translate}}</%block>
+<%namespace file="../helpers.html" import="show_attr, add_pagination_links, show_route_title, show_title"/>
+<%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Routes')">${show_title('Routes')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
 <div class="text-center">
-  <h3 ng-init="nbItems = ${total}">${self.pagetitle()} ({{nbItems}})</h3>
+  <h3 ng-init="nbItems = ${total}" ng-cloak>{{'Routes' | translate}} ({{nbItems}})</h3>
 </div>
 <section id="routes-section">
   <div class="add-route text-center">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -8,7 +8,7 @@ route_id = route['document_id']
 other_cultures, missing_cultures = get_culture_lists(route, culture)
 %>\
 <%block name="pagelang">lang="${culture}"</%block>\
-<%block name="pagetitle">${show_route_title(locale)}</%block>\
+<%block name="pagetitle"><title>${show_route_title(locale, True)}</title></%block>\
 <%block name="metarobots">\
   % if version:
 <meta name="robots" content="noindex,follow">\
@@ -18,7 +18,7 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
 </%block>\
 
 <header class="view-details-title">
-  <span class="heading">${self.pagetitle()} <label class="badge" translate>route</label></span>
+  <span class="heading">${show_route_title(locale)} <label class="badge" translate>route</label></span>
   <div class="float-buttons">
     <div class="float-button float-edit" tooltip-placement="top" uib-tooltip="{{'Edit' | translate}}">
       <app-edit-button app-edit-button-url="${request.route_url('routes_edit', id=route_id, culture=culture)}"></app-edit-button>
@@ -67,6 +67,7 @@ other_cultures, missing_cultures = get_culture_lists(route, culture)
       ${show_other_cultures_links('routes', route, other_cultures)}
       ${show_missing_cultures_links('routes', route, missing_cultures)}
     % endif
+    <a class="btn btn-info" href="${request.route_url('routes_history', id=route_id, culture=culture)}" translate>History</a>
   </div>
   <div class="view-details-description col-lg-8 col-md-8 col-xs-12">
     <span class="lead"> 

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -5,9 +5,12 @@ from c2corg_common.attributes import default_cultures
 <%
 updating_doc = waypoint_id and waypoint_culture
 %>\
-<%block name="pagetitle">${"{{'Editing a waypoint' | translate}}" if waypoint_id and waypoint_culture else "{{'Creating a waypoint' | translate}}"}</%block>\
+<%namespace file="../helpers.html" import="show_title"/>
+<%block name="pagetitle"><title ng-init="id=${waypoint_id if waypoint_id else 0}" 
+                                ng-bind="id ? mainCtrl.page_title('Editing a waypoint') : mainCtrl.page_title('Creating a waypoint')">${show_title('Create/edit waypoint')}</title></%block>\
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>\
-<h1>${self.pagetitle()}</h1>
+
+<h1 ng-init="id=${waypoint_id if waypoint_id else 0}" ng-bind="id ? ('Editing a waypoint' | translate) : ('Creating a waypoint' | translate)" class="text-center"></h1>
 <form app-document-editing="waypoints" app-document-editing-model="waypoint"
 % if updating_doc:
   app-document-editing-id="${waypoint_id}" app-document-editing-culture="${waypoint_culture}"

--- a/c2corg_ui/templates/waypoint/filters.html
+++ b/c2corg_ui/templates/waypoint/filters.html
@@ -82,6 +82,6 @@ from c2corg_common.attributes import default_cultures, waypoint_types, activitie
         <span class="glyphicon glyphicon-search"></span>
       </button>
     </div>
-    <button class="btn btn-info" data-toggle="collapse" data-target="#moreFilters" aria-expanded="false" aria-controls="moreFilters" translate>More filters</button>
+    <button class="btn btn-info search-filters-btn" data-toggle="collapse" data-target="#moreFilters" aria-expanded="false" aria-controls="moreFilters" translate>More filters</button>
   </div>
 </form>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,6 +1,6 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="show_attr, add_pagination_links"/>
-<%block name="pagetitle">{{'Waypoints' | translate}}</%block>\
+<%namespace file="../helpers.html" import="show_attr, add_pagination_links, show_title"/>
+<%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Waypoints')">${show_title('Waypoints')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,follow"></%block>\
 
 <%block name="moduleConstantsValues">

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -2,7 +2,7 @@
 from c2corg_ui.templates.utils import get_culture_lists
 %>\
 <%inherit file="../base.html"/>
-<%namespace file="../helpers.html" import="show_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links"/>
+<%namespace file="../helpers.html" import="show_attr, show_archive_data, show_other_cultures_links, show_missing_cultures_links, show_title"/>
 <%
 waypoint_id = waypoint['document_id']
 other_cultures, missing_cultures = get_culture_lists(waypoint, culture)
@@ -12,8 +12,9 @@ other_cultures, missing_cultures = get_culture_lists(waypoint, culture)
 geometry4326 = geometry
 %>\
 <%block name="pagelang">lang="${culture}"</%block>\
-<%block name="pagetitle">${show_attr(locale, 'title', False)}</%block>\
+<%block name="pagetitle"><title>${show_title(locale['title'])}</title></%block>\
 <%block name="metarobots">\
+
   % if version:
 <meta name="robots" content="noindex,follow">\
   % else:
@@ -41,7 +42,7 @@ module.value('mapFeatureCollection', {
 </%block>\
 
 <header class="view-details-title">
-  <span class="heading">${self.pagetitle()} <label class="badge" translate>waypoint</label></span>
+  <span class="heading">${locale['title']} <label class="badge" translate>waypoint</label></span>
   <div class="float-buttons">
     <div class="float-button float-edit" tooltip-placement="top" uib-tooltip="{{'Edit' | translate}}">
       <app-edit-button app-edit-button-url="${request.route_url('waypoints_edit', id=waypoint_id, culture=culture)}"></app-edit-button>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -32,6 +32,17 @@ html, body{
   overflow: auto;
   padding: 0 4% 2% 4%;
   
+  .search-filters-btn {
+    margin-left: 40px;
+    top: 1px;
+    position: relative;
+    z-index: 1;
+
+    .glyphicon-search {
+      color: @C2C-orange;
+    }
+  }
+  
   #moreFilters {
     z-index: 2;
     position: absolute;
@@ -46,12 +57,6 @@ html, body{
       margin-right: 20px;
       top: 7px;
       position: relative;
-    }
-    .search-filters-btn {
-      margin-left: 40px;
-      .glyphicon-search {
-        color: @C2C-orange;
-      }
     }
   }
   .row {


### PR DESCRIPTION
fixes #113 
![screenshot from 2016-02-04 13 53 14](https://cloud.githubusercontent.com/assets/7814311/12815453/b2eb85a6-cb46-11e5-8dbb-f55baaca2d49.png)
Page titles that are normally translated, for instance 'Waypoints' or 'Routes' have a default title in english that is translated on the go into other languages but will stay in english in the browser history.

Other pages that use waypoint_title or route_title as page title don't have this issue of course.