### PR TITLE
Minimal and temporary layout for the associations

### DIFF
--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -75,10 +75,14 @@ other_langs, missing_langs = get_lang_lists(route, lang)
       ${show_attr(locale, 'description')}
     </span>
   </div>
+  <div class="view-details-description col-lg-8 col-md-8 col-xs-12">
+    <span class="lead"> 
+      <h3 class="text-center heading">Associations</h3>
+      <div>Waypoint associations: ${show_associated_waypoints(route)}</div>
+      <div>Route associations: ${show_associated_routes(route)}</div>
+      <div>Areas: ${show_areas(route)}</div>
+      <div>Maps: ${show_maps(route)}</div>
+    </span>
+  </div>
 </section>
 <%include file="../document/floating-button-responsive.html"/>
-
-<div>Waypoint associations: ${show_associated_waypoints(route)}</div>
-<div>Route associations: ${show_associated_routes(route)}</div>
-<div>Areas: ${show_areas(route)}</div>
-<div>Maps: ${show_maps(route)}</div>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -112,10 +112,14 @@ module.value('mapFeatureCollection', {
     </span>
   </div>
   % endif
+  <div class="view-details-description col-lg-8 col-md-8 col-xs-12">
+    <span class="lead">
+      <h3 class="text-center heading">Associations</h3>
+      <div>Waypoints: ${show_associated_waypoints(waypoint)}</div>
+      <div>Routes: ${show_associated_routes(waypoint)}</div>
+      <div>Areas: ${show_areas(waypoint)}</div>
+      <div>Maps: ${show_maps(waypoint)}</div>
+    </span>
+  </div>
 </section>
 <%include file="../document/floating-button-responsive.html"/>
-
-<div>Waypoint associations: ${show_associated_waypoints(waypoint)}</div>
-<div>Route associations: ${show_associated_routes(waypoint)}</div>
-<div>Areas: ${show_areas(waypoint)}</div>
-<div>Maps: ${show_maps(waypoint)}</div>


### PR DESCRIPTION
This PR moves the associations links recently added by @gberaudo (see https://github.com/c2corg/v6_ui/pull/143) to some temporary (but nicer :P) block below the description block.