### PR TITLE
Add cache busting

### DIFF
--- a/c2corg_ui/lib/cacheversion.py
+++ b/c2corg_ui/lib/cacheversion.py
@@ -1,0 +1,35 @@
+# Inspired from GeoMapFish
+# noqa https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/lib/icacheversion.py
+
+from urllib.parse import urljoin
+
+
+CACHE_PATH = []
+
+
+def version_cache_buster(request, subpath, kw):
+    # TODO get cache version from server caching?
+    cache_version = request.registry.settings.get('cache_version')
+    return urljoin(cache_version + '/', subpath), kw
+
+
+class CachebusterTween:
+    ''' Get back the cachebuster URL. '''
+    def __init__(self, handler, registry):
+        self.handler = handler
+
+    def __call__(self, request):
+        path = request.path_info.split('/')
+        if path[1] in CACHE_PATH:
+            # remove the cache buster
+            path.pop(2)
+            request.path_info = '/' .join(path)
+
+        response = self.handler(request)
+
+        if path[1] in CACHE_PATH:
+            response.headers['Access-Control-Allow-Origin'] = '*'
+            response.headers['Access-Control-Allow-Headers'] = \
+                'X-Requested-With, Content-Type'
+
+        return response

--- a/c2corg_ui/lib/cacheversion.py
+++ b/c2corg_ui/lib/cacheversion.py
@@ -17,19 +17,50 @@ class CachebusterTween:
     ''' Get back the cachebuster URL. '''
     def __init__(self, handler, registry):
         self.handler = handler
+        self.expected_cache_version = registry.settings.get('cache_version')
+
+    @staticmethod
+    def is_hexa(str):
+        try:
+            int(str, 16)
+            return True
+        except:
+            return False
+
+    @staticmethod
+    def is_git_hash(str):
+        # 592d5db = git rev-parse --short HEAD
+        return len(str) == 7 and CachebusterTween.is_hexa(str)
 
     def __call__(self, request):
         path = request.path_info.split('/')
-        if path[1] in CACHE_PATH:
-            # remove the cache buster
+        if not path[1] in CACHE_PATH:
+            # Simply forward the request unmodified.
+            return self.handler(request)
+
+        received_hash = path[2]
+        if CachebusterTween.is_git_hash(received_hash):
+            # Remove the cache buster only if it looks like a git hash. This
+            # distinction is necessary to get debug mode work.
             path.pop(2)
             request.path_info = '/' .join(path)
 
+        # Prepare a response
         response = self.handler(request)
 
-        if path[1] in CACHE_PATH:
-            response.headers['Access-Control-Allow-Origin'] = '*'
-            response.headers['Access-Control-Allow-Headers'] = \
-                'X-Requested-With, Content-Type'
+        headers = response.headers
+        headers['Access-Control-Allow-Origin'] = '*'
+        headers['Access-Control-Allow-Headers'] = \
+            'X-Requested-With, Content-Type'
+
+        # Prevent caching if the requested version does not match the
+        # one we are configured to serve. This is intended to prevent
+        # cache poisoning.
+        # noqa See http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browsers
+        if received_hash != self.expected_cache_version:
+                headers['Cache-Control'] = \
+                        'no-cache, no-store, must-revalidate'
+                headers['Pragma'] = 'no-cache'
+                headers['Expires'] = '0'
 
         return response

--- a/common.ini.in
+++ b/common.ini.in
@@ -9,7 +9,8 @@ api_url_host = {api_url_host}
 
 pyramid.default_locale_name = fr
 
-version = {version}
+cache_max_age = 3600
+cache_version = {version}
 
 logging.level = {logging_level}
 

--- a/config/dev
+++ b/config/dev
@@ -1,3 +1,1 @@
 include Makefile
-
-export version = 0

--- a/development.ini.in
+++ b/development.ini.in
@@ -15,9 +15,6 @@ pyramid.includes =
     pyramid_closure
     pyramid_mako
 
-# disable version in dev mode
-version =
-
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 debugtoolbar.hosts = 0.0.0.0/0


### PR DESCRIPTION
GMF 2 also uses Pyramid 1.6 and its cache busting system.

I have then ported the GMF code
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/__init__.py#L344-L352
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/lib/cacheversion.py
to our project with a few adaptations (python3, no server caching yet).

It works pretty nice and almost out of the box.

Instead of a random uuid string, I would like to use the short last commit hash provided by https://github.com/c2corg/v6_ui/blob/cache_buster2/config/default#L4
but I don't know how to get a config parameter from within a standard function (say ``get_cache_version``). I have tried to use some ``CACHE_VERSION`` variable set in the ``main()`` function but it's then not available in ``get_cache_version``. flake8 by the way says that:
> c2corg_ui/__init__.py:3:1: F401 'CACHE_VERSION' imported but unused
c2corg_ui/__init__.py:14:5: F811 redefinition of unused 'CACHE_VERSION' from line 3
c2corg_ui/__init__.py:14:5: F841 local variable 'CACHE_VERSION' is assigned to but never used

Anyone knows what's the best way to do this? Thanks!

Fixes https://github.com/c2corg/v6_ui/issues/82