### PR TITLE
Waypoints + routes specific fields and associated-documents cards

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -5,6 +5,7 @@ msgstr ""
 "Project-Id-Version: \n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -13,7 +14,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -31,7 +31,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -40,19 +39,17 @@ msgid "Articles"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -93,7 +90,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -103,6 +99,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -138,7 +146,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -182,6 +189,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -191,7 +202,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -217,7 +227,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -226,7 +236,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -236,6 +245,7 @@ msgid "Home"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -260,7 +270,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -281,13 +291,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -325,10 +333,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -342,6 +346,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -365,7 +370,6 @@ msgstr ""
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr ""
 
@@ -395,6 +399,10 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -435,7 +443,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -452,14 +459,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr ""
 
@@ -477,7 +482,16 @@ msgid "You are viewing an archived version of this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -485,6 +499,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -496,6 +514,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -504,11 +530,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -524,8 +559,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -536,12 +583,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -553,24 +620,40 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -585,6 +668,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -597,16 +684,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -634,6 +738,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -653,7 +765,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -690,6 +816,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -698,6 +836,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -717,8 +863,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -761,8 +919,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -773,12 +941,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -789,8 +973,33 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -798,6 +1007,7 @@ msgid "red"
 msgstr ""
 
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -806,6 +1016,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -821,7 +1032,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -838,6 +1051,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -848,6 +1069,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -890,6 +1115,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -915,12 +1148,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -17,7 +18,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -34,7 +34,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -42,20 +41,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -93,7 +88,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -103,6 +97,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -138,7 +144,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -182,6 +187,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -191,7 +200,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -217,7 +225,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -226,7 +234,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -234,7 +241,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -259,7 +266,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -279,12 +286,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -322,10 +328,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -339,6 +341,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -360,7 +363,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Itineraris"
 
@@ -388,6 +390,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
@@ -424,7 +430,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -441,14 +446,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr ""
 
@@ -465,14 +468,26 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -484,6 +499,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -492,11 +515,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -512,8 +544,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -524,12 +568,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -541,23 +605,39 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -572,6 +652,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -584,16 +668,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -621,6 +722,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -639,7 +748,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -676,6 +799,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -683,6 +818,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -702,8 +845,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -746,8 +901,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -758,12 +923,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -774,15 +955,40 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -791,6 +997,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -806,7 +1013,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -823,6 +1032,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -833,6 +1050,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -871,6 +1092,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -896,12 +1125,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -10,6 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -18,7 +19,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -35,7 +35,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -43,20 +42,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -94,7 +89,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -104,6 +98,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -139,7 +145,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -183,6 +188,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -192,7 +201,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -218,7 +226,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -227,7 +235,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -235,7 +242,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -260,7 +267,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -280,12 +287,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -323,10 +329,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -340,6 +342,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -361,7 +364,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Routen"
 
@@ -389,6 +391,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
@@ -425,7 +431,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -442,14 +447,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr "Waypoints"
 
@@ -466,14 +469,26 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -485,6 +500,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -493,11 +516,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -513,8 +545,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -525,12 +569,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -542,23 +606,39 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -573,6 +653,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -585,16 +669,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -622,6 +723,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -640,7 +749,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -677,6 +800,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -684,6 +819,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -703,8 +846,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -747,8 +902,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -759,12 +924,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -775,15 +956,40 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -792,6 +998,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -807,7 +1014,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -824,6 +1033,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -834,6 +1051,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -872,6 +1093,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -897,12 +1126,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -10,6 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -18,7 +19,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -35,7 +35,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -43,20 +42,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -94,7 +89,6 @@ msgid "Comment about the changes"
 msgstr "Comment about the changes"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -104,6 +98,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -139,7 +145,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Edit"
 
@@ -183,6 +188,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -192,7 +201,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -218,7 +226,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -227,7 +235,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -235,7 +242,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -260,7 +267,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -280,12 +287,11 @@ msgstr "Sign out"
 msgid "Longitude"
 msgstr "Longitude"
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -323,10 +329,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -340,6 +342,7 @@ msgid "Previous"
 msgstr "Previous"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -361,7 +364,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Routes"
 
@@ -390,6 +392,10 @@ msgstr ""
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
 msgstr "Short description of the applied changes"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
+msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
@@ -425,7 +431,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -442,14 +447,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr "View in other lang"
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr "Waypoints"
 
@@ -466,9 +469,17 @@ msgstr "Yes"
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr "Access"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -476,12 +487,24 @@ msgstr "Access"
 msgid "activities"
 msgstr "Activities"
 
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "aid_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "already used username"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -493,12 +516,21 @@ msgid "bergschrund"
 msgstr "bergschrund"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr "bisse"
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
 msgstr "bivouac"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
+msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 #: c2corg_ui/templates/helpers/view.html
@@ -513,9 +545,21 @@ msgstr "catalan"
 msgid "camp_site"
 msgstr "camp site"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
 msgstr "cave"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "cliff"
@@ -525,12 +569,32 @@ msgstr "cliff"
 msgid "climbing_indoor"
 msgstr "climbing indoor"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr "climbing outdoor"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -542,23 +606,39 @@ msgid "confluence"
 msgstr "confluence"
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr "german"
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr "Elevation"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -573,6 +653,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr "spanish"
@@ -585,16 +669,33 @@ msgstr "basque"
 msgid "expedition"
 msgstr "expedition"
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr "french"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr "gear"
 
@@ -622,6 +723,14 @@ msgstr ""
 msgid "green"
 msgstr "green"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -640,7 +749,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr "Height difference up"
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -677,6 +800,18 @@ msgid "it"
 msgstr "italian"
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr "lake"
 
@@ -685,6 +820,14 @@ msgstr "lake"
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr "Lang"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
@@ -703,9 +846,21 @@ msgid "loop_hut"
 msgstr "loop hut"
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
 msgstr "Maps info"
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "misc"
@@ -747,8 +902,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -759,13 +924,29 @@ msgstr "paragliding"
 msgid "paragliding_landing"
 msgstr "paragliding landing"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr "paragliding takeoff"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr "pass"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
@@ -775,15 +956,40 @@ msgstr "pit"
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
 msgstr "raid"
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
+msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -792,6 +998,7 @@ msgid "return_same_way"
 msgstr "return same way"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -807,7 +1014,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -824,6 +1033,14 @@ msgstr ""
 msgid "route_types"
 msgstr "Route types"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr "shelter"
@@ -834,6 +1051,10 @@ msgstr "skitouring"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -872,6 +1093,14 @@ msgstr "traverse"
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr "via ferrata"
@@ -897,7 +1126,7 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr "waypoint type"
 
@@ -905,15 +1134,10 @@ msgstr "waypoint type"
 msgid "weather_station"
 msgstr "weather station"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
-
-#~ msgid "Forgotten password?"
-#~ msgstr "Forgotten password?"
-
-#~ msgid "coordinates"
-#~ msgstr "Coordinates"
-
-#~ msgid "Authentication"
-#~ msgstr "Authentication"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -10,6 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -18,7 +19,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -35,7 +35,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -43,20 +42,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -94,7 +89,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -104,6 +98,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -139,7 +145,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -183,6 +188,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -192,7 +201,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -218,7 +226,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -227,7 +235,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -235,7 +242,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -260,7 +267,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -280,12 +287,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -323,10 +329,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -340,6 +342,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -361,7 +364,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Itinerarios"
 
@@ -389,6 +391,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
@@ -425,7 +431,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -442,14 +447,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr ""
 
@@ -466,14 +469,26 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -485,6 +500,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -493,11 +516,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -513,8 +545,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -525,12 +569,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -542,23 +606,39 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -573,6 +653,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -585,16 +669,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -622,6 +723,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -640,7 +749,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -677,6 +800,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -684,6 +819,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -703,8 +846,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -747,8 +902,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -759,12 +924,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -775,15 +956,40 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -792,6 +998,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -807,7 +1014,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -824,6 +1033,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -834,6 +1051,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -872,6 +1093,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -897,12 +1126,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -17,7 +18,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -34,7 +34,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -42,20 +41,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -93,7 +88,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -103,6 +97,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -138,7 +144,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -182,6 +187,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -191,7 +200,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -217,7 +225,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -226,7 +234,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -234,7 +241,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -259,7 +266,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -279,12 +286,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -322,10 +328,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -339,6 +341,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -360,7 +363,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Ibilbideak"
 
@@ -388,6 +390,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
@@ -424,7 +430,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -441,14 +446,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr ""
 
@@ -465,14 +468,26 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -484,6 +499,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -492,11 +515,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -512,8 +544,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -524,12 +568,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -541,23 +605,39 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -572,6 +652,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -584,16 +668,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -621,6 +722,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -639,7 +748,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -676,6 +799,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -683,6 +818,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -702,8 +845,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -746,8 +901,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -758,12 +923,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -774,15 +955,40 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -791,6 +997,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -806,7 +1013,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -823,6 +1032,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -833,6 +1050,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -871,6 +1092,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -896,12 +1125,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -7,6 +7,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr "Accès"
 
@@ -15,7 +16,6 @@ msgid "Accident database"
 msgstr "Base accidents"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr "Ajouter"
 
@@ -32,7 +32,6 @@ msgid "Add association"
 msgstr "Ajouter une association"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr "Ajouter aux favoris"
 
@@ -40,21 +39,17 @@ msgstr "Ajouter aux favoris"
 msgid "Articles"
 msgstr "Articles"
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr "Itinéraires associés"
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr "Points de passage associés"
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
 msgstr "L'Association C2C"
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
-msgstr "Associations"
 
 #: c2corg_ui/templates/document/history.html
 msgid "Author"
@@ -91,7 +86,6 @@ msgid "Comment about the changes"
 msgstr "Courte description des changements"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr "Commentaires"
 
@@ -102,6 +96,18 @@ msgstr "Comparer les versions sélectionnées"
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
 msgstr "Comparaison des documents"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
+msgstr ""
 
 #: c2corg_ui/templates/document/history.html
 msgid "Created on"
@@ -136,7 +142,6 @@ msgid "Document has been protected"
 msgstr "Le document a été verrouillé."
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr "Modifier"
 
@@ -180,6 +185,10 @@ msgstr "Edition d'un point de passage"
 msgid "Email"
 msgstr "Adresse email"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr "Impossible d'associer ce document"
@@ -189,7 +198,6 @@ msgid "Failed to unassociate document"
 msgstr "Impossible de dissocier ce document"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr "Favoris"
 
@@ -215,7 +223,7 @@ msgid "GPS Track"
 msgstr "Tracé GPS"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr "Général"
 
@@ -224,7 +232,6 @@ msgid "Has lift access"
 msgstr "Remontée mécanique"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr "Versions"
 
@@ -232,7 +239,7 @@ msgstr "Versions"
 msgid "Home"
 msgstr "Accueil"
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr "Informations"
 
@@ -257,7 +264,7 @@ msgid "List of versions for language:"
 msgstr "Liste des versions pour la langue :"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr "Situation"
 
@@ -277,12 +284,11 @@ msgstr "Se déconnecter"
 msgid "Longitude"
 msgstr "Longitude"
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr "Cartes"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr "Plus"
 
@@ -320,10 +326,6 @@ msgstr "Pas de changement."
 msgid "No description available"
 msgstr "Pas de description disponible"
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr "Pas d'informations sur le matériel nécessaire"
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr "Aucune carte associée"
@@ -337,6 +339,7 @@ msgid "Previous"
 msgstr "Précédent"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr "Cotation"
 
@@ -360,7 +363,6 @@ msgstr "Version du"
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Itinéraires"
 
@@ -390,6 +392,10 @@ msgstr "Sélectionner"
 msgid "Short description of the applied changes"
 msgstr "Courte description des changements appliqués"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
+msgstr ""
+
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
@@ -417,14 +423,13 @@ msgstr "Le titre doit comporter au moins 3 caractères."
 
 #: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "To page head"
-msgstr "Retourner au début de la page"
+msgstr "Haut de page"
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr "Traduire dans une autre langue"
 
@@ -441,14 +446,12 @@ msgid "Version 2 in"
 msgstr "Version 2 en"
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr "Voir dans une autre langue"
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr "Points de passage"
 
@@ -465,15 +468,27 @@ msgstr "Oui"
 msgid "You are viewing an archived version of this document."
 msgstr "Vous consultez une ancienne version de ce document."
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr "accès"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr "Période d'accès"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
 msgstr "Activités"
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
+msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "aid_rating"
@@ -484,6 +499,14 @@ msgid "already used username"
 msgstr "Cet identifiant est déjà utilisé."
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr "avril"
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr "août"
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr "camp de base"
 
@@ -492,12 +515,21 @@ msgid "bergschrund"
 msgstr "rimaye"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr "Méilleures périodes"
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr "bisse"
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
 msgstr "bivouac"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
+msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 #: c2corg_ui/templates/helpers/view.html
@@ -512,9 +544,21 @@ msgstr "catalan"
 msgid "camp_site"
 msgstr "camping"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr "Capacité"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
 msgstr "grotte"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "cliff"
@@ -524,34 +568,66 @@ msgstr "falaise"
 msgid "climbing_indoor"
 msgstr "SAE"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr "Types de grimpe intérieur"
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr "site de couenne/bloc"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr "Types de grimpe extérieur"
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
 msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
+msgstr "Styles de grimpe"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "configuration"
-msgstr ""
+msgstr "Configuration"
 
 #: c2corg_ui/templates/i18n.html
 msgid "confluence"
 msgstr "confluent"
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr "Pays"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr "Tutelle"
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr "allemand"
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr "décembre"
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr "Altitude"
@@ -559,6 +635,10 @@ msgstr "Altitude"
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
 msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
+msgstr "Elévation min"
 
 #: c2corg_ui/templates/i18n.html
 msgid "en"
@@ -570,6 +650,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "equipment_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -584,16 +668,33 @@ msgstr "basque"
 msgid "expedition"
 msgstr "expédition"
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "feb"
+msgstr "février"
+
+#: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr "français"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr "Matériel"
 
@@ -621,6 +722,14 @@ msgstr "Cotation globale"
 msgid "green"
 msgstr "vert"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr "Types de terrain"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -639,7 +748,21 @@ msgstr "Dénivelé négatif"
 msgid "height_diff_up"
 msgstr "Dénivelé positif"
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr "Hauteur max"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr "Hauteur médiane"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr "Hauteur min"
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr "Hauteurs"
 
@@ -676,6 +799,18 @@ msgid "it"
 msgstr "italien"
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr "janvier"
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr "juillet"
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr "fuin"
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr "lac"
 
@@ -684,6 +819,14 @@ msgstr "lac"
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr "Langue"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr "Longueur"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
+msgstr "Remontée mécanique"
 
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
@@ -702,9 +845,21 @@ msgid "loop_hut"
 msgstr "boucle avec retour au refuge"
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
-msgstr "Références cartographiques"
+msgstr "Cartes"
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr "mars"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
+msgstr "mai"
 
 #: c2corg_ui/templates/i18n.html
 msgid "misc"
@@ -746,8 +901,18 @@ msgstr ""
 msgid "next difference"
 msgstr "différence suivante"
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr "novembre"
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -758,13 +923,29 @@ msgstr "parapente"
 msgid "paragliding_landing"
 msgstr "atterrissage parapente"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr "décollage parapente"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr "Parking payant"
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr "col"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr "Téléphone"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
@@ -774,15 +955,40 @@ msgstr "gouffre"
 msgid "previous difference"
 msgstr "différence précédente"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr "Types de produits"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr "Transports publics"
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
 msgstr "raid"
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
+msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr "rouge"
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr "Remarques"
 
@@ -791,6 +997,7 @@ msgid "return_same_way"
 msgstr "aller-retour"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -806,7 +1013,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -816,12 +1025,20 @@ msgstr "itinéraire"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "route_length"
-msgstr ""
+msgstr "Longueur de l'itinéraire"
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "route_types"
 msgstr "Type d'itinéraire"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr "Quantité des itinéraires"
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr "septembre"
 
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
@@ -833,6 +1050,10 @@ msgstr "ski, surf"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr "Pente"
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -871,6 +1092,14 @@ msgstr "traversée"
 msgid "type"
 msgstr "Type"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr "URL"
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr "très sûr"
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr "via ferrata"
@@ -896,7 +1125,7 @@ msgid "waypoint"
 msgstr "point de passage"
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr "Type"
 
@@ -904,6 +1133,16 @@ msgstr "Type"
 msgid "weather_station"
 msgstr "station météo"
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
+
+#~ msgid "Associations"
+#~ msgstr "Associations"
+
+#~ msgid "No gear info"
+#~ msgstr "Pas d'informations sur le matériel nécessaire"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -10,6 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
 msgstr ""
 
@@ -18,7 +19,6 @@ msgid "Accident database"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add"
 msgstr ""
 
@@ -35,7 +35,6 @@ msgid "Add association"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Add to favorites"
 msgstr ""
 
@@ -43,20 +42,16 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated routes"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Associated waypoints"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Association"
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/view.html
-msgid "Associations"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -94,7 +89,6 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Comments"
 msgstr ""
 
@@ -104,6 +98,18 @@ msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "Comparing documents"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Contact"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new route"
+msgstr ""
+
+#: c2corg_ui/templates/base.html
+msgid "Create a new waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/document/history.html
@@ -139,7 +145,6 @@ msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Edit"
 msgstr ""
 
@@ -183,6 +188,10 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Equipment"
+msgstr ""
+
 #: c2corg_ui/static/js/apiservice.js
 msgid "Failed to associate document"
 msgstr ""
@@ -192,7 +201,6 @@ msgid "Failed to unassociate document"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Favorites"
 msgstr ""
 
@@ -218,7 +226,7 @@ msgid "GPS Track"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "General"
 msgstr ""
 
@@ -227,7 +235,6 @@ msgid "Has lift access"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "History"
 msgstr ""
 
@@ -235,7 +242,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "Informations"
 msgstr ""
 
@@ -260,7 +267,7 @@ msgid "List of versions for language:"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Location"
 msgstr ""
 
@@ -280,12 +287,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "More"
 msgstr ""
 
@@ -323,10 +329,6 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "No gear info"
-msgstr ""
-
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr ""
@@ -340,6 +342,7 @@ msgid "Previous"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Rating"
 msgstr ""
 
@@ -361,7 +364,6 @@ msgstr ""
 
 #: c2corg_ui/templates/route/filters.html c2corg_ui/templates/route/index.html
 #: c2corg_ui/templates/waypoint/filters.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Routes"
 msgstr "Itinerari"
 
@@ -389,6 +391,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Short description of the applied changes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
@@ -425,7 +431,6 @@ msgid "Topoguide"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Translate into an other lang"
 msgstr ""
 
@@ -442,14 +447,12 @@ msgid "Version 2 in"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "View in other lang"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/index.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "Waypoints"
 msgstr ""
 
@@ -466,14 +469,26 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
 msgid "access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_period"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "access_time"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "activities"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "admin_limits"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -485,6 +500,14 @@ msgid "already used username"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "apr"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "aug"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "base_camp"
 msgstr ""
 
@@ -493,11 +516,20 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "best_periods"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "bisse"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "bivouac"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "blanket_unstaffed"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -513,8 +545,20 @@ msgstr ""
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "capacity_staffed"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "children_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -525,12 +569,32 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_indoor_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_median"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_rating_min"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "climbing_styles"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -542,23 +606,39 @@ msgid "confluence"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "country"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "custodianship"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "de"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "dec"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "elevation"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "elevation min/max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "elevation_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -573,6 +653,10 @@ msgstr ""
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "equipment_ratings"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "es"
 msgstr ""
@@ -585,16 +669,33 @@ msgstr ""
 msgid "expedition"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "exposed"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "exposition_rating"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "exposition_rock_rating"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "feb"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "gas_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr ""
 
@@ -622,6 +723,14 @@ msgstr ""
 msgid "green"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "ground_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "heating_unstaffed"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "height_diff_access"
 msgstr ""
@@ -640,7 +749,21 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_max"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_median"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "height_min"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heights"
 msgstr ""
 
@@ -677,6 +800,18 @@ msgid "it"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "jan"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jul"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "jun"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "lake"
 msgstr ""
 
@@ -684,6 +819,14 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "length"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "lift_access"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -703,8 +846,20 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "mar"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "matress_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "may"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -747,8 +902,18 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "oct"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
-msgid "orientations"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "orientation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -759,12 +924,28 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "paragliding_rating"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "parking_fee"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "phone_custodian"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -775,15 +956,40 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "product_types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "prominence"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_types"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "rain_proof"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
 msgid "red"
 msgstr ""
 
-#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/view.html
 msgid "remarks"
 msgstr ""
 
@@ -792,6 +998,7 @@ msgid "return_same_way"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "risk_rating"
 msgstr ""
 
@@ -807,7 +1014,9 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
 
@@ -824,6 +1033,14 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "routes_quantity"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "sep"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
 msgstr ""
@@ -834,6 +1051,10 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "slope"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "snow_clearance_rating"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -872,6 +1093,14 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "url"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "very_safe"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "via_ferrata"
 msgstr ""
@@ -897,12 +1126,16 @@ msgid "waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
-#: c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "weather_station"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/static/js/documentdetailsview.js
+++ b/c2corg_ui/static/js/documentdetailsview.js
@@ -14,14 +14,21 @@ app.viewDetailsDirective = function() {
     bindToController: true,
     link: function(el, scope, attrs, ctrl) {
       var s = app.constants.SCREEN;
+      var notPhone  = window.matchMedia('(max-width: ' + s.SMARTPHONE + 'px)');
+      var onPhone  = window.matchMedia('(min-width: ' + (s.SMARTPHONE + 1) + 'px)');
+      $('.location-static').css({top: $('app-map').offset().top + 40});
 
       // show tabs if they have been hidden on smartphone and inversely
       $(window).resize(function() {
         if (window.innerWidth > s.SMARTPHONE) {
           $('.tab, .accordion').show();
         }
-        // show description tab by default or selected tab
-        if (window.innerWidth < s.SMARTPHONE) {
+
+      // show description tab by default or selected tab
+      notPhone.addListener(function(mql) {
+        if (mql.matches) {
+          $('.location-static').css({top: $('app-map').offset().top + 40});
+
           $('.tab').hide();
           if (!ctrl.selected) {
             $('.view-details-description').show();

--- a/c2corg_ui/static/js/documentdetailsview.js
+++ b/c2corg_ui/static/js/documentdetailsview.js
@@ -16,19 +16,20 @@ app.viewDetailsDirective = function() {
       var s = app.constants.SCREEN;
       var notPhone  = window.matchMedia('(max-width: ' + s.SMARTPHONE + 'px)');
       var onPhone  = window.matchMedia('(min-width: ' + (s.SMARTPHONE + 1) + 'px)');
+
       $('.location-static').css({top: $('app-map').offset().top + 40});
 
       // show tabs if they have been hidden on smartphone and inversely
-      $(window).resize(function() {
-        if (window.innerWidth > s.SMARTPHONE) {
+      onPhone.addListener(function(mql) {
+        if (mql.matches) {
           $('.tab, .accordion').show();
         }
+      })
 
       // show description tab by default or selected tab
       notPhone.addListener(function(mql) {
         if (mql.matches) {
           $('.location-static').css({top: $('app-map').offset().top + 40});
-
           $('.tab').hide();
           if (!ctrl.selected) {
             $('.view-details-description').show();
@@ -36,14 +37,15 @@ app.viewDetailsDirective = function() {
             ctrl.selected.show();
           }
         }
-        return;
       });
+
       $('.heading').click(function() {
-        var icon = $(this).find('.glyphicon');
-        if (icon.hasClass('glyphicon-menu-down')) {
-          icon.toggleClass('rotate-arrow-up');
-        } else if (icon.hasClass('glyphicon-menu-right')) {
-          icon.toggleClass('rotate-arrow-down');
+        var menuDown = $(this).find('.glyphicon-menu-down');
+        var menuUp = $(this).find('.glyphicon-menu-right');
+        if (menuDown) {
+          menuDown.toggleClass('rotate-arrow-up');
+        } else if (menuUp) {
+          menuUp.toggleClass('rotate-arrow-down');
         }
         return;
       });

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -126,22 +126,22 @@ app.DocumentEditingController = function($scope, $element, $attrs,
   // When creating a new document, the model is not created until
   // the form is touched. At least create an empty object.
   this.scope_[this.modelName_] = {};
-
-  if (this.id_ && this.lang_) {
-    if (this.auth_.isAuthenticated()) {
-      // Get document attributes from the API to feed the model:
+  if (this.auth_.isAuthenticated()) {
+    if (this.id_ && this.lang_) {
+     // Get document attributes from the API to feed the model:
       goog.asserts.assert(!goog.isNull(this.id_));
       goog.asserts.assert(!goog.isNull(this.lang_));
       this.api_.readDocument(this.module_, this.id_, this.lang_).then(
           this.successRead_.bind(this)
       );
-    } else {
-      // Redirect to the auth page
-      var current_url = window.location.href;
-      window.location.href = '{authUrl}?from={redirect}'
-          .replace('{authUrl}', this.authUrl_)
-          .replace('{redirect}', encodeURIComponent(current_url));
     }
+  } else {
+    // Redirect to the auth page
+    var current_url = window.location.href;
+    window.location.href = '{authUrl}?from={redirect}'
+        .replace('{authUrl}', this.authUrl_)
+        .replace('{redirect}', encodeURIComponent(current_url));
+    return;
   }
 
   this.scope_.$root.$on('mapFeatureChange', function(event, feature) {

--- a/c2corg_ui/static/js/style/sidemenu.js
+++ b/c2corg_ui/static/js/style/sidemenu.js
@@ -17,4 +17,8 @@ app.sidemenu = function() {
     }
   });
 
+  $('.menu-open-close').click(function() {
+    $('.menu-open-close.menu').toggleClass('is-active');
+  })
+
 };

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -61,7 +61,21 @@ closure_library_path = settings.get('closure_library_path')
       </div>
     </div>
     <app-alerts></app-alerts>
-
+    <div id="empty-results">
+        <div class="tt-dataset empty">
+          <div class="header">No results</div>
+          <p>
+            <a class="btn btn-default tt-suggestion" href="${request.route_url('routes_add')}">
+              <span translate>Create a new route</span><span class="glyphicon glyphicon-plus-sign text-right"></span>
+            </a>
+          </p>
+          <p>
+            <a class="btn btn-default tt-suggestion" href="${request.route_url('waypoints_add')}">
+              <span translate>Create a new waypoint</span><span class="glyphicon glyphicon-plus-sign text-right"></span>
+            </a>
+          </p>
+        </div>
+    </div>
 % if debug:
     <script>
       // We should really use the empty string for CLOSURE_BASE_PATH for there

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -26,7 +26,7 @@
     <h2><span class="glyphicon glyphicon-warning-sign"></span>&nbsp;<span translate>You are viewing an archived version of this document.</span></h2>
     <div class="text-left">
       <p><b translate>Date</b>: {{'${1000 * version['written_at']}' | date:'medium'}} &nbsp;<span translate>by</span>&nbsp; <a href="#TODO">${version['username']}</a></p>
-      <p><b translate>Changes</b>: ${show_version_comment(version)}</p>
+      <p><b translate>Changes</b>: <span x-translate>${show_version_comment(version)}</span></p>
     </div>
     <p class="text-center">
         <a href="${request.route_url(module + '_view', id=document['document_id'], lang=locale['lang'])}">
@@ -85,7 +85,6 @@
 </%def>
 
 <%def name="show_associated_waypoints(document, type=None)">\
-  % if 'waypoints' in document['associations']:
     % for w in document['associations']['waypoints']:
       % if type is None or type == w['waypoint_type']:
       <div class="list-item">
@@ -94,37 +93,34 @@
       </div>
       % endif
     % endfor
-  % endif
 </%def>
 
 <%def name="show_associated_routes(document)">\
-  % if 'routes' in document['associations']:
     % for r in document['associations']['routes']:
     <div class="list-item">
       <a href="${request.route_url('routes_view', id=r['document_id'], lang=r['locales'][0]['lang'])}">${r['locales'][0]['title']}</a>
       <app-delete-association parent-id="${document['document_id']}" child-id="${r['document_id']}"></app-delete-association>
     </div>
     % endfor
-  % endif
 </%def>
 
 <%def name="show_maps(document)">\
-  % if len(document['maps']) > 0:
+  % if document.get('maps') and len(document['maps']) > 0:
     <ul>
-    % for m in document['maps']:
-      <li>${m['editor']} ${m['locales'][0]['title']}</li>
-    % endfor
+      % for m in document['maps']:
+        <li class="text-left"><b>${m['editor']}</b><br> ${m['locales'][0]['title']}</li>
+      % endfor
     </ul>
   % else :
-  <p translate>No maps associated</p>
+    <h4 translate>No maps associated</h4>
   % endif
 </%def>
 
 <%def name="show_areas(document)">\
   % if document.get('areas'):
     <ul>
-      % for a in document['areas']:
-        <li><span x-translate>${a['area_type']}</span> : <b>${a['locales'][0]['title']}</b></li>
+      % for a in reversed(document['areas']):
+        <li ng-cloak>${a['locales'][0]['title']}</li>
       % endfor
     </ul>
   % endif

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -93,3 +93,32 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 
 <!-- home -->
 <span translate>Home</span>
+
+<!--waypoint attributes-->
+<span translate>rain_proof</span>
+<span translate>very_safe</span>
+<span translate>exposed</span>
+<span translate>rock_types</span>
+<span translate>best_periods</span>
+<span translate>climbing_styles</span>
+<span translate>orientation</span>
+<span translate>height_max</span>
+<span translate>climbing_rating_min</span>
+<span translate>climbing_rating_median</span>
+<span translate>admin_limits</span>
+<span translate>country</span>
+<span translate>range</span>
+
+<!--months-->
+<span translate>jan</span>
+<span translate>feb</span>
+<span translate>mar</span>
+<span translate>apr</span>
+<span translate>may</span>
+<span translate>jun</span>
+<span translate>jul</span>
+<span translate>aug</span>
+<span translate>sep</span>
+<span translate>nov</span>
+<span translate>oct</span>
+<span translate>dec</span>

--- a/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+++ b/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1,22 +1,26 @@
-<%namespace file="../../helpers/view.html" import="show_areas, show_attr"/>
+<%namespace file="../../helpers/view.html" import="show_areas, show_attr, show_maps"/>
 
 ## LOCATION
 <%def name="get_route_location(route)">\
-  <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
-    <h4><span translate>Location</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-    <div class="name-icon">
-      <span class="glyphicon glyphicon-map-marker"></span>
-      <p translate>Location</p>
-    </div>
-    <span class="detail-text accordion">
-      ${show_areas(route)}
-      
-      % if route.get('orientations'):
-      <p><span translate>orientations</span>: <b>${route['orientations']}</b></p>
-      % endif
+  % if route.get('areas') or route.get('orientation'):
+    <div class="name-icon-value location" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Location</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <p translate>Location</p>
+      </div>
+      <span class="detail-text accordion">
+        ${show_areas(route)}
 
-    </span>
-  </div>
+      % if route.get('orientation'):
+        <p><span translate>orientation</span>:</p>
+        % for orient in route['orientation'] :
+          <span x-translate>${orient}</span>
+        % endfor
+      % endif
+      </span>
+    </div>
+  % endif
 </%def>
 
 ## GENERAL
@@ -30,37 +34,55 @@
     <span class="detail-text accordion">
 
       % if route.get('route_types'):
-      <div ng-init="route_types = ${route['route_types']}">
+      <article>
         <b translate>route_types</b><br>
         <ul>
-          <li ng-repeat="type in route_types" ng-cloak>{{mainCtrl.translate(type)}}</li>
+          % for type in route['route_types'] :
+          <li x-translate>${type}</li>
+          % endfor
         </ul>
-      </div>
+      </article>
       % endif
-
-      % if route['activities']:
-      <div ng-init="route_activites = ${route['activities']}">
-        <b translate>activities</b>:
+    
+      % if route.get('activities'):
+      <article>
+        <b translate>activities</b><br>
         <ul>
-          <li ng-repeat="activity in route_activites" ng-cloak>{{mainCtrl.translate(activity)}}{{$last ? '' : ', '}}</li>
+          % for activity in route['activities'] :
+          <li x-translate>${activity}</li>
+          % endfor
         </ul>
-      </div>
+      </article>
       % endif
 
+      % if route.get('rock_types'):
+      <article>
+        <b translate>rock_types</b><br>
+        <ul>
+          % for type in route['rock_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+      % endif
+      
+      % if route.get('climbing_outdoor_types'):
+      <article>
+        <b translate>climbing_outdoor_types</b><br>
+        <ul>
+          % for type in route['climbing_outdoor_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+      % endif
+      
       % if route.get('configuration'):
       <p><span translate>configuration</span>: <b>${','.join(route['configuration'])}</b></p>
       % endif
 
-      % if route.get('global_rating'):
-      <p><span translate>global_rating</span>: <b>${route['global_rating']}</b></p>
-      % endif
-
       % if locale.get('slope'):
       <p><span translate>slope</span>: <b>${locale['slope']}</b></p>
-      % endif
-
-      % if route.get('rock_types'):
-      <p><span translate>rock_types</span>: <b>${route['rock_types']}</b></p>
       % endif
 
       % if route.get('aid_rating'):
@@ -75,9 +97,6 @@
       <p><span translate>mtb_length_trail</span>: <b>${route['mtb_length_trail']}</b></p>
       % endif
 
-      % if route.get('climbing_outdoor_types'):
-      <p><span translate>climbing_outdoor_types</span>: <b>${route['climbing_outdoor_types']}</b></p>
-      % endif
     </span>
   </div>
 </%def>
@@ -85,6 +104,10 @@
 
 ## RATING  
 <%def name="get_route_rating(route)">\
+% if route.get('global_rating') or route.get('engagement_rating') or route.get('risk_rating') or route.get('exposition_rock_rating') \
+  or route.get('rock_free_rating') or route.get('rock_required_rating') or route.get('rock_required_rating') or route.get('hiking_rating') \
+  or route.get('hiking_mtb_exposition') or route.get('ice_rating') or route.get('mixed_rating') or route.get('snowshoe_rating')  \
+  or route.get('mtb_down_rating') or route.get('mtb_up_rating') or route.get('via_ferrata_rating'):
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Rating</span><span class="glyphicon glyphicon-menu-right"></span></h4>
     <div class="name-icon">
@@ -92,7 +115,10 @@
       <p translate>Rating</p>
     </div>
     <span class="detail-text accordion">
-
+      
+      % if route.get('global_rating'):
+      <p><span translate>global_rating</span>: <b>${route['global_rating']}</b></p>
+      % endif
 
       % if route.get('engagement_rating'):
       <p><span translate>engagement_rating</span>: <b>${route['engagement_rating']}</b></p>
@@ -147,35 +173,32 @@
       % endif
     </span>
   </div>
+  % endif
 </%def>
 
 
 ## GEAR  
 <%def name="get_route_gear(route, locale)">\
-  <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
-    <h4><span translate>gear</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-    <div class="name-icon">
-      <span class="glyphicon glyphicon-cog"></span>
-      <p translate>gear</p>
+  % if route.get('equipment_rating') or route.get('glacier_gear'):
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>gear</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-cog"></span>
+        <p translate>gear</p>
+      </div>
+      <span class="detail-text accordion">
+
+        % if route.get('equipment_rating'):
+        <p><span translate>equipment_rating</span>: <b>${route['equipment_rating']}</b></p>
+        % endif
+
+        % if route.get('glacier_gear'):
+        <p><span translate>glacier_gear</span>: <b>${route['glacier_gear']}</b></p>
+        % endif
+
+      </span>
     </div>
-    <span class="detail-text accordion">
-      % if locale.get('gear'):
-      <p>${show_attr(locale, 'gear')}</p>
-      % endif
-
-      % if route.get('equipment_rating'):
-      <p><span translate>equipment_rating</span>: <b>${route['equipment_rating']}</b></p>
-      % endif
-
-      % if route.get('glacier_gear'):
-      <p><span translate>glacier_gear</span>: <b>${route['glacier_gear']}</b></p>
-      % endif
-
-      % if not route.get('glacier_gear') and not route.get('equipment_rating') and not locale.get('gear'):
-      <p translate>No gear info</p>
-      % endif
-    </span>
-  </div>
+  % endif
 </%def>
 
 
@@ -220,7 +243,7 @@
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Access</span><span class="glyphicon glyphicon-menu-right"></span></h4>
     <div class="name-icon">
-      <span class="glyphicon glyphicon-screenshot"></span>
+      <span class="glyphicon glyphicon-road"></span>
       <p translate>Access</p>
     </div>
     <span class="detail-text accordion" ng-init="lift_access = ${route['lift_access']}">
@@ -229,9 +252,25 @@
       <b ng-cloak>{{lift_access == 'None' ? mainCtrl.translate('No'): mainCtrl.translate('Yes')}}</b>
 
       % if route.get('height_diff_access'):
-      <p><span translate>height_diff_access</span>: <b>${route['height_diff_access']}</b></p>
+        <p><span translate>height_diff_access</span>: <b>${route['height_diff_access']}</b></p>
       % endif
       
     </span>
   </div>
+</%def>
+
+## MAPS
+<%def name="get_route_associated_maps(route)">\
+  % if route.get('maps'):
+  <div class="name-icon-value maps" ng-click="detailsCtrl.openTab($event)">
+    <h4><span translate>Maps</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+    <div class="name-icon">
+      <span class="glyphicon glyphicon-globe"></span>
+      <p translate>Maps</p>
+    </div>
+    <span class="detail-text accordion" ng-init="lift_access = ${route['lift_access']}">
+        ${show_maps(route)} 
+    </span>
+  </div>
+  % endif
 </%def>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -6,7 +6,9 @@ from c2corg_ui.templates.utils import get_lang_lists
     show_other_langs_links, show_archive_data, show_route_title, show_associated_waypoints,
     show_associated_routes, show_areas, show_float_buttons, show_maps" />
 <%namespace file="helpers/detailed_route_attributes.html" import="get_route_gear, get_route_location, 
-  get_route_rating, get_route_general, get_route_heights,  get_route_access" />
+  get_route_rating, get_route_general, get_route_heights,  get_route_access, get_route_associated_maps" 
+ />
+
 <%
 route_id = route['document_id']
 other_langs, missing_langs = get_lang_lists(route, lang)
@@ -25,7 +27,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 </%block>
 
 <header  class="view-details-title">
-  <h1>${show_route_title(locale)}<label class="badge" translate>route</label></h1>
+  <h1>${show_route_title(locale)}<label class="badge route" translate>route</label></h1>
 </header>
 
 <app-map class="view-details-map"></app-map>
@@ -42,10 +44,20 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   <uib-tabset app-view-details>
     <uib-tab heading="{{mainCtrl.translate('Description')}}" ng-click="detailsCtrl.openTab('description')" id="description-tab"></uib-tab>
     <uib-tab heading="{{mainCtrl.translate('Details')}}" ng-click="detailsCtrl.openTab('informations')"></uib-tab>
-    <uib-tab heading="{{mainCtrl.translate('Associations')}}" ng-click="detailsCtrl.openTab('associations')"></uib-tab>
+    % if route.get('associations'):
+      % if 'routes' in route['associations']  or 'waypoint' in route['associations']  :
+        <uib-tab heading="{{mainCtrl.translate('Associations')}}" ng-click="detailsCtrl.openTab('associations')"></uib-tab>
+      % endif
+    % endif
   </uib-tabset>
-
-
+  
+    % if route.get('maps'):
+      <article class="location-static">
+        <span class="pin"></span>
+        ${show_areas(route)}
+      </article>
+    % endif
+  
   <div class="thumbnail view-details-informations tab  col-sm-12">
     <h3 class="heading informations" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
@@ -57,6 +69,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
       ${get_route_gear(route, locale)}
       ${get_route_rating(route)}
       ${get_route_access(route)}
+      ${get_route_associated_maps(route)}
     </section>
   </div> 
 
@@ -66,22 +79,30 @@ other_langs, missing_langs = get_lang_lists(route, lang)
       <div id="document-description" class="collapse in">
 
         % if locale['summary']:
-        <summary class="document-summary">
-          <label translate>summary</label><br>
-          "${locale['summary']}"
-        </summary>
+          <summary class="document-summary">
+            <label translate>summary</label><br>
+            ${show_attr(locale, 'summary')}
+          </summary>
         % endif
 
         % if locale['description']:
-        ${show_attr(locale, 'description')}
+          ${show_attr(locale, 'description')}
+        % endif
+
+        % if locale['gear']:
+          <div class="document-gear">
+            <label translate>gear</label><br>
+            ${show_attr(locale, 'gear')}
+          </div>
         % endif
 
         % if locale['remarks']:
-        <div class="document-remarks">
-          <label translate>remarks</label><br>
-          "${locale['remarks']}"
-        </div>
+          <div class="document-remarks">
+            <label translate>remarks</label><br>
+            ${show_attr(locale, 'remarks')}
+          </div>
         % endif
+        
       </div>
     </span>
   </div>
@@ -103,12 +124,12 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   % if not version:
   <div class="view-details-associations col-xs-12 tab">
     <span class="lead">
-
       <div ng-show="userCtrl.auth.isAuthenticated()">
         <label translate>Add association</label>:
         <app-add-association parent-id="${route_id}" added-documents="added"></app-add-association>
       </div>
       <section>
+        % if 'waypoints' in route['associations'] and  len(route['associations']['waypoints']) > 0 :
         <article>
           <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-waypoints">
             <span translate>Associated waypoints</span><span class="glyphicon glyphicon-menu-down"></span>
@@ -120,28 +141,21 @@ other_langs, missing_langs = get_lang_lists(route, lang)
             </div>
           </div>
         </article>
+        % endif
+        % if 'routes' in route['associations'] and  len(route['associations']['routes']) > 0 :
         <article>
           <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-routes">
             <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
           <div class="associated-documents collapse in" id="associated-routes">
-            <div class="list-item"></div>
-            <div class="list-item"></div>
-            <div class="list-item"></div>
             ${show_associated_routes(route)}
             <article ng-repeat="doc in added | filter:{'documentType': 'routes'}">
               <app-association-card parent-id="${route_id}" doc="doc" added-documents="added"></app-association-card>
             </article>
           </div>
         </article>
+        % endif
       </section>
-      <h3 class="heading" data-toggle="collapse" data-target="#associated-maps">
-        <span translate>Maps</span><span class="glyphicon glyphicon-menu-down"></span>
-      </h3>
-      <div class="collapse in" id="associated-maps">
-        ${show_maps(route)}
-      </div>
-
     </span>
   </div>
   % endif

--- a/c2corg_ui/templates/sidemenu.html
+++ b/c2corg_ui/templates/sidemenu.html
@@ -1,8 +1,7 @@
 <aside id="sidemenu">
   <div class="page-menu">
     <button class="btn btn-default menu-open-close menu">
-      <span class="glyphicon glyphicon-align-justify">
-        <a href="#sidemenu"></a>
+      <span>
       </span>
     </button>
     <a href="${request.route_url('index')}" title="{{'Back to homepage'|translate}}">

--- a/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+++ b/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -1,0 +1,395 @@
+<%namespace file="../../helpers/view.html" import="show_areas, show_attr, show_maps"/>
+
+## MAPSINFO
+<%def name="get_waypoint_maps_info(waypoint)">\
+  % if waypoint.get('maps_info') or waypoint.get('maps'):
+    <div class="name-icon-value maps" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>maps_info</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-globe"></span>
+        <p translate>maps_info</p>
+      </div>
+      <span class="detail-text accordion">
+        % if waypoint.get('maps_info'):
+          <p><span translate>maps_info</span>: <b>${waypoint['maps_info']}</b></p>
+        % endif
+        
+        ${show_maps(waypoint)}
+      </span>
+    </div>
+  % endif
+</%def>
+
+## GENERAL
+<%def name="get_waypoint_general(waypoint)">\
+<div class="name-icon-value general" ng-click="detailsCtrl.openTab($event)">
+  <h4><span translate>General</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+  <div class="name-icon">
+    <span class="glyphicon glyphicon-asterisk"></span>
+    <p translate>General</p>
+  </div>
+  <span class="detail-text accordion">
+    % if waypoint.get('waypoint_type'):
+      <p><span translate>waypoint_type</span>: <b x-translate>${waypoint['waypoint_type']}</b></p>
+    % endif
+
+    % if waypoint.get('orientation'):
+      <p><span translate>orientation</span>:</p>
+      % for orient in waypoint['orientation'] :
+        <span x-translate>${orient}</span>
+      % endfor
+    % endif
+
+    % if waypoint.get('climbing_indoor_types'):
+      <article>
+        <b translate>climbing_indoor_types</b><br>
+        <ul>
+          % for style in waypoint['climbing_indoor_types'] :
+          <li x-translate>${style}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('rock_types'):
+      <article>
+        <b translate>rock_types</b><br>
+        <ul>
+          % for type in waypoint['rock_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('climbing_outdoor_types') and waypoint['climbing_outdoor_types'][0] != '':
+      <article>
+        <b translate>climbing_outdoor_types</b><br>
+        <ul>
+          % for type in waypoint['climbing_outdoor_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('product_types'):
+      <article>
+        <b translate>product_types</b><br>
+        <ul>
+          % for type in waypoint['product_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('ground_types'):
+      <article>
+        <b translate>ground_types</b><br>
+        <ul>
+          % for type in waypoint['ground_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('weather_station_types'):
+      <article>
+        <b translate>weather_station_types</b><br>
+        <ul>
+          % for type in waypoint['weather_station_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+    % endif
+
+    % if waypoint.get('rain_proof'):
+    <p><span translate>rain_proof</span>: <b x-translate>${waypoint['rain_proof']}</b></p>
+    % endif
+
+    % if waypoint.get('children_proof'):
+    <p><span translate>children_proof</span>: <b x-translate>${waypoint['children_proof']}</b></p>
+    % endif
+
+    % if waypoint.get('capacity'):
+    <p><span translate>capacity</span>: <b>${waypoint['capacity']}</b></p>
+    % endif
+
+    % if waypoint.get('capacity_staffed'):
+    <p><span translate>capacity_staffed</span>: <b>${waypoint['capacity_staffed']}</b></p>
+    % endif
+
+    % if waypoint.get('length'):
+    <p><span translate>length</span>: <b>${waypoint['length']}</b></p>
+    % endif
+
+  </span>
+</div>
+</%def>
+
+## LOCATION
+<%def name="get_waypoint_location(waypoint, geometry4326)">\
+<div class="name-icon-value location" ng-click="detailsCtrl.openTab($event)">
+  <h4><span translate>Location</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+  <div class="name-icon">
+    <span class="glyphicon glyphicon-map-marker"></span>
+    <p translate>Location</p>
+  </div>
+  <span class="detail-text accordion">
+    % if not version:
+      ${show_areas(waypoint)}
+    % endif
+    <p>${round(geometry4326.x)} °E / ${round(geometry4326.y)} °N</p>
+  </span>
+</div>
+</%def>
+
+## HEIGHTS
+<%def name="get_waypoint_heights(waypoint)">\
+
+  % if waypoint.get('elevation') and ( waypoint.get('prominence') or waypoint.get('elevation_min') \
+    or waypoint.get('height_min')  or waypoint.get('height_max') \
+    or waypoint.get('prominence')  or waypoint.get('height_median') ):
+    
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>heights</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <p translate>heights</p>
+      </div>
+      <span class="detail-text accordion">
+
+        % if waypoint.get('prominence'):
+          <p><span translate>prominence</span>: <b>${waypoint['prominence']} m</b></p>
+        % endif
+
+        % if waypoint.get('elevation_min'):
+          <p><span translate>elevation_min</span>: <b>${waypoint['elevation_min']} m</b></p>
+        % endif
+
+        % if waypoint.get('elevation'):
+          <p class="show-phone elevation"><span translate>elevation</span>: <b>${waypoint['elevation']} m</b></p>
+        % endif
+
+        % if waypoint.get('height_min'):
+          <p><span translate>height_min</span>: <b>${waypoint['height_min']} m</b></p>
+        % endif
+
+        % if waypoint.get('height_max'):
+          <p><span translate>height_max</span>: <b>${waypoint['height_max']} m</b></p>
+        % endif
+
+        % if waypoint.get('height_median'):
+          <p><span translate>height_median</span>: <b>${waypoint['height_median']} m</b></p>
+        % endif
+
+      </span>
+    </div>
+  % endif
+</%def>
+
+## ACCESS
+<%def name="get_waypoint_access(waypoint, locale)">\
+  % if locale.get('access_period') or waypoint.get('access_period') or waypoint.get('access_time') or \
+   waypoint.get('best_periods') or  waypoint.get('public_transportation_types') or  waypoint.get('public_transportation_rating') or \
+   waypoint.get('parking_fee') or waypoint.get('snow_clearance_rating') or waypoint.get('lift_access') :
+
+  <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+    <h4><span translate>Access</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+    <div class="name-icon">
+      <span class="glyphicon glyphicon-road"></span>
+      <p translate>Access</p>
+    </div>
+    <span class="detail-text accordion">
+
+      % if locale.get('access_period'):
+        <p><span translate>access_period</span>: <b>${locale['access_period']}</b></p>
+      % endif
+
+      % if waypoint.get('access_period'):
+        <p><span translate>routes_quantity</span>: <b>${waypoint['routes_quantity']}</b></p>
+      % endif
+
+      % if waypoint.get('access_time'):
+        <p><span translate>access_time</span>: <b>${waypoint['access_time']}</b></p>
+      % endif
+      
+      % if waypoint.get('best_periods'):
+      <article>
+        <b translate>best_periods</b><br>
+        <ul>
+          % for month in waypoint['best_periods'] :
+          <li x-translate>${month}</li>
+          % endfor
+        </ul>
+      </article>
+      % endif
+      
+      % if waypoint.get('public_transportation_types'):
+      <article>
+        <b translate>public_transportation_types</b><br>
+        <ul>
+          % for type in waypoint['public_transportation_types'] :
+          <li x-translate>${type}</li>
+          % endfor
+        </ul>
+      </article>
+      % endif
+      
+      % if waypoint.get('public_transportation_rating'):
+        <p><span translate>public_transportation_rating</span>: <b>${waypoint['public_transportation_rating']}</b></p>
+      % endif
+
+      % if waypoint.get('parking_fee'):
+        <p><span translate>parking_fee</span>: <b>${waypoint['parking_fee']}</b></p>
+      % endif
+
+      % if waypoint.get('snow_clearance_rating'):
+        <p><span translate>snow_clearance_rating</span>: <b>${waypoint['snow_clearance_rating']}</b></p>
+      % endif
+
+      % if waypoint.get('lift_access'):
+        <p><span translate>lift_access</span>: <b>${waypoint['lift_access']}</b></p>
+      % endif
+    </span>
+  </div>
+ % endif
+</%def>
+
+## RATING  
+<%def name="get_waypoint_rating(waypoint)">\
+  % if waypoint.get('climbing_rating_max') or waypoint.get('risk_rating') or waypoint.get('climbing_rating_median') or waypoint.get('equipment_ratings') or  waypoint.get('paragliding_rating') or waypoint.get('exposition_rating') :
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Rating</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-sort-by-attributes"></span>
+        <p translate>Rating</p>
+      </div>
+      <span class="detail-text accordion">
+
+        % if waypoint.get('climbing_rating_max'):
+        <p><span translate>climbing_rating_min</span>: <b>${waypoint['climbing_rating_min']}</b></p>
+        % endif
+
+        % if waypoint.get('risk_rating'):
+          <p><span translate>risk_rating</span>: <b>${waypoint['risk_rating']}</b></p>
+        % endif
+
+        % if waypoint.get('climbing_rating_median'):
+          <p><span translate>climbing_rating_median</span>: <b>${waypoint['climbing_rating_median']}</b></p>
+        % endif
+        
+        % if waypoint.get('equipment_ratings'):
+        <article>
+          <b translate>equipment_ratings</b><br>
+          <ul>
+            % for activity in waypoint['equipment_ratings'] :
+            <li x-translate>${equipment_ratings}</li>
+            % endfor
+          </ul>
+        </article>
+        % endif
+
+        % if waypoint.get('paragliding_rating'):
+          <p><span translate>paragliding_rating</span>: <b>${waypoint['paragliding_rating']}</b></p>
+        % endif
+
+        % if waypoint.get('exposition_rating'):
+          <p><span translate>exposition_rating</span>: <b>${waypoint['exposition_rating']}</b></p>
+        % endif
+      </span>
+    </div>
+  % endif
+</%def>
+
+## STYLE  
+<%def name="get_waypoint_style(waypoint)">\
+  % if waypoint.get('climbing_styles'):
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Style</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-sunglasses"></span>
+        <p translate>Style</p>
+      </div>
+      <span class="detail-text accordion">
+        % if waypoint.get('climbing_styles'):
+        <article>
+          <b translate>climbing_styles</b><br>
+          <ul>
+            % for type in waypoint['climbing_styles'] :
+            <li x-translate>${type}</li>
+            % endfor
+          </ul>
+        </article>
+        % endif
+      </span>
+    </div>
+  % endif
+</%def>
+
+## CONTACT  
+<%def name="get_waypoint_contact(waypoint)">\
+  % if waypoint.get('url') and waypoint.get('phone') and waypoint.get('phone_custodian') and waypoint.get('custodianship') :
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Contact</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-phone-alt"></span>
+        <p translate>Contact</p>
+      </div>
+      <span class="detail-text accordion">
+
+        % if waypoint.get('url'):
+          <p><span translate>url</span>${waypoint['url']}</p>
+        % endif
+
+        % if waypoint.get('phone'):
+          <p><span translate>phone</span> ${waypoint['phone']}</p>
+        % endif
+
+        % if waypoint.get('phone_custodian'):
+          <p><span translate>phone_custodian</span> ${waypoint['phone_custodian']}</p>
+        % endif
+
+        % if waypoint.get('custodianship'):
+          <p><span translate>custodianship</span> ${waypoint['custodianship']}</p>
+        % endif
+
+      </span>
+    </div>
+  % endif
+</%def>
+
+## EQUIPMENT  
+<%def name="get_waypoint_equipment(waypoint)">\
+  % if waypoint.get('matress_unstaffed') and  waypoint.get('gas_unstaffed') and waypoint.get('heating_unstaffed') and waypoint.get('blanket_unstaffed') :
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Equipment</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-cutlery"></span>
+        <p translate>Equipment</p>
+      </div>
+      <span class="detail-text accordion">
+
+        % if waypoint.get('matress_unstaffed'):
+          <p><span translate>matress_unstaffed</span>${waypoint['matress_unstaffed']}</p>
+        % endif
+
+        % if waypoint.get('blanket_unstaffed'):
+          <p><span translate>blanket_unstaffed</span> ${waypoint['blanket_unstaffed']}</p>
+        % endif
+
+        % if waypoint.get('heating_unstaffed'):
+          <p><span translate>heating_unstaffed</span> ${waypoint['heating_unstaffed']}</p>
+        % endif
+
+        % if waypoint.get('gas_unstaffed'):
+          <p><span translate>gas_unstaffed</span> ${waypoint['gas_unstaffed']}</p>
+        % endif
+
+      </span>
+    </div>
+  % endif
+</%def>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -3,9 +3,10 @@ from c2corg_ui.templates.utils import get_lang_lists
 %>
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
+<%namespace file="helpers/detailed_waypoint_attributes.html" import="get_waypoint_equipment, get_waypoint_contact, get_waypoint_style, get_waypoint_rating, get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general, get_waypoint_maps_info"/>
 <%namespace file="../helpers/view.html" import="show_attr, show_short_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title, show_associated_waypoints,
-    show_associated_routes, show_areas, show_maps"/>
+    show_associated_routes, show_areas, show_maps, show_float_buttons"/>
 <%
 waypoint_id = waypoint['document_id']
 other_langs, missing_langs = get_lang_lists(waypoint, lang)
@@ -47,10 +48,19 @@ module.value('mapFeatureCollection', {
 </%block>
 
 <header class="view-details-title">
-  <h1>${locale['title']} <label class="badge" translate>waypoint</label></h1>
+  <h1>${locale['title']} <label class="badge waypoint" translate>waypoint</label></h1>
 </header>
 
 <app-map class="view-details-map"></app-map>
+
+<article class="location-static">
+  <span class="pin"></span>
+  ${show_areas(waypoint)}
+      % if waypoint.get('elevation'):
+        <p><span translate>elevation</span>: <b>${waypoint['elevation']} m</b></p>
+      % endif
+  <p>${round(geometry4326.x)} °E / ${round(geometry4326.y)} °N</p>
+</article>
 
 <section class="view-details-section" app-view-details>
   
@@ -63,148 +73,132 @@ module.value('mapFeatureCollection', {
       ${show_missing_langs_links('waypoints', waypoint, missing_langs)}
     % endif
   </div>
-  <uib-tabset>
-    <uib-tab heading="Description" ng-click="detailsCtrl.openTab('.view-details-description')"></uib-tab>
-    <uib-tab heading="Details" ng-click="detailsCtrl.openTab('.view-details-list')"></uib-tab>
-    <uib-tab heading="Associations" ng-click="detailsCtrl.openTab('.view-details-associations')"></uib-tab>
-  </uib-tabset>
-
-  <div class="thumbnail view-details-list col-xs-12 tab">
-    ## LOCATION
-    <div class="name-icon-value col-sm-6" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>Location</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-      <div class="name-icon">
-        <span class="glyphicon glyphicon-map-marker"></span>
-        <p translate>Location</p>
-      </div>
-      <span class="detail-text accordion">
-        % if not version:
-        ${show_areas(waypoint)}
-        % endif
-        <p>${round(geometry4326.x)} °E / ${round(geometry4326.y)} °N</p>
-      </span>
-    </div>
-
-    ## GENERAL
-    <div class="name-icon-value col-sm-6" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>General</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-      <div class="name-icon">
-        <span class="glyphicon glyphicon-stats"></span>
-        <p translate>General</p>
-      </div>
-      <span class="detail-text accordion">
-        <p><span translate>waypoint_type</span>: <b x-translate>${waypoint['waypoint_type']}</b></p>
-        <p><span translate>elevation</span>: <b>${waypoint['elevation']} m</b></p>
-      </span>
-    </div>
-
-    ## SUMMARY
-    % if locale['summary']:
-    <div class="name-icon-value col-sm-6" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>summary</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-      <div class="name-icon">
-        <span class="glyphicon glyphicon-list-alt"></span>
-        <p translate>summary</p>
-      </div>
-      <span class="detail-text accordion">
-        ${locale['summary']}
-      </span>
-    </div>
-    % endif
-
-    ## MAPSINFO
-    % if waypoint['maps_info']:
-    <div class="name-icon-value col-sm-6" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>maps_info</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-      <div class="name-icon">
-        <span class="glyphicon glyphicon-info-sign"></span>
-        <p translate>maps_info</p>
-      </div>
-      <span class="detail-text accordion">
-        <p><span translate>maps_info</span>:<b>${waypoint['maps_info']}</b></p>
-      </span>
-    </div>
-    % endif
-  </div>
-
-  ## DESCRIPTION
-  <div class="view-details-description col-xs-12 tab">
-    <span class="lead">
-      % if locale['description']:
-      <h3 translate class="text-center heading">description</h3>
-      ${show_attr(locale, 'description')}
-      % else :
-      <h3 class="text-center" translate>No description available</h3>
+  <uib-tabset app-view-details>
+    <uib-tab heading="{{mainCtrl.translate('Description')}}" ng-click="detailsCtrl.openTab('description')" id="description-tab"></uib-tab>
+    <uib-tab heading="{{mainCtrl.translate('Details')}}" ng-click="detailsCtrl.openTab('informations')"></uib-tab>
+    % if waypoint.get('associations'):
+      % if 'routes' in waypoint['associations'] or 'waypoint' in waypoint['associations']  :
+        <uib-tab heading="{{mainCtrl.translate('Associations')}}" ng-click="detailsCtrl.openTab('associations')"></uib-tab>
       % endif
+    % endif
+  </uib-tabset>
+  
+  <div class="thumbnail view-details-informations col-xs-12 tab">
+    <h3 class="heading informations" data-toggle="collapse" data-target="#document-informations">
+      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+    </h3>
+    <section id="document-informations" class="collapse in">
+      ${get_waypoint_general(waypoint)}
+      ${get_waypoint_location(waypoint, geometry4326)}
+      ${get_waypoint_contact(waypoint)}
+      ${get_waypoint_maps_info(waypoint)}
+      ${get_waypoint_rating(waypoint)}
+      ${get_waypoint_heights(waypoint)}
+      ${get_waypoint_equipment(waypoint)}
+      ${get_waypoint_style(waypoint)}
+      ${get_waypoint_access(waypoint, locale)}
+    </section>
+  </div>
+    
+  
+  ## DESCRIPTION
+  <div class="view-details-description col-xs-12 tab ">
+    <span class="lead">
+      <div id="document-description" class="collapse in">
+
+        % if locale['summary']:
+          <summary class="document-summary">
+            <label translate>summary</label><br>
+            ${show_attr(locale, 'summary')}
+          </summary>
+        % endif
+                
+        % if locale['description'] :
+          ${show_attr(locale, 'description')}
+        % else :
+          <h3 class="text-center" translate>No description available</h3>
+        % endif
+        
+        % if locale.get('remarks'):
+          <div class="document-remarks">
+            <label translate>remarks</label><br>
+            ${show_attr(locale, 'remarks')}
+          </div>
+        % endif
+        
+        % if locale.get('access'):
+          <div class="document-access">
+            <label translate>access</label><br>
+            ${show_attr(locale, 'access')}
+          </div>
+        % endif
+        
+      </div>
     </span>
   </div>
 
+    ## IMAGES
+  % if not version:
+  <div class="view-details-photos col-xs-12 tab">
+    <div class="photos">
+      <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgdmlld0JveD0iMCAwIDE0MCAxNDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzE0MHgxNDAKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTMwOTM2ZThhYyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1MzA5MzZlOGFjIj48cmVjdCB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjQ0LjA2MjUiIHk9Ijc0LjU1NjI1Ij4xNDB4MTQwPC90ZXh0PjwvZz48L2c+PC9zdmc+" alt="..." class="img-thumbnail">
+      <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgdmlld0JveD0iMCAwIDE0MCAxNDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzE0MHgxNDAKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTMwOTM2ZThhYyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1MzA5MzZlOGFjIj48cmVjdCB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjQ0LjA2MjUiIHk9Ijc0LjU1NjI1Ij4xNDB4MTQwPC90ZXh0PjwvZz48L2c+PC9zdmc+" alt="..." class="img-thumbnail">
+      <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgdmlld0JveD0iMCAwIDE0MCAxNDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzE0MHgxNDAKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTMwOTM2ZThhYyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1MzA5MzZlOGFjIj48cmVjdCB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjQ0LjA2MjUiIHk9Ijc0LjU1NjI1Ij4xNDB4MTQwPC90ZXh0PjwvZz48L2c+PC9zdmc+" alt="..." class="img-thumbnail">
+      <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgdmlld0JveD0iMCAwIDE0MCAxNDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzE0MHgxNDAKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTMwOTM2ZThhYyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1MzA5MzZlOGFjIj48cmVjdCB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjQ0LjA2MjUiIHk9Ijc0LjU1NjI1Ij4xNDB4MTQwPC90ZXh0PjwvZz48L2c+PC9zdmc+" alt="..." class="img-thumbnail">
+      <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgdmlld0JveD0iMCAwIDE0MCAxNDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzE0MHgxNDAKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTMwOTM2ZThhYyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1MzA5MzZlOGFjIj48cmVjdCB3aWR0aD0iMTQwIiBoZWlnaHQ9IjE0MCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjQ0LjA2MjUiIHk9Ijc0LjU1NjI1Ij4xNDB4MTQwPC90ZXh0PjwvZz48L2c+PC9zdmc+" alt="..." class="img-thumbnail">
+    </div>
+  </div>
+  % endif
+  
+  ## ASSOCIATIONS
   % if not version:
   <div class="view-details-associations col-xs-12 tab">
     <span class="lead">
-      <h3 class="text-center heading" translate>Associations</h3>
-      <div ng-show="userCtrl.auth.isAuthenticated()"><span translate>Add association</span>:
+
+      <div ng-show="userCtrl.auth.isAuthenticated()">
+        <label translate>Add association</label>:
         <app-add-association parent-id="${waypoint_id}" added-documents="added"></app-add-association>
       </div>
-      <div><span translate>Waypoints</span>: ${show_associated_waypoints(waypoint)}
-        <ul>
-          <li ng-repeat="doc in added | filter:{'documentType': 'waypoints'}">
-            <app-association-card parent-id="${waypoint_id}" doc="doc" added-documents="added"></app-association-card>
-          </li>
-        </ul>
-      </div>
-      <div><span translate>Routes</span>: ${show_associated_routes(waypoint)}
-        <ul>
-          <li ng-repeat="doc in added | filter:{'documentType': 'routes'}">
-            <app-association-card parent-id="${waypoint_id}" doc="doc" added-documents="added"></app-association-card>
-          </li>
-        </ul>
-      </div>
-      <div><span translate>Maps</span>: ${show_maps(waypoint)}</div>
+      <section>
+        % if 'waypoints' in waypoint['associations'] and  len(waypoint['associations']['waypoints']) > 0 :
+        <article>
+          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-waypoints">
+            <span class="glyphicon glyphicon-map-marker"></span>
+            <span translate>Associated waypoints</span><span class="glyphicon glyphicon-menu-down"></span>
+          </h3>
+          <div class="associated-documents collapse in" id="associated-waypoints">
+            ${show_associated_waypoints(waypoint)}
+            <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'waypoints'}">
+              <app-association-card parent-id="${waypoint_id}" doc="doc" added-documents="added"></app-association-card>
+            </article>
+          </div>
+        </article>
+        % endif
+        % if 'routes' in waypoint['associations'] and  len(waypoint['associations']['routes']) > 0 :
+        <article>
+          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-routes">
+            <span class="glyphicon glyphicon-road"></span>
+            <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
+          </h3>
+          <div class="associated-documents collapse in" id="associated-routes">
+            ${show_associated_routes(waypoint)} 
+            <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'routes'}">
+              <app-association-card parent-id="${waypoint_id}" doc="doc" added-documents="added"></app-association-card>
+            </article>
+          </div>
+        </article>
+        % endif
+      </section>
     </span>
   </div>
   % endif
 
   <div class="text-center col-xs-12">
-    <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span> <span class="glyphicon glyphicon-menu-up"></span></button>
+    <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span><span class="glyphicon glyphicon-menu-up"></span></button>
   </div>
 </section>
 
-<div class="float-buttons">
-  <div class="float-button float-edit" tooltip-placement="top" uib-tooltip="{{'Edit' | translate}}">
-    <app-edit-button ng-click="ebCtrl.redirect()" app-edit-button-url="${request.route_url('waypoints_edit', id=waypoint_id, lang=lang)}"></app-edit-button>
-    <span class="glyphicon glyphicon-edit"></span>
-    <p class="float-button-text" translate>Edit</p>
-  </div>
-  <div class="float-button float-favorite" tooltip-placement="top" uib-tooltip="{{'Add to favorites' | translate}}">
-    <span class="glyphicon glyphicon-heart"></span>
-    <p class="float-button-text" translate>Favorites</p>
-  </div>
-  <div class="float-button float-add" tooltip-placement="top" uib-tooltip="{{'Add' | translate}}">
-    <span class="glyphicon glyphicon-plus"></span>
-    <p class="float-button-text" translate>Add</p>
-  </div>
-  <div class="float-button float-comments" tooltip-placement="top" uib-tooltip="{{'Comments' | translate}}">
-    <span class="glyphicon glyphicon-comment"></span>
-    <p class="float-button-text" translate>Comments</p>
-  </div>
-  <div class="btn-group float-more float-button " uib-dropdown>
-    <span class="glyphicon glyphicon-th-list dropdown-toggle" uib-dropdown-toggle></span>
-    <p class="float-button-text" translate>More</p>
-    <ul class="dropdown-menu"  role="menu" aria-labelledby="dLabel">
-      <li><a href="${request.route_url('waypoints_history', id=waypoint_id, lang=lang)}" translate>History</a></li>
-      % if other_langs and not version:
-      <li ng-click="detailsCtrl.openModal('#other-langs')"><a translate>View in other lang</a></li>
-      % endif
-      % if missing_langs and not version:
-      <li ng-click="detailsCtrl.openModal('#missing-langs')"><a translate>Translate into an other lang</a></li>
-      % endif
-      <li role="separator" class="divider"></li>
-      <li><a href="#">Print</a></li>
-      <li><a href="#">Save</a></li>
-    </ul>
-  </div>
-</div>
+${show_float_buttons('waypoints', waypoint_id, lang, other_langs, missing_langs)}
 
 <script>
   window.onload = function() {

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -229,12 +229,12 @@ main {
   .heading{
     .flex();
     width: 100%;
+    padding: 5px;
     justify-content: space-between;
     margin-bottom: 10px;
     line-height: 1em;
     color: white;
     cursor: pointer;
-    padding: 5px;
     font-size: 1.2em;
     background-color: #FFB761;
     border: 1px solid transparent;
@@ -617,36 +617,26 @@ app-user{
   -moz-transition: width .5s ease-in-out !important;
   -o-transition: width .5s ease-in-out !important;
   transition: width .5s ease-in-out !important;
-  width: 160px !important;
+  width: 163px !important;
   visibility: visible !important;
   padding: 8px !important;
 }
 
 .search {
   background-color: #FBFBFB !important;
-  width : 150px;
+  width : 380px;
   height: 35px;
   border-radius: 0 5px 5px 0;
   border: none;
   -webkit-transition: width .5s ease;
   -moz-transition: width .5s ease;
   transition: width .5s ease;
-
-  &:focus, &:hover {
-    width: 200px;
-    -webkit-transition: width .5s ease;
-    -moz-transition: width .5s ease;
-    transition: width .5s ease;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    
-    @media @tablet {
-      width: 150px;
-    }
+  
+  @media @tablet {
+    width: 150px;
   }
   @media @phone {
-    width: 0px;
+     border: 1px solid bisque;
   }
 }
 
@@ -727,7 +717,26 @@ app-search {
       }
     }
   }
-
+  .search {
+    -webkit-transition: width .5s ease;
+    -moz-transition: width .5s ease;
+    transition: width .5s ease;
+    &:focus, &:hover {
+      width: 420px;
+      -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      outline: none;
+      border: 1px solid bisque;
+      @media @tablet {
+        width: 150px;
+      }
+    }
+    @media @phone {
+      width: 0px;
+      margin-left: -3px;
+    }
+  }
   .lang-user {
     .flex();
     width: 100%;

--- a/less/documentdetailsview.less
+++ b/less/documentdetailsview.less
@@ -16,7 +16,7 @@
     width: 80%;
     text-align: center;
     transition: 0.4s;
-    line-height: 50px;
+    line-height: 45px;
 
     @media @phone {
       font-size: 1.8em;
@@ -74,12 +74,11 @@
     text-align: justify;
     padding-left: 0;
     padding-right: 0;
-    padding-top: 10px;
     background: white;
     margin-bottom: 10px;
     border-radius: 5px;
     border: 1px solid #eee;
-    
+    padding-top: 10px;
     @media @phone {
       border-width: 2px;
     }
@@ -104,7 +103,6 @@
 
       @media (max-width: @screen-xs-max) {
         font-size: 14px;
-        padding-top: 10px;
       }
     }
   }
@@ -139,11 +137,17 @@
       margin-bottom: 10px;
       background: #EEE;
       width: 44%;
+      
+      a {
+        text-align: left; 
+     }
       @media @big {
         width: 49%;
       }
       @media @phone {
-        font-size: 1.4em;
+        a {
+          font-size: 1.3em;
+        }
       }
       @media @tablet {
         min-height: 90px;
@@ -153,11 +157,18 @@
     .associated-documents {
       margin-top: 10px;
       padding: 0 10px;
+      max-height: 500px;
+      overflow-y: scroll;
+      -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
       .flex();
       flex-flow: wrap;
-      overflow: hidden;
       justify-content: space-around;
       @media @big {
+        justify-content: space-between;
+      }
+      @media @phone{
         justify-content: space-between;
       }
       app-delete-association {
@@ -166,11 +177,16 @@
         right: 0;
         margin-bottom: 5px;
         margin-right: 5px;
+
         .glyphicon {
           color: white;
         }
         button {
           padding: 5px;
+          @media (max-width: @screen-sm-min)  {
+                padding: 7px 3px 3px 3px;
+                font-size: 1.3em;
+          }
         }
       }
     }
@@ -238,7 +254,7 @@
       }
       ul {
         padding-left: 15px;
-        width: 85%;
+        width: 90%;
       }
     }
     .no-info-text {
@@ -280,6 +296,7 @@
           border-top: 1px solid #dfd6c5;
         }
       }
+
       &.general {
         -webkit-flex: 0 0 100%;
         flex: 0 0 100%;
@@ -300,7 +317,7 @@
       &.location {
         display: none;
         @media @phone {
-          display: block;
+          .flex();
         }
       }
 
@@ -396,7 +413,7 @@
   padding: 5px 15px 5px 15px;
   background-color: rgba(168, 168, 168, 0.07);
   margin: 10px 0 10px 0;
-  box-shadow: 0 0 2px rgba(0,0,0,0.2);
+  .shadow(0, 0, 2px, rgba(0,0,0,0.2));
  font-style: italic;
 
  label {
@@ -408,8 +425,21 @@
 }
 
 app-add-association {
+  
   app-search {
-    width: 196px;
+    margin-bottom: 20px;
+    width: 346px;
+    
+    @media @phone {
+          width: 100%;
+    }
+    @media @tablet {
+          width: 100%;
+    }
+    .search {
+      width: 100%;
+
+    }
     .glyphicon-search {
       margin-top: 4px;
       font-size: 1.5em;
@@ -431,4 +461,112 @@ app-add-association {
     }
   }
 }
+
+#associated-maps {
+  ul {
+    .flex();
+    flex-flow: row wrap;
+    li {
+      flex-basis: 33.3%;
+      margin-bottom: 20px;
+    }
+  }
+}
+.scroll-top-btn {
+  margin-top: 50px;
+  margin-bottom: 25px;
+}
+
+.location-static {
+  min-height: 80px;
+  padding: 10px;
+  position: absolute;
+  color: #A55944;
+  top: 160px;
+  right: 100px;
+  background: #FFFB80;
+  -webkit-transform: rotate(4deg);
+  -moz-transform: rotate(4deg);
+  -o-transform: rotate(4deg);
+  -ms-transform: rotate(4deg);
+  transform: rotate(4deg);
+  .shadow(2px, 2px, 10px, rgba(33,33,33,0.4) );
   
+  @media @tablet {
+    top: 130px;
+    right: 24px;
+    font-size: 1em;
+    width: 167px;
+  }
+  @media @phone {
+    display: none;
+  }
+  @media @big {
+    font-size: 1.2em;
+  }
+  .pin {
+    background-color: #aaa;
+    display: block;
+    height: 32px;
+    width: 2px;
+    position: absolute;
+    left: 50%;
+    top: -20px;
+    z-index: 1;
+
+    &:after {
+      background-color: #A31;
+      background-image: radial-gradient(25% 25%, circle, hsla(0,0%,100%,.3), hsla(0,0%,0%,.3));
+      border-radius: 50%;
+      box-shadow: inset 0 0 0 1px hsla(0,0%,0%,.1),
+              inset 3px 3px 3px hsla(0,0%,100%,.2),
+              inset -3px -3px 3px hsla(0,0%,0%,.2),
+              23px 20px 3px hsla(0,0%,0%,.15);
+      content: '';
+      height: 12px;
+      left: -5px;
+      position: absolute;
+      top: -10px;
+      width: 12px;
+  }
+  &:before {
+    background-color: hsla(0,0%,0%,0.1);
+    box-shadow: 0 0 .25em hsla(0,0%,0%,.1);
+    content: '';
+    height: 24px;
+    width: 2px;
+    left: 0;
+    position: absolute;
+    top: 8px;
+    transform: rotate(57.5deg);
+    -moz-transform: rotate(57.5deg);
+    -webkit-transform: rotate(57.5deg);
+    -o-transform: rotate(57.5deg);
+    -ms-transform: rotate(57.5deg);
+    transform-origin: 50% 100%;
+    -moz-transform-origin: 50% 100%;
+    -webkit-transform-origin: 50% 100%;
+    -o-transform-origin: 50% 100%;
+  }
+ }
+  p {
+    margin-top: 10px;
+  }
+  ul {
+     list-style: none;
+     padding: 0;
+     margin: 0;
+     li:first-of-type {
+       font-weight: bold;
+     }
+     li:last-of-type {
+       text-decoration: underline;
+     }
+  }
+}
+.view-details-description {
+  min-height: 190px;
+  @media @phone {
+    min-height:  50px;
+  }
+}

--- a/less/documentdetailsview.less
+++ b/less/documentdetailsview.less
@@ -3,6 +3,7 @@
 .view-details-title {
   .flex();
   margin-top: 60px;
+  margin-bottom: 10px;
   
   @media @phone {
     margin-top: 55px;
@@ -29,8 +30,13 @@
     }
     .badge {
       font-size: 0.5em;
-      background-color: @brand-success;
       margin-left: 10px;
+      &.route {
+         background-color: @brand-info;
+      }
+      &.waypoint {
+         background-color: @brand-success;
+      }
     }
   }
 }
@@ -42,10 +48,13 @@
   width: 90%;
   margin-top: -30px;
   padding-top: 15px;
+  padding-bottom: 266px;
   overflow: hidden;
 
   @media @phone{
-    padding: 28px 5px @float-buttons-bar-height + 10px 5px;
+    padding-top: 28px;
+    padding-left: 5px;
+    padding-right: 5px;
     width: 100%;
     margin-left: 0%;
     margin-right: 0%;
@@ -63,14 +72,14 @@
       justify-content: space-around;
     }
   }
-/* uib accordion*/
+  /* uib accordion*/
   .panel-title {
     .glyphicon {
       float: right;
     }
   }
-  
-   .view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos {
+
+  .view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos {
     text-align: justify;
     padding-left: 0;
     padding-right: 0;
@@ -78,7 +87,8 @@
     margin-bottom: 10px;
     border-radius: 5px;
     border: 1px solid #eee;
-    padding-top: 10px;
+    padding-top: 15px;
+    
     @media @phone {
       border-width: 2px;
     }
@@ -87,7 +97,7 @@
       width: 72.5%;
       margin-left: 2.5%;
     }
-    
+
     h2 {
       text-align: left;
       font-size: 1.5em;
@@ -98,21 +108,22 @@
       font-size: 17px;
       word-break: break-word;
       float: left;
-      padding: 0 15px 5px 15px;
+      padding: 0 30px 15px 30px;
       margin-bottom: 0;
 
       @media (max-width: @screen-xs-max) {
         font-size: 14px;
+        padding: 0 15px 15px 15px;
       }
     }
   }
-  
+
   .view-details-associations {
     width: 100%;
     margin-left: 0;
     background: white;
-     border: 1px solid #eee;
-    
+    border: 1px solid #eee;
+
     @media @phone {
       display: none;
     }
@@ -137,10 +148,10 @@
       margin-bottom: 10px;
       background: #EEE;
       width: 44%;
-      
+
       a {
         text-align: left; 
-     }
+      }
       @media @big {
         width: 49%;
       }
@@ -157,7 +168,7 @@
     .associated-documents {
       margin-top: 10px;
       padding: 0 10px;
-      max-height: 500px;
+      max-height: 600px;
       overflow-y: scroll;
       -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
       -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
@@ -184,8 +195,8 @@
         button {
           padding: 5px;
           @media (max-width: @screen-sm-min)  {
-                padding: 7px 3px 3px 3px;
-                font-size: 1.3em;
+            padding: 7px 3px 3px 3px;
+            font-size: 1.3em;
           }
         }
       }
@@ -196,9 +207,10 @@
     border: 2px solid #FFB761;
     .flex();
     flex-flow: row wrap;
-    
+
     @media @phone { 
       width: 100%;
+      margin-bottom: -200px;
       display: none;
     }
     @media @big {
@@ -225,7 +237,7 @@
     }
     .glyphicon {
       font-size: 3em;
-      
+
       @media @phone {
         font-size: 1em;
       }
@@ -255,6 +267,9 @@
       ul {
         padding-left: 15px;
         width: 90%;
+        li {
+          margin-bottom: 5px;
+        }
       }
     }
     .no-info-text {
@@ -270,14 +285,14 @@
       .flex();
       flex-basis: 33.33%;
       padding: 0;
-      min-height: 100px;
+      min-height: 130px;
       background-color: white;
       border-bottom: 1px solid #dfd6c5;
       transition: 0.3s;
       margin: auto;
-      
+
       @media @big {
-        padding-top: 1%;
+        padding-top: 2%;
         flex-basis: 100%;
         min-height: 0;
         height: auto;
@@ -297,39 +312,26 @@
         }
       }
 
-      &.general {
-        -webkit-flex: 0 0 100%;
-        flex: 0 0 100%;
-        .detail-text {
-          .flex();
-          justify-content: space-around;
-          @media @big {
-            display: block;
-          }
-          @media @phone {
-            /*hack - first display as block (flex before, then hide it)*/
-            display: block;
-            display: none;
-          }
-        }
-
-      }
+    
       &.location {
         display: none;
         @media @phone {
           .flex();
         }
       }
-
     }
+    
     .accordion {
       margin-left: 5px;
 
       @media @phone {
-         padding-top: 1%;
+        padding-top: 1%;
       }
       @media @tablet {
         font-size: 14px;
+      }
+      ul {
+        margin: 0;
       }
     }
     h4 {
@@ -378,12 +380,12 @@
 
 .view-details-map{
   .map {
-     width: 100%;
-      margin-bottom: 29px;
+    width: 100%;
+    margin-bottom: 29px;
 
-      @media @phone {
-        margin-bottom: 0;
-      }
+    @media @phone {
+      margin-bottom: 0;
+    }
   }
   .ol-viewport {
     height: 280px !important;
@@ -397,7 +399,7 @@
     }
   }
 }
-  
+
 .view-details-other {
   width: 100% !important;
   margin: 0 0 40px 0 !important; 
@@ -406,7 +408,7 @@
   }
 }
 
-.document-summary, .document-remarks {
+.document-summary, .document-remarks, .document-access, .document-gear {
   color: #626262;
   border: 1px solid #D8D8D8;
   border-left: 0.5em solid #5FE45F;
@@ -414,27 +416,33 @@
   background-color: rgba(168, 168, 168, 0.07);
   margin: 10px 0 10px 0;
   .shadow(0, 0, 2px, rgba(0,0,0,0.2));
- font-style: italic;
+  font-style: italic;
 
- label {
-   font-style: normal;
- }
+  label {
+    font-style: normal;
+  }
 }
 .document-remarks {
   border-left-color: rgba(255, 67, 34, 0.61);
 }
+.document-access {
+  border-left-color: #ADD8E6;
+}
+.document-gear {
+  border-left-color: beige;
+}
 
 app-add-association {
-  
+
   app-search {
     margin-bottom: 20px;
     width: 346px;
-    
+
     @media @phone {
-          width: 100%;
+      width: 100%;
     }
     @media @tablet {
-          width: 100%;
+      width: 100%;
     }
     .search {
       width: 100%;
@@ -444,7 +452,15 @@ app-add-association {
       margin-top: 4px;
       font-size: 1.5em;
     }
+    .tt-suggestion {
+      border-radius: 0;
+      padding: 5px !important;
+    }
+    p {
+      margin: 0 !important;
+    }
   }
+
 }
 
 .view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos, .view-details-informations{
@@ -462,16 +478,6 @@ app-add-association {
   }
 }
 
-#associated-maps {
-  ul {
-    .flex();
-    flex-flow: row wrap;
-    li {
-      flex-basis: 33.3%;
-      margin-bottom: 20px;
-    }
-  }
-}
 .scroll-top-btn {
   margin-top: 50px;
   margin-bottom: 25px;
@@ -482,8 +488,6 @@ app-add-association {
   padding: 10px;
   position: absolute;
   color: #A55944;
-  top: 160px;
-  right: 100px;
   background: #FFFB80;
   -webkit-transform: rotate(4deg);
   -moz-transform: rotate(4deg);
@@ -491,10 +495,9 @@ app-add-association {
   -ms-transform: rotate(4deg);
   transform: rotate(4deg);
   .shadow(2px, 2px, 10px, rgba(33,33,33,0.4) );
-  
+
   @media @tablet {
-    top: 130px;
-    right: 24px;
+    right: 30px;
     font-size: 1em;
     width: 167px;
   }
@@ -502,7 +505,11 @@ app-add-association {
     display: none;
   }
   @media @big {
-    font-size: 1.2em;
+    font-size: 1.1em;
+    right: 50px;
+  }
+  @media @desktop {
+     right: 50px;
   }
   .pin {
     background-color: #aaa;
@@ -519,54 +526,67 @@ app-add-association {
       background-image: radial-gradient(25% 25%, circle, hsla(0,0%,100%,.3), hsla(0,0%,0%,.3));
       border-radius: 50%;
       box-shadow: inset 0 0 0 1px hsla(0,0%,0%,.1),
-              inset 3px 3px 3px hsla(0,0%,100%,.2),
-              inset -3px -3px 3px hsla(0,0%,0%,.2),
-              23px 20px 3px hsla(0,0%,0%,.15);
+        inset 3px 3px 3px hsla(0,0%,100%,.2),
+        inset -3px -3px 3px hsla(0,0%,0%,.2),
+        23px 20px 3px hsla(0,0%,0%,.15);
       content: '';
       height: 12px;
       left: -5px;
       position: absolute;
       top: -10px;
       width: 12px;
+    }
+    &:before {
+      background-color: hsla(0,0%,0%,0.1);
+      box-shadow: 0 0 .25em hsla(0,0%,0%,.1);
+      content: '';
+      height: 24px;
+      width: 2px;
+      left: 0;
+      position: absolute;
+      top: 8px;
+      transform: rotate(57.5deg);
+      -moz-transform: rotate(57.5deg);
+      -webkit-transform: rotate(57.5deg);
+      -o-transform: rotate(57.5deg);
+      -ms-transform: rotate(57.5deg);
+      transform-origin: 50% 100%;
+      -moz-transform-origin: 50% 100%;
+      -webkit-transform-origin: 50% 100%;
+      -o-transform-origin: 50% 100%;
+    }
   }
-  &:before {
-    background-color: hsla(0,0%,0%,0.1);
-    box-shadow: 0 0 .25em hsla(0,0%,0%,.1);
-    content: '';
-    height: 24px;
-    width: 2px;
-    left: 0;
-    position: absolute;
-    top: 8px;
-    transform: rotate(57.5deg);
-    -moz-transform: rotate(57.5deg);
-    -webkit-transform: rotate(57.5deg);
-    -o-transform: rotate(57.5deg);
-    -ms-transform: rotate(57.5deg);
-    transform-origin: 50% 100%;
-    -moz-transform-origin: 50% 100%;
-    -webkit-transform-origin: 50% 100%;
-    -o-transform-origin: 50% 100%;
-  }
- }
   p {
-    margin-top: 10px;
+    margin-top: 2px;
+    margin-bottom: 0;
   }
   ul {
-     list-style: none;
-     padding: 0;
-     margin: 0;
-     li:first-of-type {
-       font-weight: bold;
-     }
-     li:last-of-type {
-       text-decoration: underline;
-     }
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li:first-of-type {
+      font-weight: bold;
+    }
+    li:last-of-type {
+      text-decoration: underline;
+    }
   }
 }
 .view-details-description {
   min-height: 190px;
+  
   @media @phone {
     min-height:  50px;
+    margin-bottom: -200px;
+  }
+  h2{
+    margin-top: 10px;
+  }
+}
+.show-phone.elevation {
+  display: none;
+  @media @phone {
+     display: block;
   }
 }

--- a/less/filters.less
+++ b/less/filters.less
@@ -85,6 +85,9 @@
           margin-right: 25px;
           top: 4px;
         }
+        .glyphicon {
+          color: white;
+        }
       }
       .search-filters-btn {
         @media @phone {

--- a/less/search.less
+++ b/less/search.less
@@ -11,7 +11,7 @@
       width: 320px !important;
     }
     @media @tablet {
-      width: 380px !important;
+      width: 340px !important;
     }
   }
 }

--- a/less/search.less
+++ b/less/search.less
@@ -1,5 +1,4 @@
-@phone: ~"only screen and (min-width: 130px) and (max-width: 619px)";
-@tablet: ~"only screen and (min-width: 620px) and (max-width: 1099px)";
+@import: 'variables.less';
 
 .twitter-typeahead, .tt-dropdown-menu, .tt-hint {
   width: 220px;
@@ -57,6 +56,7 @@ span.twitter-typeahead {
     &:hover,
     &:focus {
       &:extend(.dropdown-menu > .active > a);
+      cursor: pointer;
     }
     &:last-child {
       border-bottom: none;
@@ -89,7 +89,7 @@ span.twitter-typeahead {
     font-weight: bold;
     font-family: Verdana;
     padding: 1%;
-    background-color:#FFAC4A;
+    background: @C2C-orange;
   }
 
   .tt-hint {
@@ -106,3 +106,43 @@ span.twitter-typeahead {
   visibility: visible !important;
   padding: 8px !important;
 }
+
+.tt-empty.tt-open {
+  display: block !important;
+  width: 300px !important;
+
+  @media @phone {
+    width: 200px;
+  }
+  .tt-dataset.empty {
+    p {
+       margin: 0 !important;
+    }
+   .tt-suggestion{
+     .flex();
+     justify-content: space-between;
+     &:hover {
+       .glyphicon {
+         color: white;
+       }
+     }
+   }
+   .glyphicon {
+     color: @brand-primary;
+   }
+  }
+}
+.tt-menu {
+  border: none !important;
+}
+
+.header.Routes {
+  background: @brand-info !important;
+}
+.header.Waypoints {
+  background: @brand-success !important;
+}    
+#empty-results {
+  display: none;
+}
+

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -121,7 +121,11 @@
   margin: auto;
   position: relative;
   z-index: 2;
-
+  width: 40px;
+  height: 40px;
+  background-color: white;
+  outline: none;
+  
   @media @tablet {
     display: block;
     margin: auto;
@@ -131,6 +135,56 @@
     margin: 0;
     float: right;
   }
+  &.is-active {
+    background-color: #F1EEE8;
+    span {
+      transform: rotate(180deg);
+      background-color: @C2C-orange;
+      &::before, &::after {
+        width: 50%;
+        background-color: @C2C-orange;
+      }
+      &::before {
+        top: 0;
+        transform: translateX(16px) translateY(2px) rotate(45deg);
+      }
+      &::after {
+        bottom: 0;
+        transform: translateX(16px) translateY(-2px) rotate(-45deg);
+      }
+    }
+    
+  }
+  span {
+    display: block;
+    position: absolute;
+    top: 18px;
+    left: 7px;
+    right: 7px;
+    height: 4px;
+    background: graytext;
+    transition: transform 0.3s;
+    &::before, &::after {
+      position: absolute;
+      display: block;
+      left: 0;
+      width: 100%;
+      height: 4px;
+      background-color: graytext;
+      content: "";
+    }
+    &::before {
+      top: -8.5px;
+      transform-origin: top right;
+      transition: transform 0.3s, width 0.3s, top 0.3s;
+    }
+    &::after {
+      bottom: -8.5px;
+      transform-origin: bottom right;
+      transition: transform 0.3s, width 0.3s, bottom 0.3s;
+    }
+  }
+
 }
 .menu-open-close.header{
   display: none;
@@ -148,3 +202,4 @@
   background-color: rgba(146, 203, 119, 0.65)!important;
   transition: 0.1s;
 }
+

--- a/less/variables.less
+++ b/less/variables.less
@@ -10,6 +10,11 @@
 @menu-width-tablet: 50px;
 @float-buttons-bar-height: 65px;
 
+.shadow(@right, @bottom, @spread, @color) {
+  -moz-box-shadow: @right @bottom @spread @color;
+  -webkit-box-shadow: @right @bottom @spread @color;
+  box-shadow: @right @bottom @spread @color;
+}
 .flex(){
   display: -moz-box;
   display: -ms-flexbox;
@@ -17,3 +22,5 @@
   display: -webkit-flex;
   display: flex;
 }
+
+


### PR DESCRIPTION
Same layout as already done for routes, but this time for waypoints with a few upgrades like a super-duper sticky-note with location info and an animated shiny bling bling menu button, all in CSS ! 
![screenshot from 2016-02-25 15 46 17](https://cloud.githubusercontent.com/assets/7814311/13322884/033efa9c-dbd7-11e5-88d0-2f6043a47e8f.png)
