### PR TITLE
Parse c2corg custom wikilinks

### DIFF
--- a/c2corg_ui/format/README.md
+++ b/c2corg_ui/format/README.md
@@ -1,0 +1,18 @@
+Parsing the custom formating syntax of camptocamp.org
+=====================================================
+
+Base syntaxes
+-------------
+
+Camptocamp.org uses several base syntaxes to format the documents text attributes.
+External python libraries are used to parse those base syntaxes:
+* Markdown: [Python-Markdown](https://github.com/waylan/Python-Markdown)
+* BBcode: [bbcode](https://github.com/dcwatson/bbcode)
+
+Custom tags
+-----------
+
+Custom tags are also available and supported by the extensions provided in this package.
+
+See the documentations for:
+* [Python-Markdown extensions](https://pythonhosted.org/Markdown/extensions/api.html)

--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -1,0 +1,1 @@
+# package

--- a/c2corg_ui/format/wikilinks.py
+++ b/c2corg_ui/format/wikilinks.py
@@ -1,0 +1,45 @@
+'''
+c2corg wikiLinks Extension for Python-Markdown
+==============================================
+
+Converts tags such as [[document_type/document_id|label]]
+to <a href="/document_type/document_id">label</a>
+
+Inspired from https://github.com/waylan/Python-Markdown/blob/master
+/markdown/extensions/wikilinks.py
+'''
+
+from markdown.extensions import Extension
+from markdown.inlinepatterns import Pattern
+from markdown.util import etree
+
+
+class C2CWikiLinkExtension(Extension):
+
+    def extendMarkdown(self, md, md_globals):  # noqa
+        self.md = md
+
+        wikilink_re = r'\[\[([^|]+)\|([^\]]+)\]\]'
+        pattern = C2CWikiLinks(wikilink_re)
+        pattern.md = md
+        # append to end of inline patterns
+        md.inlinePatterns.add('c2cwikilink', pattern, "<not_strong")
+
+
+class C2CWikiLinks(Pattern):
+
+    def handleMatch(self, m):  # noqa
+        if m.group(2).strip():
+            url = m.group(2).strip()
+            url = '/' + url if url[0] != '/' else url
+            label = m.group(3).strip()
+            a = etree.Element('a')
+            a.text = label
+            a.set('href', url)
+        else:
+            a = ''
+        return a
+
+
+def makeExtension(*args, **kwargs):  # noqa
+    return C2CWikiLinkExtension(*args, **kwargs)

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -2,6 +2,8 @@ import bbcode
 import markdown
 import html
 
+from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
+
 
 def sanitize(text):
     return html.escape(text)
@@ -9,7 +11,9 @@ def sanitize(text):
 
 def parse_code(text, md=True, bb=True):
     if md:
-        text = markdown.markdown(text, output_format='xhtml5')
+        wikilink = C2CWikiLinkExtension()
+        text = markdown.markdown(text, output_format='xhtml5',
+            extensions=[wikilink])
     if bb:
         bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
         text = bbcode_parser.format(text)

--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -5,16 +5,35 @@ import html
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
 
 
-def sanitize(text):
-    return html.escape(text)
+_markdown_parser = None
+_bbcode_parser = None
+
+
+def _get_markdown_parser():
+    global _markdown_parser
+    if not _markdown_parser:
+        extensions = [
+            C2CWikiLinkExtension(),
+        ]
+        _markdown_parser = markdown.Markdown(output_format='xhtml5',
+                                             extensions=extensions)
+    return _markdown_parser
+
+
+def _get_bbcode_parser():
+    global _bbcode_parser
+    if not _bbcode_parser:
+        _bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+    return _bbcode_parser
 
 
 def parse_code(text, md=True, bb=True):
     if md:
-        wikilink = C2CWikiLinkExtension()
-        text = markdown.markdown(text, output_format='xhtml5',
-            extensions=[wikilink])
+        text = _get_markdown_parser().convert(text)
     if bb:
-        bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
-        text = bbcode_parser.format(text)
+        text = _get_bbcode_parser().format(text)
     return text
+
+
+def sanitize(text):
+    return html.escape(text)

--- a/c2corg_ui/tests/format/__init__.py
+++ b/c2corg_ui/tests/format/__init__.py
@@ -1,0 +1,1 @@
+# package

--- a/c2corg_ui/tests/format/input.txt
+++ b/c2corg_ui/tests/format/input.txt
@@ -1,0 +1,14 @@
+## Title 1
+Some [b]bold text[/b] and a [[waypoints/12345/fr/some-slug|wiki link]] before [[/whatever|another one]] that follows.
+
+### Title 2
+
+Here is a list:
+
+* a [url=http://example.com]standard link[/url]
+* some [i]italic âccentuated content[/i]
+
+Another list:
+
+- [[routes/56730|Eperon de la Tournette]]
+- [[routes/49571|Versant W - Couloir Saudan]]

--- a/c2corg_ui/tests/format/output.txt
+++ b/c2corg_ui/tests/format/output.txt
@@ -1,0 +1,13 @@
+<h2>Title 1</h2>
+<p>Some <strong>bold text</strong> and a <a href="/waypoints/12345/fr/some-slug">wiki link</a> before <a href="/whatever">another one</a> that follows.</p>
+<h3>Title 2</h3>
+<p>Here is a list:</p>
+<ul>
+<li>a <a href="http://example.com">standard link</a></li>
+<li>some <em>italic âccentuated content</em></li>
+</ul>
+<p>Another list:</p>
+<ul>
+<li><a href="/routes/56730">Eperon de la Tournette</a></li>
+<li><a href="/routes/49571">Versant W - Couloir Saudan</a></li>
+</ul>

--- a/c2corg_ui/tests/format/test_format.py
+++ b/c2corg_ui/tests/format/test_format.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+import bbcode
+import markdown
+
+from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
+from c2corg_ui.tests import read_file
+
+
+base_path = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestFormat(unittest.TestCase):
+
+    def setUp(self):  # noqa
+        extensions = [
+            C2CWikiLinkExtension(),
+        ]
+        self.markdown_parser = markdown.Markdown(output_format='xhtml5',
+                                                 extensions=extensions)
+        self.bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+
+    def test_wikilinks(self):
+        input1 = (
+            'Some text and a [[waypoints/12345/fr/some-slug|wiki link]] '
+            'before [[/whatever|another one]] that follows.'
+        )
+        output1 = (
+            '<p>Some text and a '
+            '<a href="/waypoints/12345/fr/some-slug">wiki link</a> '
+            'before <a href="/whatever">another one</a> that follows.</p>'
+        )
+        md_output1 = self.markdown_parser.convert(input1)
+        self.assertEqual(md_output1, output1)
+        # Make sure the bbcode parser does not impact the wikilink conversion:
+        bb_output1 = self.bbcode_parser.format(md_output1)
+        self.assertEqual(bb_output1, output1)
+
+    def test_full_conversion(self):
+        input_txt = read_file(os.path.join(base_path, 'input.txt'))
+        output_txt = read_file(os.path.join(base_path, 'output.txt'))
+        txt = self.markdown_parser.convert(input_txt)
+        txt = self.bbcode_parser.format(txt)
+        self.assertEqual(txt, output_txt)


### PR DESCRIPTION
This PR adds a first extension to the standard markdown/bbcode syntaxes: wikilinks.

Links such as ``[[routes/12345/etc|Some label]]`` are converted to ``<a href="/routes/12345/etc">Some label</a>``.

One problem left: flake8 complains because some of the methods used in the markdown extension class are not lowercased:
> c2corg_ui/format/wikilinks.py:19:9: N802 function name should be lowercase
c2corg_ui/format/wikilinks.py:31:9: N802 function name should be lowercase
c2corg_ui/format/wikilinks.py:44:5: N802 function name should be lowercase

but I can't change the case of this functions since they are overloading methods defined in the Markdown classes. Is there a way to tell flake8 to ignore those errors here?