### PR TITLE
ApiError directive

### DIFF
--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -44,14 +44,15 @@ app.Alerts.prototype.gettext = function(str) {
  * @export
  */
 app.Alerts.prototype.add = function(data) {
-  this.addLoading_();
+  var timeout = data['timeout'] || 0;
+  this.addLoading_(timeout);
   var msg = data['msg'];
   msg = msg instanceof Object ? this.formatErrorMsg_(msg) :
       this.filterStr_(msg);
   this.alerts_.push({
     type: data['type'] || 'warning',
     msg: msg,
-    timeout: data['timeout'] || 0
+    timeout: timeout
   });
 };
 
@@ -92,13 +93,14 @@ app.Alerts.prototype.get = function() {
 
 
 /**
+ * @param {number} timeout
  * @private
  */
-app.Alerts.prototype.addLoading_ = function() {
+app.Alerts.prototype.addLoading_ = function(timeout) {
   $('main, aside, .page-header').addClass('loading');
   setTimeout(function() {
     $('main, aside, .page-header').removeClass('loading');
-  }, 4500);
+  }, timeout);
 };
 
 

--- a/c2corg_ui/static/js/apierror.js
+++ b/c2corg_ui/static/js/apierror.js
@@ -1,0 +1,54 @@
+goog.provide('app.ApiErrorController');
+goog.provide('app.apiErrorDirective');
+
+goog.require('app');
+
+
+/**
+ * This directive is used to display the API error passed to the HTML
+ * templates engine.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.apiErrorDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'AppApiErrorController',
+    bindToController: true,
+    link: function(scope, element, attrs, controller) {
+      controller.addMsg(element[0].innerText);
+    }
+  };
+};
+
+
+app.module.directive('appApiError', app.apiErrorDirective);
+
+
+/**
+ * @param {app.Alerts} appAlerts
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.ApiErrorController = function(appAlerts) {
+
+  /**
+   * @type {app.Alerts}
+   * @private
+   */
+  this.alerts_ = appAlerts;
+};
+
+
+/**
+ * @param {string} msg
+ * @export
+ */
+app.ApiErrorController.prototype.addMsg = function(msg) {
+  this.alerts_.addError(msg);
+};
+
+
+app.module.controller('AppApiErrorController', app.ApiErrorController);

--- a/c2corg_ui/static/js/filters.js
+++ b/c2corg_ui/static/js/filters.js
@@ -1,3 +1,4 @@
+goog.provide('app.capitalize');
 goog.provide('app.trustAsHtmlFilter');
 
 goog.require('app');

--- a/c2corg_ui/static/js/loading.js
+++ b/c2corg_ui/static/js/loading.js
@@ -14,10 +14,10 @@ app.loadingDirective = function($http) {
     scope: true,
     link:
      /**
-     * @param {angular.Scope} scope Scope.
-     * @param {angular.JQLite} el Element.
-     * @param {angular.Attributes} attrs Atttributes.
-     */
+      * @param {angular.Scope} scope Scope.
+      * @param {angular.JQLite} el Element.
+      * @param {angular.Attributes} attrs Atttributes.
+      */
      function(scope, el, attrs) {
        scope.$watch(function() {
          return $http.pendingRequests.length;

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -9,6 +9,7 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.addAssociationDirective');
+goog.require('app.apiErrorDirective');
 goog.require('app.associationCardDirective');
 goog.require('app.alertsDirective');
 goog.require('app.authDirective');

--- a/c2corg_ui/templates/helpers/common.html
+++ b/c2corg_ui/templates/helpers/common.html
@@ -1,3 +1,9 @@
 <%def name="show_title(title)">\
   ${title + ' - ' if title else ''}Camptocamp.org\
 </%def>
+
+<%def name="show_api_error(error)">\
+  % if error:
+    <app-api-error>${error}</app-api-error>
+  % endif
+</%def>

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -122,3 +122,6 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <span translate>nov</span>
 <span translate>oct</span>
 <span translate>dec</span>
+
+<!-- misc -->
+<span translate>API failed responding</span>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/common.html" import="show_title"/>
+<%namespace file="../helpers/common.html" import="show_title, show_api_error"/>
 <%namespace file="../helpers/list.html" import="add_pagination_links"/>
 <%namespace file="../helpers/view.html" import="show_attr, show_route_title"/>
 
@@ -53,3 +53,4 @@ window.onload = function(){
   app.stickyFilters();
 }
 </script>
+${show_api_error(error)}

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -1,5 +1,5 @@
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/common.html" import="show_title"/>
+<%namespace file="../helpers/common.html" import="show_title, show_api_error"/>
 <%namespace file="../helpers/list.html" import="add_pagination_links"/>
 <%namespace file="../helpers/view.html" import="show_attr"/>
 
@@ -91,3 +91,4 @@ window.onload = function(){
   app.stickyFilters();
 }
 </script>
+${show_api_error(error)}

--- a/c2corg_ui/tests/views/__init__.py
+++ b/c2corg_ui/tests/views/__init__.py
@@ -45,7 +45,7 @@ class BaseTestUi(BaseTestCase):
         self.assertEqual(isinstance(documents, list), True)
 
     def _test_get_documents(self):
-        documents, total, params, lang = self.view._get_documents()
+        documents, total, params, lang, error = self.view._get_documents()
         self.assertEqual(isinstance(total, int), True)
         self.assertEqual(isinstance(documents, list), True)
         self.assertEqual(isinstance(params, dict), True)

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -125,14 +125,15 @@ class Document(object):
 
         # Inject default list filters params:
         filters = dict(self._DEFAULT_FILTERS, **{k: v for k, v in params})
-        # TODO: better error handling
         if resp['status'] == '200':
             documents = content['documents']
             total = content['total']
+            error = ''
         else:
             documents = []
             total = 0
-        return documents, total, filters, lang
+            error = 'API failed responding'
+        return documents, total, filters, lang, error
 
     def _get_filter_params(self):
         """This function is used to parse the filters provided in URLs such as

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -13,12 +13,13 @@ class Route(Document):
     @view_config(route_name='routes_index_default',
                  renderer='c2corg_ui:templates/route/index.html')
     def index(self):
-        routes, total, filter_params, lang = self._get_documents()
+        routes, total, filter_params, lang, error = self._get_documents()
         self.template_input.update({
             'routes': routes,
             'total': total,
             'filter_params': filter_params,
-            'lang': lang
+            'lang': lang,
+            'error': error
         })
         return self.template_input
 

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -13,12 +13,13 @@ class Waypoint(Document):
     @view_config(route_name='waypoints_index_default',
                  renderer='c2corg_ui:templates/waypoint/index.html')
     def index(self):
-        waypoints, total, filter_params, lang = self._get_documents()
+        waypoints, total, filter_params, lang, error = self._get_documents()
         self.template_input.update({
             'waypoints': waypoints,
             'total': total,
             'filter_params': filter_params,
-            'lang': lang
+            'lang': lang,
+            'error': error
         })
         return self.template_input
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -955,16 +955,20 @@ app-alerts {
   }
 }
 
-  .versions-list {
-    background-color: #EBEBEB;
-    
-    tr:first-of-type {
-      background-color: #337AB7 !important;
-      color: white;
-    }
-    td {
-      .hide-radio {
-        display: none;
-      }
+.versions-list {
+  background-color: #EBEBEB;
+
+  tr:first-of-type {
+    background-color: #337AB7 !important;
+    color: white;
+  }
+  td {
+    .hide-radio {
+      display: none;
     }
   }
+}
+
+app-api-error {
+  display: none;
+}


### PR DESCRIPTION
The directive is used to display an alert (using ``AlertService``) when the API fails (for instance down) while loading the WP or routes list pages (as for now we only show pages with 0 item).

It does not support errors when loading a document view page (yet?), because the UI already raises a 500 or 404 error:
https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/views/document.py#L85-L89
In that case it's probably better to customize the 500/404 pages.

Related to https://github.com/c2corg/v6_ui/issues/25 and https://github.com/c2corg/v6_ui/issues/27 and https://github.com/c2corg/v6_ui/issues/201