### PR TITLE
Add the map mouseWheel interaction back

### DIFF
--- a/c2corg_ui/static/js/map/diffmap.js
+++ b/c2corg_ui/static/js/map/diffmap.js
@@ -3,12 +3,14 @@ goog.provide('app.diffMapDirective');
 
 goog.require('app');
 goog.require('app.MapController');
+goog.require('app.utils');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mapDirective');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.format.GeoJSON');
+goog.require('ol.interaction.MouseWheelZoom');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
@@ -43,8 +45,7 @@ app.module.directive('appDiffMap', app.diffMapDirective);
 
 /**
  * @param {?GeoJSONFeatureCollection} mapFeatureCollection FeatureCollection
- *    of features
- * to show on the map.
+ *    of features to show on the map.
  * @constructor
  * @export
  * @ngInject
@@ -74,6 +75,11 @@ app.DiffMapController = function(mapFeatureCollection) {
       })
     ]
   });
+
+  var mouseWheelZoomInteraction = new ol.interaction.MouseWheelZoom();
+  this.map.addInteraction(mouseWheelZoomInteraction);
+  app.utils.setupSmartScroll(mouseWheelZoomInteraction);
+
   if (!mapFeatureCollection) {
     this.map.setView(new ol.View({
       center: app.MapController.DEFAULT_CENTER,

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -13,6 +13,7 @@ goog.require('ol.format.GeoJSON');
 goog.require('ol.geom.Point');
 goog.require('ol.interaction.Draw');
 goog.require('ol.interaction.Modify');
+goog.require('ol.interaction.MouseWheelZoom');
 goog.require('ol.interaction.Select');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
@@ -35,7 +36,7 @@ app.mapDirective = function() {
     scope: {
       'editCtrl': '=appMapEditCtrl',
       'drawType': '@appMapDrawType',
-      'mouseWheel': '@appMapMouseWheel'
+      'disableWheel': '=appMapDisableWheel'
     },
     controller: 'AppMapController',
     controllerAs: 'mapCtrl',
@@ -98,15 +99,19 @@ app.MapController = function($scope, mapFeatureCollection) {
    * @export
    */
   this.map = new ol.Map({
-    interactions: ol.interaction.defaults({
-      mouseWheelZoom: this['mouseWheel'] || false
-    }),
+    interactions: ol.interaction.defaults({mouseWheelZoom: false}),
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
       })
     ]
   });
+
+  if (!(this['disableWheel'] || false)) {
+    var mouseWheelZoomInteraction = new ol.interaction.MouseWheelZoom();
+    this.map.addInteraction(mouseWheelZoomInteraction);
+    app.utils.setupSmartScroll(mouseWheelZoomInteraction);
+  }
 
   if (mapFeatureCollection) {
     this.getVectorLayer_().setStyle(this.createStyleFunction_(1));

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -13,3 +13,20 @@ app.utils.buildDocumentUrl = function(document_type, documentId, lang) {
     .replace('{id}', String(documentId))
     .replace('{lang}', lang);
 };
+
+
+/**
+ * @param {ol.interaction.MouseWheelZoom} mouseWheelZoomInteraction
+ */
+app.utils.setupSmartScroll = function(mouseWheelZoomInteraction) {
+  var scrollTimer;
+  $(window).on('scroll', function(e) {
+    mouseWheelZoomInteraction.setActive(false);
+    if (scrollTimer) {
+      clearInterval(scrollTimer);
+    }
+    scrollTimer = setTimeout(function() {
+      mouseWheelZoomInteraction.setActive(true);
+    }, 500);
+  });
+};

--- a/c2corg_ui/templates/index.html
+++ b/c2corg_ui/templates/index.html
@@ -1,4 +1,4 @@
 <%inherit file="base.html"/>
 
 <h1 translate class="welcome-title text-center">Welcome to Camptocamp.org</h1>
-<app-map app-map-mouse-wheel="true"></app-map>
+<app-map></app-map>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -45,7 +45,7 @@
 </section>
 % if len(routes):
 <div class="map-right">
-  <app-map app-map-mouse-wheel="true"></app-map>
+  <app-map></app-map>
 </div>
 % endif
 <script>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -83,7 +83,7 @@ module.value('mapFeatureCollection', {
 </section>
 % if len(waypoints):
 <div class="map-right">
-  <app-map app-map-mouse-wheel="true"></app-map>
+  <app-map></app-map>
 </div>
 % endif
 <script>


### PR DESCRIPTION
- MouseWheel is disable when scrolling the page unless the cursor
stops on the map for >500ms (credits go to @tsauerwein).
- It is possible to fully disable the mouseWheel interaction using
an `app-map-disable-wheel` attribute.

Based upon and fixes https://github.com/c2corg/v6_ui/issues/189