### PR TITLE
Rename API's 'l' parameter to 'lang'

### DIFF
--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -183,7 +183,7 @@ app.DocumentEditingController.DATA_PROJ = 'EPSG:3857';
 app.DocumentEditingController.prototype.buildUrl_ = function(type) {
   switch (type) {
     case 'read':
-      return '{base}/{module}/{id}?l={lang}'
+      return '{base}/{module}/{id}?lang={lang}'
           .replace('{base}', this.apiUrl_)
           .replace('{module}', this.module_)
           .replace('{id}', String(this.id_))

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -74,7 +74,7 @@ class Document(object):
             raise HTTPBadRequest("Incorrect " + field)
 
     def _get_document(self, id, lang):
-        url = '%s/%d?l=%s' % (self._API_ROUTE, id, lang)
+        url = '%s/%d?lang=%s' % (self._API_ROUTE, id, lang)
         resp, document = self._call_api(url)
         # TODO: better error handling
         if resp['status'] == '404':


### PR DESCRIPTION
See https://github.com/c2corg/v6_api/issues/101#issuecomment-166672389
Requires https://github.com/c2corg/v6_api/pull/148

Should we rename the "pl" parameter as well?