### PR TITLE
Check for unused `goog.require`s

### DIFF
--- a/build.json
+++ b/build.json
@@ -41,41 +41,10 @@
       "node_modules/ngeo/externs/ngeox.js"
     ],
     "jscomp_error": [
-      "accessControls",
-      "ambiguousFunctionDecl",
-      "checkEventfulObjectDisposal",
-      "checkRegExp",
-      "checkTypes",
-      "checkVars",
-      "const",
-      "constantProperty",
-      "deprecated",
-      "duplicateMessage",
-      "es3",
-      "es5Strict",
-      "externsValidation",
-      "fileoverviewTags",
-      "globalThis",
-      "internetExplorerChecks",
-      "invalidCasts",
-      "misplacedTypeAnnotation",
-      "missingGetCssName",
-      "missingProperties",
-      "missingProvide",
-      "missingRequire",
-      "missingReturn",
-      "newCheckTypes",
-      "nonStandardJsDocs",
-      "suspiciousCode",
-      "strictModuleDepCheck",
-      "typeInvalidation",
-      "undefinedNames",
-      "undefinedVars",
-      "uselessCode",
-      "visibility"
+      "*"
     ],
     "jscomp_off": [
-      "unknownDefines"
+      "useOfGoogBase", "lintChecks", "unnecessaryCasts"
     ],
     "extra_annotation_name": [
       "api", "observable", "ngdoc", "ngname"

--- a/c2corg_ui/static/js/alerts.js
+++ b/c2corg_ui/static/js/alerts.js
@@ -5,6 +5,7 @@ goog.provide('app.alertsDirective');
 
 goog.require('app');
 goog.require('app.Alerts');
+/** @suppress {extraRequire} */
 goog.require('app.trustAsHtmlFilter');
 
 

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -3,6 +3,7 @@
  */
 goog.provide('app');
 
+/** @suppress {extraRequire} */
 goog.require('ngeo');
 
 

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Application entry point.
+ * @suppress {extraRequire}
  *
  * This file defines the "app.main" Closure namespace, which is be used as the
  * Closure entry point (see "closure_entry_point" in the "build.json" file).

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -1,6 +1,7 @@
 goog.provide('app.MainController');
 
 goog.require('app');
+/** @suppress {extraRequire} */
 goog.require('app.HttpAuthenticationInterceptor');
 
 

--- a/c2corg_ui/static/js/map/diffmap.js
+++ b/c2corg_ui/static/js/map/diffmap.js
@@ -3,6 +3,7 @@ goog.provide('app.diffMapDirective');
 
 goog.require('app');
 goog.require('app.MapController');
+/** @suppress {extraRequire} */
 goog.require('ngeo.mapDirective');
 goog.require('ol.Feature');
 goog.require('ol.Map');

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -3,6 +3,7 @@ goog.provide('app.mapDirective');
 
 goog.require('app');
 goog.require('app.utils');
+/** @suppress {extraRequire} */
 goog.require('ngeo.mapDirective');
 goog.require('ol.Collection');
 goog.require('ol.Feature');

--- a/c2corg_ui/static/js/search.js
+++ b/c2corg_ui/static/js/search.js
@@ -3,6 +3,7 @@ goog.provide('app.searchDirective');
 
 goog.require('app');
 goog.require('app.utils');
+/** @suppress {extraRequire} */
 goog.require('ngeo.searchDirective');
 
 

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -1,7 +1,5 @@
 goog.provide('app.utils');
 
-goog.require('goog.asserts');
-
 
 /**
  * @param {string} document_type The document type.

--- a/c2corg_ui/templates/templatecache.js
+++ b/c2corg_ui/templates/templatecache.js
@@ -23,6 +23,7 @@
  * GENERATED FILE. DO NOT EDIT.
  */
 
+/** @suppress {extraRequire} */
 goog.require('app');
 
 (function() {


### PR DESCRIPTION
Closes #76 

Directives that are used in partials can be flagged with `@suppress {extraRequire}`, e.g.:

    /** @suppress {extraRequire} */
    goog.require('ngeo.searchDirective');