### PR TITLE
Edit/create waypoint attributes

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -4,6 +4,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: \n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -101,6 +105,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -127,6 +132,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -189,6 +202,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -287,8 +301,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -317,6 +331,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -335,6 +350,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -407,8 +426,13 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -422,10 +446,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -444,6 +464,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -473,6 +497,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -482,14 +507,20 @@ msgid "You are viewing an archived version of this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -530,6 +561,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -542,8 +575,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -556,13 +599,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -571,6 +622,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -583,6 +636,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -592,21 +647,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -619,10 +687,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -636,11 +711,13 @@ msgid "dec"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -652,6 +729,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -664,10 +743,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -688,6 +773,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -704,6 +791,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -712,6 +801,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -742,6 +835,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -766,14 +861,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -833,15 +934,20 @@ msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -854,6 +960,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -863,14 +973,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -919,8 +1039,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -929,6 +1057,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -941,6 +1071,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -949,18 +1081,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -973,18 +1114,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -994,12 +1146,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1034,6 +1192,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1051,12 +1211,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1068,11 +1234,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1090,6 +1263,7 @@ msgstr ""
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
@@ -1102,8 +1276,17 @@ msgid "summit"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1115,6 +1298,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1147,6 +1337,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1156,10 +1347,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -8,6 +8,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -99,6 +103,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -125,6 +130,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -187,6 +200,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -282,8 +296,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -312,6 +326,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -330,6 +345,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -397,8 +416,13 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -411,10 +435,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -431,6 +451,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -460,6 +484,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Benvingut/da a Camptocamp.org!"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -468,14 +493,21 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -515,6 +547,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -527,8 +561,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -541,13 +585,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -556,6 +608,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -568,6 +622,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -577,21 +633,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -604,10 +673,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -620,11 +696,14 @@ msgstr ""
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -636,6 +715,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -648,10 +729,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -672,6 +759,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -688,6 +777,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -696,6 +787,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -726,6 +821,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -749,14 +846,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -815,15 +918,20 @@ msgid "lake"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -836,6 +944,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -845,14 +957,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -901,8 +1023,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -911,6 +1041,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -923,6 +1055,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -931,18 +1065,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -955,18 +1098,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -976,12 +1130,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1015,6 +1175,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1032,12 +1194,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1049,11 +1217,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1069,7 +1244,9 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1079,8 +1256,18 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1092,6 +1279,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1124,6 +1318,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1133,10 +1328,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -100,6 +104,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -126,6 +131,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -188,6 +201,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -283,8 +297,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -313,6 +327,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -331,6 +346,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -398,8 +417,13 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -412,10 +436,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -432,6 +452,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -461,6 +485,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Willkommen bei Camptocamp.org"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -469,14 +494,21 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -516,6 +548,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -528,8 +562,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -542,13 +586,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -557,6 +609,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -569,6 +623,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -578,21 +634,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -605,10 +674,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -621,11 +697,14 @@ msgstr ""
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -637,6 +716,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -649,10 +730,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -673,6 +760,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -689,6 +778,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -697,6 +788,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -727,6 +822,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -750,14 +847,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -816,15 +919,20 @@ msgid "lake"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -837,6 +945,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -846,14 +958,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -902,8 +1024,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -912,6 +1042,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -924,6 +1056,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -932,18 +1066,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -956,18 +1099,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -977,12 +1131,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1016,6 +1176,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1033,12 +1195,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1050,11 +1218,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1070,7 +1245,9 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1080,9 +1257,19 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
 msgstr "Titel"
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
@@ -1093,6 +1280,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1125,6 +1319,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1134,10 +1329,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -100,6 +104,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -126,6 +131,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -188,6 +201,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -283,9 +297,9 @@ msgstr ""
 msgid "Logout"
 msgstr "Sign out"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
+msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
@@ -313,6 +327,7 @@ msgid "Next"
 msgstr "Next"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -331,6 +346,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -398,9 +417,14 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
 msgstr "This field is required."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be a number."
@@ -412,10 +436,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -432,6 +452,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -461,6 +485,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Welcome to Camptocamp.org"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr "Yes"
@@ -469,14 +494,21 @@ msgstr "Yes"
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr "Access"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -516,6 +548,8 @@ msgid "bergschrund"
 msgstr "bergschrund"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -528,8 +562,18 @@ msgstr "bisse"
 msgid "bivouac"
 msgstr "bivouac"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -542,13 +586,21 @@ msgid "ca"
 msgstr "catalan"
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr "camp site"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -557,6 +609,8 @@ msgstr ""
 msgid "cave"
 msgstr "cave"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -569,6 +623,8 @@ msgstr "cliff"
 msgid "climbing_indoor"
 msgstr "climbing indoor"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -578,21 +634,34 @@ msgid "climbing_outdoor"
 msgstr "climbing outdoor"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -605,10 +674,17 @@ msgstr ""
 msgid "confluence"
 msgstr "confluence"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -621,11 +697,14 @@ msgstr "german"
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -637,6 +716,8 @@ msgstr "Elevation"
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -649,10 +730,16 @@ msgstr "english"
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -673,6 +760,8 @@ msgstr "expedition"
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -689,6 +778,8 @@ msgstr ""
 msgid "fr"
 msgstr "french"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -698,6 +789,10 @@ msgstr ""
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr "gear"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "geometry"
@@ -727,6 +822,8 @@ msgstr "green"
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -750,14 +847,20 @@ msgid "height_diff_up"
 msgstr "Height difference up"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -816,15 +919,20 @@ msgid "lake"
 msgstr "lake"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr "Lang"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -837,6 +945,10 @@ msgstr "local product"
 msgid "locality"
 msgstr "locality"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr "loop"
@@ -846,14 +958,24 @@ msgid "loop_hut"
 msgstr "loop hut"
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
 msgstr "Maps info"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -902,8 +1024,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -912,6 +1042,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -924,6 +1056,8 @@ msgstr "paragliding"
 msgid "paragliding_landing"
 msgstr "paragliding landing"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -932,18 +1066,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr "paragliding takeoff"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr "pass"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -956,18 +1099,29 @@ msgstr "pit"
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -977,12 +1131,18 @@ msgid "raid"
 msgstr "raid"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1016,6 +1176,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1033,12 +1195,18 @@ msgstr ""
 msgid "route_types"
 msgstr "Route types"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1050,11 +1218,18 @@ msgid "skitouring"
 msgstr "skitouring"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1070,7 +1245,9 @@ msgid "snowshoeing"
 msgstr "snowshoeing"
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1080,9 +1257,19 @@ msgstr ""
 msgid "summit"
 msgstr "summit"
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
 msgstr "Title"
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
@@ -1093,6 +1280,13 @@ msgstr "traverse"
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1125,6 +1319,7 @@ msgstr "waterpoint"
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1134,6 +1329,8 @@ msgstr "waypoint type"
 msgid "weather_station"
 msgstr "weather station"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
@@ -1141,3 +1338,14 @@ msgstr ""
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
+msgstr ""
+
+#~ msgid "Longitude"
+#~ msgstr "Longitude"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -100,6 +104,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -126,6 +131,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -188,6 +201,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -283,8 +297,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -313,6 +327,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -331,6 +346,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -398,8 +417,13 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -412,10 +436,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -432,6 +452,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -461,6 +485,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "¡Bienvenido/a a Camptocamp.org!"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -469,14 +494,21 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -516,6 +548,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -528,8 +562,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -542,13 +586,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -557,6 +609,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -569,6 +623,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -578,21 +634,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -605,10 +674,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -621,11 +697,14 @@ msgstr ""
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -637,6 +716,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -649,10 +730,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -673,6 +760,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -689,6 +778,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -697,6 +788,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -727,6 +822,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -750,14 +847,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -816,15 +919,20 @@ msgid "lake"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -837,6 +945,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -846,14 +958,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -902,8 +1024,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -912,6 +1042,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -924,6 +1056,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -932,18 +1066,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -956,18 +1099,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -977,12 +1131,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1016,6 +1176,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1033,12 +1195,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1050,11 +1218,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1070,7 +1245,9 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1080,8 +1257,18 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1093,6 +1280,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1125,6 +1319,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1134,10 +1329,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -8,6 +8,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -99,6 +103,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -125,6 +130,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -187,6 +200,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -282,8 +296,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -312,6 +326,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -330,6 +345,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -397,8 +416,13 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -411,10 +435,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -431,6 +451,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -460,6 +484,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Ongi etorri Camptocamp.org-era!"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -468,14 +493,21 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -515,6 +547,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -527,8 +561,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -541,13 +585,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -556,6 +608,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -568,6 +622,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -577,21 +633,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -604,10 +673,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -620,11 +696,14 @@ msgstr ""
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -636,6 +715,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -648,10 +729,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -672,6 +759,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -688,6 +777,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -696,6 +787,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -726,6 +821,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -749,14 +846,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -815,15 +918,20 @@ msgid "lake"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -836,6 +944,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -845,14 +957,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -901,8 +1023,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -911,6 +1041,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -923,6 +1055,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -931,18 +1065,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -955,18 +1098,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -976,12 +1130,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1015,6 +1175,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1032,12 +1194,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1049,11 +1217,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1069,7 +1244,9 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1079,8 +1256,18 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1092,6 +1279,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1124,6 +1318,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1133,10 +1328,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -6,6 +6,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -65,7 +69,7 @@ msgstr "Naviguer en"
 
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Cable car"
-msgstr "Remontée mécanique"
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Cancel"
@@ -97,6 +101,7 @@ msgstr "Comparer les versions sélectionnées"
 msgid "Comparing documents"
 msgstr "Comparaison des documents"
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -124,6 +129,14 @@ msgstr "Création d'un point de passage"
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
 msgstr "Date"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
 msgid "Describe here the gear needed for this route"
@@ -185,6 +198,7 @@ msgstr "Edition d'un point de passage"
 msgid "Email"
 msgstr "Adresse email"
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -280,9 +294,9 @@ msgstr "Identifiant ou mot de passe incorrects"
 msgid "Logout"
 msgstr "Se déconnecter"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
-msgstr "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
+msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "Maps"
@@ -310,6 +324,7 @@ msgid "Next"
 msgstr "Suivant"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr "Non"
@@ -329,6 +344,10 @@ msgstr "Pas de description disponible"
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
 msgstr "Aucune carte associée"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
+msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Password"
@@ -397,9 +416,14 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
 msgstr "Ce champ est obligatoire."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
+msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be a number."
@@ -412,10 +436,6 @@ msgstr "Ce champ doit être compris entre -180° et 180°."
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
 msgstr "Ce champ doit être compris entre -90° and 90°.."
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
-msgstr "Ce champ doit être inférieur à 9999m."
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "Title must have at least 3 characters."
@@ -432,6 +452,10 @@ msgstr ""
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
 msgstr "Traduire dans une autre langue"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
+msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Username"
@@ -460,6 +484,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Bienvenue sur Camptocamp.org"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr "Oui"
@@ -468,14 +493,21 @@ msgstr "Oui"
 msgid "You are viewing an archived version of this document."
 msgstr "Vous consultez une ancienne version de ce document."
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr "accès"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr "Période d'accès"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -515,6 +547,8 @@ msgid "bergschrund"
 msgstr "rimaye"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr "Méilleures périodes"
@@ -527,8 +561,18 @@ msgstr "bisse"
 msgid "bivouac"
 msgstr "bivouac"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr "couvertures hors de gardiennage"
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr "bateau"
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -541,24 +585,34 @@ msgid "ca"
 msgstr "catalan"
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr "Remontée mécanique"
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr "camping"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
-msgstr "Capacité"
+msgstr "nombre de places hors gardiennage"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
-msgstr ""
+msgstr "nombre de places en gardiennage"
 
 #: c2corg_ui/templates/i18n.html
 msgid "cave"
 msgstr "grotte"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
-msgstr ""
+msgstr "enfants"
 
 #: c2corg_ui/templates/i18n.html
 msgid "cliff"
@@ -568,6 +622,8 @@ msgstr "falaise"
 msgid "climbing_indoor"
 msgstr "SAE"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr "Types de grimpe intérieur"
@@ -577,21 +633,34 @@ msgid "climbing_outdoor"
 msgstr "site de couenne/bloc"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr "Types de grimpe extérieur"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr "Styles de grimpe"
@@ -604,13 +673,20 @@ msgstr "Configuration"
 msgid "confluence"
 msgstr "confluent"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr "Pays"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
-msgstr "Tutelle"
+msgstr "gardiennage"
 
 #: c2corg_ui/templates/i18n.html
 msgid "de"
@@ -620,11 +696,14 @@ msgstr "allemand"
 msgid "dec"
 msgstr "décembre"
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr "Description"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -636,6 +715,8 @@ msgstr "Altitude"
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr "Elévation min"
@@ -648,10 +729,16 @@ msgstr "anglais"
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -672,6 +759,8 @@ msgstr "expédition"
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -688,6 +777,8 @@ msgstr "février"
 msgid "fr"
 msgstr "français"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -697,6 +788,10 @@ msgstr ""
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
 msgstr "Matériel"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "geometry"
@@ -724,8 +819,10 @@ msgstr "vert"
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr "Types de terrain"
+msgstr "natures du sol"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -749,14 +846,20 @@ msgid "height_diff_up"
 msgstr "Dénivelé positif"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr "Hauteur max"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr "Hauteur médiane"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr "Hauteur min"
@@ -776,7 +879,7 @@ msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "hiking_rating"
-msgstr "Cotation"
+msgstr "Cotation hiking"
 
 #: c2corg_ui/templates/i18n.html
 msgid "hut"
@@ -815,15 +918,20 @@ msgid "lake"
 msgstr "lac"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr "Langue"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr "Longueur"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr "Remontée mécanique"
@@ -836,6 +944,10 @@ msgstr "produit local/commerce"
 msgid "locality"
 msgstr "lieu-dit"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr "boucle avec retour au pied de la voie"
@@ -845,17 +957,27 @@ msgid "loop_hut"
 msgstr "boucle avec retour au refuge"
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
 msgstr "Cartes"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
+msgstr "Références cartographiques"
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr "mars"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
-msgstr ""
+msgstr "matelas hors gardiennage"
 
 #: c2corg_ui/templates/i18n.html
 msgid "may"
@@ -901,9 +1023,17 @@ msgstr ""
 msgid "next difference"
 msgstr "différence suivante"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
 msgstr "novembre"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "oct"
@@ -911,6 +1041,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -923,6 +1055,8 @@ msgstr "parapente"
 msgid "paragliding_landing"
 msgstr "atterrissage parapente"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -931,21 +1065,30 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr "décollage parapente"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
 msgstr "Parking payant"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr "col"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr "Téléphone"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
+msgstr "téléphone gardien/gérant"
 
 #: c2corg_ui/templates/i18n.html
 msgid "pit"
@@ -955,33 +1098,50 @@ msgstr "gouffre"
 msgid "previous difference"
 msgstr "différence précédente"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
-msgstr "Types de produits"
+msgstr "types de produits locaux"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
-msgstr "Transports publics"
+msgstr "Transports en commun"
 
 #: c2corg_ui/templates/i18n.html
 msgid "raid"
 msgstr "raid"
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
+msgstr "plue"
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1015,9 +1175,11 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
-msgstr ""
+msgstr "types de rocher"
 
 #: c2corg_ui/templates/route/view.html
 msgid "route"
@@ -1032,6 +1194,8 @@ msgstr "Longueur de l'itinéraire"
 msgid "route_types"
 msgstr "Type d'itinéraire"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr "Quantité des itinéraires"
@@ -1039,6 +1203,10 @@ msgstr "Quantité des itinéraires"
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
 msgstr "septembre"
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
+msgstr "service à la demande"
 
 #: c2corg_ui/templates/i18n.html
 msgid "shelter"
@@ -1049,12 +1217,19 @@ msgid "skitouring"
 msgstr "ski, surf"
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr "Pente"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
-msgstr ""
+msgstr "déneigement"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
+msgstr "cotation déneigement"
 
 #: c2corg_ui/templates/i18n.html
 msgid "snow_ice_mixed"
@@ -1069,7 +1244,9 @@ msgid "snowshoeing"
 msgstr "raquette"
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr "Résumé"
@@ -1079,9 +1256,19 @@ msgstr "Résumé"
 msgid "summit"
 msgstr "sommet"
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
 msgstr "Titre"
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "traverse"
@@ -1092,6 +1279,13 @@ msgstr "traversée"
 msgid "type"
 msgstr "Type"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr "URL"
@@ -1124,6 +1318,7 @@ msgstr "point d'eau/source"
 msgid "waypoint"
 msgstr "point de passage"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1133,6 +1328,8 @@ msgstr "Type"
 msgid "weather_station"
 msgstr "station météo"
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
@@ -1140,6 +1337,20 @@ msgstr ""
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
 msgstr "webcam"
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
+msgstr ""
+
+#~ msgid "Longitude"
+#~ msgstr "Longitude"
+
+#~ msgid "This field must be smaller than 9999 m."
+#~ msgstr "Ce champ doit être inférieur à 9999m."
 
 #~ msgid "Associations"
 #~ msgstr "Associations"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -9,6 +9,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "&"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Access"
@@ -100,6 +104,7 @@ msgstr ""
 msgid "Comparing documents"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Contact"
 msgstr ""
@@ -126,6 +131,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Date"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Describe access_period"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -188,6 +201,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "Equipment"
 msgstr ""
@@ -283,8 +297,8 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "Longitude"
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "Longitude and latitude are required."
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -313,6 +327,7 @@ msgid "Next"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "No"
 msgstr ""
@@ -331,6 +346,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "No maps associated"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Numbers"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -398,8 +417,13 @@ msgid "Style"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -412,10 +436,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be smaller than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -432,6 +452,10 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "Translate into an other lang"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "Types & styles"
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -461,6 +485,7 @@ msgid "Welcome to Camptocamp.org"
 msgstr "Benvenuti a Camptocamp.org"
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "Yes"
 msgstr ""
@@ -469,14 +494,21 @@ msgstr ""
 msgid "You are viewing an archived version of this document."
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html c2corg_ui/templates/waypoint/view.html
+#: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/waypoint/view.html
 msgid "access"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_period"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "access_time"
 msgstr ""
@@ -516,6 +548,8 @@ msgid "bergschrund"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "best_periods"
 msgstr ""
@@ -528,8 +562,18 @@ msgstr ""
 msgid "bivouac"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "blanket_unstaffed"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "boat"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "bus"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -542,13 +586,21 @@ msgid "ca"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+msgid "cable_car"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
 msgid "camp_site"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "capacity_staffed"
 msgstr ""
@@ -557,6 +609,8 @@ msgstr ""
 msgid "cave"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "children_proof"
 msgstr ""
@@ -569,6 +623,8 @@ msgstr ""
 msgid "climbing_indoor"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_indoor_types"
 msgstr ""
@@ -578,21 +634,34 @@ msgid "climbing_outdoor"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_outdoor_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "climbing_rating_max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_median"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_rating_min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "climbing_styles"
 msgstr ""
@@ -605,10 +674,17 @@ msgstr ""
 msgid "confluence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "contact"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "custodianship"
 msgstr ""
@@ -621,11 +697,14 @@ msgstr ""
 msgid "dec"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "description"
 msgstr ""
 
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -637,6 +716,8 @@ msgstr ""
 msgid "elevation min/max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "elevation_min"
 msgstr ""
@@ -649,10 +730,16 @@ msgstr ""
 msgid "engagement_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "equipment"
+msgstr ""
+
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "equipment_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "equipment_ratings"
 msgstr ""
@@ -673,6 +760,8 @@ msgstr ""
 msgid "exposed"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "exposition_rating"
 msgstr ""
@@ -689,6 +778,8 @@ msgstr ""
 msgid "fr"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "gas_unstaffed"
 msgstr ""
@@ -697,6 +788,10 @@ msgstr ""
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 #: c2corg_ui/templates/route/view.html
 msgid "gear"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "geolocation"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -727,6 +822,8 @@ msgstr ""
 msgid "ground_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "heating_unstaffed"
 msgstr ""
@@ -750,14 +847,20 @@ msgid "height_diff_up"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_max"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_median"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "height_min"
 msgstr ""
@@ -816,15 +919,20 @@ msgid "lake"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 msgid "lang"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "length"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "lift_access"
 msgstr ""
@@ -837,6 +945,10 @@ msgstr ""
 msgid "locality"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+msgid "lonlat"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "loop"
 msgstr ""
@@ -846,14 +958,24 @@ msgid "loop_hut"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
+msgid "maps"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "maps_info"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "maps_references"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "mar"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "matress_unstaffed"
 msgstr ""
@@ -902,8 +1024,16 @@ msgstr ""
 msgid "next difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "no"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "nov"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "numbers"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -912,6 +1042,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientation"
 msgstr ""
@@ -924,6 +1056,8 @@ msgstr ""
 msgid "paragliding_landing"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "paragliding_rating"
 msgstr ""
@@ -932,18 +1066,27 @@ msgstr ""
 msgid "paragliding_takeoff"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "parking_fee"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "parking_fee_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "pass"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
@@ -956,18 +1099,29 @@ msgstr ""
 msgid "previous difference"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "product_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "prominence"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_rating"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "public_transportation_ratings"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "public_transportation_types"
 msgstr ""
@@ -977,12 +1131,18 @@ msgid "raid"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "range"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "ratings"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1016,6 +1176,8 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rock_types"
 msgstr ""
@@ -1033,12 +1195,18 @@ msgstr ""
 msgid "route_types"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "sep"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "service_on_demand"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1050,11 +1218,18 @@ msgid "skitouring"
 msgstr ""
 
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "slope"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "snow_clearance_rating"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "snow_clearance_ratings"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1070,7 +1245,9 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/route/view.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/view.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/view.html
 msgid "summary"
 msgstr ""
@@ -1080,8 +1257,18 @@ msgstr ""
 msgid "summit"
 msgstr ""
 
-#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 msgid "title"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "train"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "transports"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1093,6 +1280,13 @@ msgstr ""
 msgid "type"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "types"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "url"
 msgstr ""
@@ -1125,6 +1319,7 @@ msgstr ""
 msgid "waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "waypoint_type"
@@ -1134,10 +1329,20 @@ msgstr ""
 msgid "weather_station"
 msgstr ""
 
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
+#: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "weather_station_types"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "webcam"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "yes"
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "{{type}}"
 msgstr ""

--- a/c2corg_ui/static/img/orientation.svg
+++ b/c2corg_ui/static/img/orientation.svg
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="200"
+   height="200"
+   viewBox="0 0 744.09448819 1052.3622047"
+   id="orientation-svg"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="orientation.svg"
+   inkscape:export-filename="/home/agina/NetBeansProjects/C2C.org/v6_ui/c2corg_ui/static/img/orientation.svg"
+   inkscape:export-xdpi="87.938904"
+   inkscape:export-ydpi="87.938904">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="89.770297"
+     inkscape:cy="94.212051"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4160"
+     showgrid="false"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     inkscape:window-x="3585"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       style="shape-rendering:geometricPrecision"
+       id="g4163"
+       transform="matrix(0.46798709,0,0,0.46798709,1.1749871,-0.80949143)">
+      <g
+         id="g4160"
+         transform="translate(-134.37278,-286.88378)">
+        <g ng-click="editCtrl.setOrientation('N', waypoint)">
+          <rect x="722.5813"  y="453.6731" width="400" height="400" style="opacity: 0;"></rect>
+          <text
+                 ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('N') > -1 }"
+                 style="font-size:294.78234863px;fill:#808080"
+                 x="822.5813"
+                 y="753.6731"
+                 font-size="55"
+                 id="text-N"
+                 inkscape:export-xdpi="87.938904"
+                 inkscape:export-ydpi="87.938904">N</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('NE', waypoint)">
+           <rect x="1360"  y="700" width="350" height="300" style="opacity: 0;"></rect>
+           <text
+                ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('NE') > -1 }"
+                style="font-size:155px;fill:#808080"
+                x="1420"
+                y="900"
+                font-size="35"
+                id="text-NE"
+                inkscape:export-xdpi="87.938904"
+                inkscape:export-ydpi="87.938904">NE</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('NW', waypoint)">
+          <rect x="140"  y="700" width="350" height="300" style="opacity: 0;"></rect>
+          <text
+                ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('NW') > -1 }"
+                style="font-size:155px;fill:#808080"
+                x="170"
+                y="900"
+                font-size="35"
+                id="text-NW"
+                inkscape:export-xdpi="87.938904"
+                inkscape:export-ydpi="87.938904">NW</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('SE', waypoint)">
+          <rect x="1350"  y="1900" width="350" height="300" style="opacity: 0;"></rect>
+          <text
+              ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('SE') > -1 }"
+             style="font-size:155px;fill:#808080"
+             x="1420"
+             y="2100"
+             font-size="35"
+             id="text-SE"
+             inkscape:export-xdpi="87.938904"
+             inkscape:export-ydpi="87.938904">SE</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('SW', waypoint)">
+          <rect x="150"  y="1900" width="350" height="300" style="opacity: 0;"></rect>
+          <text
+                  ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('SW') > -1 }"
+                  style="font-size:155px;fill:#808080"
+                  x="180"
+                  y="2100"
+                  font-size="35"
+                  id="text-SW"
+                  inkscape:export-xdpi="87.938904"
+                  inkscape:export-ydpi="87.938904">SW</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('S', waypoint)">
+          <rect x="722.5813"  y="2000" width="400" height="400" style="opacity: 0;"></rect>
+          <text
+             ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('S') > -1 }"
+             style="font-size:294.78234863px;fill:#808080"
+             x="830"
+             y="2287.98"
+             font-size="55"
+             id="text-S"
+             inkscape:export-xdpi="87.938904"
+             inkscape:export-ydpi="87.938904">S</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('E', waypoint)">
+          <rect x="1500"  y="1250" width="400" height="400" style="opacity: 0;"></rect>
+          <text
+             ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('E') > -1 }"
+             style="font-size:294.78234863px;fill:#808080"
+             x="1626.5331"
+             y="1559.9829"
+             font-size="55"
+             id="text-E"
+             inkscape:export-xdpi="87.938904"
+             inkscape:export-ydpi="87.938904">E</text>
+        </g>
+        <g ng-click="editCtrl.setOrientation('W', waypoint)">
+          <rect x="-20"  y="1250" width="400" height="400" style="opacity: 0;"></rect>
+          <text
+             ng-class="{ 'orientation-text-selected': waypoint.orientation.indexOf('W') > -1 }"
+             style="font-size:294.78234863px;fill:#808080"
+             x="18.629496"
+             y="1559.9829"
+             font-size="55"
+             id="text-W"
+             inkscape:export-xdpi="87.938904"
+             inkscape:export-ydpi="87.938904">W</text>
+        </g>
+        <g
+           id="layer2"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904"
+           transform="matrix(5.3596791,0,0,5.3596791,-1106.9032,-1280.6464)">
+          <circle
+             r="191.92999"
+             cy="504.85999"
+             cx="377.82001"
+             id="path4136-0"
+             style="fill:none;stroke:#1c0000;stroke-width:5.9000001;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.37562998" />
+        </g>
+        <path
+           ng-class="{ 'half-circle-selected': waypoint.orientation.indexOf('SE') > -1 }"
+           style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
+           d="m 944.48909,2448.8091 c 547.72661,-15.9027 986.84591,-458.3667 998.59261,-1006.1983 -11.5333,548.874 -450.5029,990.8632 -998.59261,1006.1983 z"
+           id="circle-SE"
+              ng-click="editCtrl.setOrientation('SE', waypoint)"
+           inkscape:label="#path4325"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904" />
+        <path
+           ng-class="{ 'half-circle-selected': waypoint.orientation.indexOf('SW') > -1 }"
+           style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
+           d="m -112.73114,1442.6108 c 11.91194,551.4284 456.6057,995.3332 1008.0545,1006.2653 -551.18312,-11.2334 -996.02593,-454.7977 -1008.0545,-1006.2653 z"
+           id="circle-SW"
+              ng-click="editCtrl.setOrientation('SW', waypoint)"
+           inkscape:label="#path4323"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904" />
+        <path
+           ng-class="{ 'half-circle-selected': waypoint.orientation.indexOf('NE') > -1 }"
+           style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
+           d="M 944.48909,393.98048 C 1496.7393,410.51081 1937.2443,858.62339 1943.0145,1410.8033 1936.8867,858.85815 1496.2317,410.12866 944.48909,393.98048 Z"
+           id="circle-NE"
+              ng-click="editCtrl.setOrientation('NE', waypoint)"
+           inkscape:label="#path4321"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904" />
+        <path
+           ng-class="{ 'half-circle-selected': waypoint.orientation.indexOf('NW') > -1 }"
+           style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
+           d="M 895.32336,393.19744 C 339.22605,403.87284 -107.67176,854.63472 -113.55873,1410.8033 -108.83519,853.44058 338.57019,404.06847 895.32336,393.19744 Z"
+           id="circle-NW"
+              ng-click="editCtrl.setOrientation('NW', waypoint)"
+           inkscape:label="#circle-main"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904" />
+        <g
+           style="fill:#FFD7A8"
+           id="g4142"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904"
+           transform="matrix(5.3596791,0,0,5.3596791,-1106.9032,-1280.6464)">
+          <circle
+             ng-class="{ 'circle-selected': waypoint.orientation.indexOf('N') > -1 }"
+             ng-click="editCtrl.setOrientation('N', waypoint)"
+             id="circle-N"
+             cx="380"
+             cy="312.59"
+             r="17" />
+          <circle
+             ng-class="{ 'circle-selected': waypoint.orientation.indexOf('S') > -1 }"
+             ng-click="editCtrl.setOrientation('S', waypoint)"
+             id="circle-S"
+             cx="380"
+             cy="694.90997"
+             r="17" />
+          <circle
+             ng-class="{ 'circle-selected': waypoint.orientation.indexOf('W') > -1 }"
+             ng-click="editCtrl.setOrientation('W', waypoint)"
+             id="circle-W"
+             cx="188"
+             cy="506.07999"
+             r="17" />
+          <circle
+             ng-class="{ 'circle-selected': waypoint.orientation.indexOf('E') > -1 }"
+             ng-click="editCtrl.setOrientation('E', waypoint)"
+             id="circle-E"
+             cx="570"
+             cy="506.07999"
+             r="17" />
+        </g>
+        <path
+           sodipodi:nodetypes="cccccccsccccccccccccccscsccccscccscsssccccccccccccsccccccccccccscccccsccccscsccccscccssscsssscc"
+           style="fill:#000000;fill-opacity:0.3"
+           inkscape:connector-curvature="0"
+           id="path4430"
+           d="m 932.5458,1052.6256 c -18.50912,-0.8774 -35.16003,25.6433 -84.72045,126.0006 l -56.43742,114.247 -111.33125,59.4763 c -61.2397,32.7203 -114.83649,63.0674 -119.09207,67.4194 -20.56188,21.0496 3.41642,41.4036 117.2269,99.5132 l 114.73465,58.5759 50.67094,104.5942 c 27.86605,57.52 55.52628,112.3656 61.4648,121.8898 11.09132,17.7866 22.83438,21.3503 37.7107,11.4295 4.66223,-3.1097 34.09614,-58.0828 65.4095,-122.1685 l 56.9359,-116.5087 114.9973,-60.4733 c 102.0697,-53.6718 115.2438,-62.8208 117.3394,-81.4135 2.2405,-19.901 -3.4366,-23.8978 -113.459,-80.0736 l -115.7959,-59.1334 -57.6487,-118.3363 c -31.71268,-65.088 -63.14773,-120.5017 -69.85269,-123.1386 -2.82118,-1.1079 -5.50493,-1.7912 -8.14886,-1.9167 z m -318.24703,30.3625 c -6.94989,0 -17.0904,5.4728 -22.51815,12.1681 -8.30536,10.2445 -5.31766,26.3825 18.81194,101.9411 15.76978,49.3798 32.18273,94.2768 36.47529,99.7704 10.24932,13.1184 35.54111,8.836 45.68644,-7.7351 6.03875,-9.8634 3.95314,-26.048 -8.40933,-64.9753 -9.05518,-28.5114 -15.13627,-53.1868 -13.52408,-54.8403 1.61278,-1.6513 26.66547,4.842 55.67634,14.4079 43.79769,14.4406 54.73305,15.6846 64.49838,7.3889 14.55475,-12.3659 15.19148,-34.0908 1.34368,-45.8558 -12.53361,-10.6487 -160.1365,-62.2742 -178.04319,-62.2742 z m 632.28133,0.7386 c -19.588,-0.8795 -53.3652,9.8768 -105.591,28.6309 -70.7424,25.4038 -79.141,30.4006 -81.167,48.2339 -4.197,36.9619 13.9604,41.6232 77.2008,19.857 31.1188,-10.7107 56.5875,-18.5252 56.5875,-17.3632 0,1.1631 -6.773,22.247 -15.0409,46.8484 -17.1702,51.0896 -19.2937,85.444 -5.6351,91.0878 32.2427,13.3188 41.0428,1.401 73.1006,-99.1487 26.4377,-82.9143 33.1893,-116.6856 0.5419,-118.1488 z m -317.63601,72.7576 44.01744,90.9967 44.01747,90.9966 93.8426,48.28 93.8212,48.2569 -91.9132,47.1716 -91.9131,47.1722 -45.18799,92.2883 c -24.85766,50.7631 -46.12969,92.3098 -47.26862,92.3098 -1.13904,0 -21.96986,-41.1672 -46.27172,-91.479 l -44.16911,-91.4791 -90.05333,-48.1647 -90.05333,-48.1648 89.37801,-46.9411 89.37801,-46.9642 46.18489,-92.149 46.18489,-92.1275 z m 4.75404,188.1108 c -96.10976,0 -129.8275,129.8061 -44.86266,172.7318 31.29356,15.8105 55.92289,14.7589 85.41185,-3.6478 30.34918,-18.9427 49.50038,-61.8614 43.12878,-96.6297 -6.467,-35.2902 -49.37656,-72.4575 -83.68065,-72.4575 z m -1.88554,61.556 c 7.2956,0 16.76508,6.7071 21.04425,14.8929 10.0628,19.2487 9.94274,20.2832 -4.03118,34.5882 -13.6913,14.016 -17.35089,14.3912 -35.17503,3.7635 -24.42621,-14.5644 -11.2296,-53.2446 18.1618,-53.2446 z m -263.71764,162.0177 c -8.15315,-0.4502 -16.13532,2.5641 -21.30419,9.1897 -4.12739,5.2905 -20.40216,50.0208 -36.17194,99.4006 -24.12981,75.5554 -27.1173,91.7202 -18.81194,101.9625 13.30648,16.4141 14.95619,16.1718 109.49288,-15.7933 93.02796,-31.4549 103.15239,-37.4277 99.97946,-59.0637 -4.31143,-29.3796 -23.86611,-33.0906 -78.54074,-14.8924 -27.85104,9.2696 -51.96209,15.5045 -53.57535,13.8537 -1.61267,-1.6508 4.72177,-27.3076 14.06594,-57.0055 14.10614,-44.8364 15.32064,-56.0408 7.21681,-66.0366 -5.86778,-7.2378 -14.1919,-11.1621 -22.3445,-11.6139 z m 521.79695,3.4173 c -19.1277,0 -22.9137,3.2812 -24.967,21.6119 -1.3315,11.8856 4.362,42.1839 12.6569,67.3283 8.2951,25.1449 13.0041,45.7169 10.4679,45.7169 -2.5361,0 -27.247,-7.4547 -54.9206,-16.5785 -58.8332,-19.3978 -74.7943,-16.0576 -74.7943,15.7006 0,24.7189 -0.3575,24.527 116.5141,65.8062 58.3186,20.5977 64.9003,21.8005 82.0727,15.0542 18.477,-7.2586 13.7996,-44.5587 -16.7967,-133.8472 -26.845,-78.3425 -28.3725,-80.7918 -50.2379,-80.7918 z"
+           inkscape:export-xdpi="87.938904"
+           inkscape:export-ydpi="87.938904" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -14,5 +14,29 @@ app.constants = {
     SMARTPHONE : 620,
     TABLET : 1099,
     DEKTOP : 1400
+  },
+  STEPS : {
+    'climbing_outdoor' : 5,
+    'climbing_indoor' :  5,
+    'hut' : 5,
+    'shelter' : 5,
+    'access' : 5,
+    'local_product' : 5,
+    'paragliding_takeoff' : 5,
+    'paragliding_landing' : 5
+  },
+  REQUIRED_FIELDS : {
+    waypoint: {
+      step_1 : ['title' , 'lang', 'waypoint_type'],
+      step_2 : ['longitude', 'latitude', 'elevation'],
+      step_3: [],
+      step_4: []
+    },
+    route : {
+      step_1 : ['title' , 'lang', 'waypoint_type'],
+      step_2 : ['longitude', 'latitude', 'elevation'],
+      step_3: [],
+      step_4: []
+    }
   }
 }

--- a/c2corg_ui/static/js/documentdetailsview.js
+++ b/c2corg_ui/static/js/documentdetailsview.js
@@ -38,17 +38,6 @@ app.viewDetailsDirective = function() {
           }
         }
       });
-
-      $('.heading').click(function() {
-        var menuDown = $(this).find('.glyphicon-menu-down');
-        var menuUp = $(this).find('.glyphicon-menu-right');
-        if (menuDown) {
-          menuDown.toggleClass('rotate-arrow-up');
-        } else if (menuUp) {
-          menuUp.toggleClass('rotate-arrow-down');
-        }
-        return;
-      });
     }
   };
 };

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -118,6 +118,44 @@ app.DocumentEditingController = function($scope, $element, $attrs,
   this.alerts_ = appAlerts;
 
   /**
+   * first next step would be 2 by default
+   * @export
+   */
+  this.next_step = 2;
+
+  /**
+   * Current step is 1by default
+   * @export
+   */
+  this.current_step = 1;
+
+  /**
+   * Waypoint type initialised in the edit.html
+   * @export
+   */
+  this.waypoint_type;
+
+  /**
+   * Previous step is 0 by default
+   * @export
+   */
+  this.previous_step = 0;
+
+  /**
+   * Max possible steps for creation/edition
+   * @export
+   */
+  this.max_steps;
+
+
+  /**
+   * Waypoint init
+   * @private
+   */
+  this.scope_.waypoint = {};
+
+
+  /**
    * @type {app.Api}
    * @private
    */
@@ -352,6 +390,190 @@ app.DocumentEditingController.prototype.getCoordinatesFromPoint_ = function(
     return Math.round(coord * 1000000) / 1000000;
   });
 };
+
+
+/**
+ * Clone input
+ * @export
+ */
+
+app.DocumentEditingController.prototype.addAnotherMapsInfo = function() {
+  var template = $('#maps_info-group input:last-of-type').val('').clone();
+  template.insertBefore($('#document-add-maps'));
+}
+
+
+/**
+ * Navigate through creation/editing steps
+ * @param {number} step
+ * @param {string} direction
+ * @export
+ */
+
+app.DocumentEditingController.prototype.step = function(step, document, direction) {
+
+  switch (step) {
+    case 1:
+      $('.editing').animate({left: '0'});
+      this.animateBar_(step, direction);
+      this.previous_step = 0;
+      this.current_step = 1;
+      this.next_step = 2;
+      break;
+
+    case 2:
+      $('.editing').animate({left: '-115%'});
+      this.animateBar_(step, direction);
+      this.previous_step = 1;
+      this.current_step = 2;
+      this.next_step = 3;
+      break;
+
+    case 3:
+      $('.editing').animate({left: '-229%'});
+      this.animateBar_(step, direction);
+      this.previous_step = 2;
+      this.current_step = 3;
+      this.next_step = 4;
+      break;
+
+    case 4:
+      $('.editing').animate({left: '-343%'});
+      this.animateBar_(step, direction);
+      this.previous_step = 3;
+      this.current_step = 4;
+      this.next_step = 5;
+      break;
+
+    case 5:
+      $('.editing').animate({left: '-457%'});
+      this.animateBar_(step, direction);
+      this.previous_step = 4;
+      this.current_step = 5;
+      this.next_step = 6;
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+/**
+ * Animate the progress bar
+ * @param {number} step
+ * @param {string} direction
+ * @private
+ */
+
+app.DocumentEditingController.prototype.animateBar_ = function(step, direction) {
+  var percent = 100 / this.max_steps;
+  var green = '#7EFF1F'; // completed color
+  var gray = '#B4B4B4'; // left color
+  var willBe;
+  var nextPosition;
+  var stopBack;
+
+  $('.nav-step-selected').removeClass('nav-step-selected');
+  $('.nav-step-' + step).addClass('nav-step-selected');
+
+  if (direction === 'forwards') {
+    willBe = (percent * (step - 1)) - 10;
+    nextPosition = (percent * step) - 10;
+  } else {
+    willBe = (percent * step) - 10;
+    nextPosition = (percent * (step + 1)) - 10;
+    stopBack = willBe;
+  }
+
+  // bar animation, timeout for a gradual filling
+  var timeout = setInterval(function() {
+    // if the direction is forwards, animate bar to the right
+    if (direction === 'forwards') {
+      // animate till the end (120%)
+      if (step === this.max_steps) {
+        if (willBe >= 120) {
+          clearTimeout(timeout);
+        } else {
+          willBe++;
+        }
+        // animate to the next position ->
+      } else {
+        if (willBe >= nextPosition) {
+          clearTimeout(timeout);
+        } else {
+          willBe++;
+        }
+      }
+      // if the direction is backwards, animate bar to the left <-
+    } else {
+      if (willBe >= stopBack) {
+        nextPosition--;
+        willBe = nextPosition;
+      } else {
+        clearTimeout(timeout);
+      }
+    }
+
+    $('.progress-bar-edit')
+            .css({'background-image': '-webkit-linear-gradient(left, ' + green + ' 0,' + green + ' ' + willBe + '%,' + gray + ' ' + (willBe + 7) + '%,' + gray + ' 0%)'})
+            .css({'background-image': '-o-linear-gradient(left, ' + green + ' 0,' + green + ' ' + willBe + '%,' + gray + ' ' + (willBe + 7) + '%,' + gray + ' 0%)'})
+            .css({'background-image': '-moz-linear-gradient(left, ' + green + ' 0,' + green + ' ' + willBe + '%,' + gray + ' ' + (willBe + 7) + '%,' + gray + ' 0%)'})
+            .css({'background-image': '-ms-linear-gradient(left, ' + green + ' 0,' + green + ' ' + willBe + '%,' + gray + ' ' + (willBe + 7) + '%,' + gray + ' 0%)'})
+            .css({'background-image': 'linear-gradient(left, ' + green + ' 0,' + green + ' ' + willBe + '%,' + gray + ' ' + (willBe + 7) + '%,' + gray + ' 0%)'});
+  }.bind(this), 10);
+};
+
+
+/**
+ * Update steps, depending on the waypoint type.
+ * @param {string} waypointType
+ * @export
+ */
+
+app.DocumentEditingController.prototype.updateMaxSteps = function(waypointType) {
+  this.waypoint_type = waypointType;
+
+  if (app.constants.STEPS[waypointType]) {
+    this.max_steps = app.constants.STEPS[waypointType];
+  } else {
+    this.max_steps = 4;
+  }
+}
+
+
+/**
+ * Update arrays and creates one, if not existing
+ * form : model[property] = value, event for finding and (un)checking the checkbox
+ * @param {Object} object
+ * @param {string} property
+ * @param {string} value
+ * @param {Event} event
+ * @export
+ */
+
+app.DocumentEditingController.prototype.pushToArray = function(object, property, value, event) {
+  var pushed = app.utils.pushToArray(object, property, value);
+  var checkbox = $(event.currentTarget).find('input');
+
+  if (pushed) {
+    checkbox.prop('checked', true);
+  } else {
+    checkbox.prop('checked', false);
+  }
+}
+
+
+/**
+ * Set the orientation of a document. Can have multiple orientations
+ * @param {string} orientation
+ * @param {Object} document (route, outing, waypoint)
+ * @export
+ */
+
+app.DocumentEditingController.prototype.setOrientation = function(orientation, document) {
+  app.utils.pushToArray(document, 'orientation', orientation);
+}
 
 
 app.module.controller('appDocumentEditingController',

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -69,3 +69,10 @@ app.MainController.prototype.isPath = function(path) {
   }
 };
 
+
+/**
+ * @export
+ */
+app.MainController.prototype.animateHeaderIcon = function(e) {
+  app.utils.animateHeaderIcon(e);
+}

--- a/c2corg_ui/static/js/searchfilters.js
+++ b/c2corg_ui/static/js/searchfilters.js
@@ -2,7 +2,7 @@ goog.provide('app.searchFiltersDirective');
 goog.provide('app.SearchFiltersController');
 
 goog.require('app');
-
+goog.require('app.utils');
 
 /**
  * Provides the 'searchFiltersDirective' directive, which is used to enrich
@@ -118,50 +118,21 @@ app.SearchFiltersController = function($scope, $element, $attrs) {
  * @param {jQuery.Event | goog.events.Event} e click
  * @export
  */
-app.SearchFiltersController.prototype.selectOption = function(option,
-    optionCategory, e) {
+app.SearchFiltersController.prototype.selectOption = function(option, optionCategory, e) {
 
   // Don't close the menu after selecting an option
   e.stopPropagation();
 
-  // Shorthand
-  var optionCat = this[optionCategory];
-  var target = $(e.currentTarget);
-  var checkbox = target.find('input');
+  var checkbox = $(e.currentTarget).find('input');
+  var pushed = app.utils.pushToArray(this, optionCategory, option);
 
-  // If this property doesn't exit in the scope, create an array and
-  // push the selected option.
-  if (!optionCat) {
-    optionCat = this[optionCategory] = [];
-  }
-  this.updateFilterArray_(optionCat, target, checkbox, option);
-};
-
-
-/**
- * Push/remove the selected option into the scope property (scope_[optionCat])
- * and check/uncheck the checkbox depending if the option is already
- * in the array or not.
- *
- * @param {Array<string>} optionCat
- * @param {jQuery} target
- * @param {jQuery} checkbox
- * @param {string} option
- * @private
- */
-app.SearchFiltersController.prototype.updateFilterArray_ = function(
-    optionCat, target, checkbox, option) {
-
-  if (optionCat.indexOf(option) === -1) {
-    optionCat.push(option);
+  if (pushed) {
+    $(e.currentTarget).addClass('option-selected');
     checkbox.prop('checked', true);
-    target.addClass('option-selected');
   } else {
-    optionCat.splice(optionCat.indexOf(option), 1);
+    $(e.currentTarget).removeClass('option-selected');
     checkbox.prop('checked', false);
-    target.removeClass('option-selected');
   }
 };
-
 
 app.module.controller('appSearchFiltersController', app.SearchFiltersController);

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -30,3 +30,42 @@ app.utils.setupSmartScroll = function(mouseWheelZoomInteraction) {
     }, 500);
   });
 };
+
+
+/**
+ * Update arrays and creates one, if not existing
+ * form : object[property] = value
+ * returns true if the item has been pushed into the array, false if removed.
+ * @param {Object} object
+ * @param {string} property
+ * @param {string} value
+ * @export
+ */
+
+app.utils.pushToArray = function(object, property, value) {
+  if (!object[property]) {
+    object[property] = [];
+  }
+  if (object[property].indexOf(value) === -1) {
+    object[property].push(value);
+    return true;
+  } else {
+    object[property].splice(object[property].indexOf(value), 1);
+    return false;
+  }
+}
+
+
+/**
+ * @export
+ */
+app.utils.animateHeaderIcon = function(e) {
+  var menuDown = $(e.target).find('.glyphicon-menu-down');
+  var menuUp = $(e.target).find('.glyphicon-menu-right');
+  if (menuDown) {
+    menuDown.toggleClass('rotate-arrow-up');
+  } else if (menuUp) {
+    menuUp.toggleClass('rotate-arrow-down');
+  }
+  return;
+}

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -96,9 +96,15 @@
 </%def>
 
 <%def name="show_associated_routes(document)">\
+
     % for r in document['associations']['routes']:
+
     <div class="list-item">
-      <a href="${request.route_url('routes_view', id=r['document_id'], lang=r['locales'][0]['lang'])}">${r['locales'][0]['title']}</a>
+      % if 'title_prefix' in r['locales'][0] and r.locales[0]['title_prefix']:
+        <a href="${request.route_url('routes_view', id=r['document_id'], lang=r['locales'][0]['lang'])}">${r['locales'][0]['title']}</a>
+      % else :
+        <a href="${request.route_url('routes_view', id=r['document_id'], lang=r['locales'][0]['lang'])}">${r['locales'][0]['title']}</a>
+      % endif
       <app-delete-association parent-id="${document['document_id']}" child-id="${r['document_id']}"></app-delete-association>
     </div>
     % endfor
@@ -108,7 +114,7 @@
   % if document.get('maps') and len(document['maps']) > 0:
     <ul>
       % for m in document['maps']:
-        <li class="text-left"><b>${m['editor']}</b><br> ${m['locales'][0]['title']}</li>
+        <li class="text-left">${m['code']} - ${m['editor']} -  ${m['locales'][0]['title']}</li>
       % endfor
     </ul>
   % else :

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -122,3 +122,9 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <span translate>nov</span>
 <span translate>oct</span>
 <span translate>dec</span>
+
+<span translate>bus</span>
+<span translate>train</span>
+<span translate>service_on_demand</span>
+<span translate>cable_car</span>
+<span translate>boat</span>

--- a/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+++ b/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -13,10 +13,10 @@
         ${show_areas(route)}
 
       % if route.get('orientation'):
-        <p><span translate>orientation</span>:</p>
-        % for orient in route['orientation'] :
-          <span x-translate>${orient}</span>
-        % endfor
+        <article ng-init="orientation = ${route['orientation']}" class="value">
+          <span translate>orientation</span>:
+          <span x-translate ng-repeat="type in orientation">{{type}}{{$last ? '' : ', '}}</span>
+        </article>
       % endif
       </span>
     </div>
@@ -34,67 +34,38 @@
     <span class="detail-text accordion">
 
       % if route.get('route_types'):
-      <article>
+      <article ng-init="route_types = ${route['route_types']}" class="value">
         <b translate>route_types</b><br>
-        <ul>
-          % for type in route['route_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in route_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
     
       % if route.get('activities'):
-      <article>
+      <article ng-init="activities = ${route['activities']}" class="value">
         <b translate>activities</b><br>
-        <ul>
-          % for activity in route['activities'] :
-          <li x-translate>${activity}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in activities">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
 
       % if route.get('rock_types'):
-      <article>
+      <article ng-init="rock_types = ${route['rock_types']}" class="value">
         <b translate>rock_types</b><br>
-        <ul>
-          % for type in route['rock_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in rock_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
       
       % if route.get('climbing_outdoor_types'):
-      <article>
+      <article ng-init="climbing_outdoor_types = ${route['climbing_outdoor_types']}" class="value">
         <b translate>climbing_outdoor_types</b><br>
-        <ul>
-          % for type in route['climbing_outdoor_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in climbing_outdoor_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
       
       % if route.get('configuration'):
-      <p><span translate>configuration</span>: <b>${','.join(route['configuration'])}</b></p>
-      % endif
-
-      % if locale.get('slope'):
-      <p><span translate>slope</span>: <b>${locale['slope']}</b></p>
-      % endif
-
-      % if route.get('aid_rating'):
-      <p><span translate>aid_rating</span>: <b>${route['aid_rating']}</b></p>
-      % endif
-
-      % if route.get('mtb_length_asphalt'):
-      <p><span translate>mtb_length_asphalt</span>: <b>${route['mtb_length_asphalt']}</b></p>
-      % endif
-
-      % if route.get('mtb_length_trail'):
-      <p><span translate>mtb_length_trail</span>: <b>${route['mtb_length_trail']}</b></p>
+      <article ng-init="configuration = ${route['configuration']}" class="value">
+        <b translate>configuration</b><br>
+        <span x-translate ng-repeat="type in configuration">{{type}}{{$last ? '' : ', '}}</span>
+      </article>
       % endif
 
     </span>
@@ -107,7 +78,7 @@
 % if route.get('global_rating') or route.get('engagement_rating') or route.get('risk_rating') or route.get('exposition_rock_rating') \
   or route.get('rock_free_rating') or route.get('rock_required_rating') or route.get('rock_required_rating') or route.get('hiking_rating') \
   or route.get('hiking_mtb_exposition') or route.get('ice_rating') or route.get('mixed_rating') or route.get('snowshoe_rating')  \
-  or route.get('mtb_down_rating') or route.get('mtb_up_rating') or route.get('via_ferrata_rating'):
+  or route.get('mtb_down_rating') or route.get('mtb_up_rating') or route.get('via_ferrata_rating') or route.get('equipment_rating'):
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Rating</span><span class="glyphicon glyphicon-menu-right"></span></h4>
     <div class="name-icon">
@@ -127,7 +98,11 @@
       % if route.get('risk_rating'):
       <p><span translate>risk_rating</span>: <b>${route['risk_rating']}</b></p>
       % endif
-
+      
+      % if route.get('equipment_rating'):
+      <p><span translate>equipment_rating</span>: <b>${route['equipment_rating']}</b></p>
+      % endif
+        
       % if route.get('exposition_rock_rating'):
       <p><span translate>exposition_rock_rating</span>: <b>${route['exposition_rock_rating']}</b></p>
       % endif
@@ -171,6 +146,11 @@
       % if route.get('via_ferrata_rating'):
       <p><span translate>via_ferrata_rating</span>: <b>${route['via_ferrata_rating']}</b></p>
       % endif
+      
+      % if route.get('aid_rating'):
+      <p><span translate>aid_rating</span>: <b>${route['aid_rating']}</b></p>
+      % endif
+      
     </span>
   </div>
   % endif
@@ -179,7 +159,7 @@
 
 ## GEAR  
 <%def name="get_route_gear(route, locale)">\
-  % if route.get('equipment_rating') or route.get('glacier_gear'):
+  % if route.get('glacier_gear'):
     <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
       <h4><span translate>gear</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">
@@ -188,12 +168,8 @@
       </div>
       <span class="detail-text accordion">
 
-        % if route.get('equipment_rating'):
-        <p><span translate>equipment_rating</span>: <b>${route['equipment_rating']}</b></p>
-        % endif
-
         % if route.get('glacier_gear'):
-        <p><span translate>glacier_gear</span>: <b>${route['glacier_gear']}</b></p>
+         <p><span translate>glacier_gear</span>: <b>${route['glacier_gear']}</b></p>
         % endif
 
       </span>
@@ -211,19 +187,21 @@
       <p translate>heights</p>
     </div>
     <span class="detail-text accordion">
-
-      <p><span translate>elevation min/max</span>: <b>${route['elevation_min']} m / ${route['elevation_max']} m </b></p>
-
+      
+      % if route.get('elevation_min') or route.get('elevation_max'):
+        <p><span translate>elevation</span>: <b>min ${route['elevation_min']} m / max ${route['elevation_max']} m</b></p>
+      % endif
+      
+      % if route.get('route_length'):
+      <p><span translate>route_length</span>: <b>${route['route_length']}</b></p>
+      % endif
+      
       % if route.get('height_diff_up'):
       <p><span translate>height_diff_up</span>: <b>${route['height_diff_up']} m</b></p>
       % endif
 
       % if route.get('height_diff_down'):
       <p><span translate>height_diff_down</span>: <b>${route['height_diff_down']} m</b></p>
-      % endif
-
-      % if route.get('route_length'):
-      <p><span translate>route_length</span>: <b>${route['route_length']}</b></p>
       % endif
 
       % if route.get('mtb_height_diff_portages'):
@@ -233,6 +211,18 @@
       %if route.get('height_diff_difficulties'):
       <p><span translate>height_diff_difficulties</span>: <b>${route['height_diff_difficulties']} m</b></p>
       % endif
+      
+      % if route.get('mtb_length_asphalt'):
+      <p><span translate>mtb_length_asphalt</span>: <b>${route['mtb_length_asphalt']}</b></p>
+      % endif
+
+      % if route.get('mtb_length_trail'):
+      <p><span translate>mtb_length_trail</span>: <b>${route['mtb_length_trail']}</b></p>
+      % endif
+      
+      % if locale.get('slope'):
+      <p><span translate>slope</span>: <b>${locale['slope']}</b></p>
+      % endif
 
     </span>
   </div>
@@ -240,23 +230,25 @@
 
 ## ACCESS
 <%def name="get_route_access(route)">\
-  <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
-    <h4><span translate>Access</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-    <div class="name-icon">
-      <span class="glyphicon glyphicon-road"></span>
-      <p translate>Access</p>
+  % if route.get('lift_access') or route.get('height_diff_access'):
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>Access</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-road"></span>
+        <p translate>Access</p>
+      </div>
+      <span class="detail-text accordion">
+        % if route.get('lift_access') and route['lift_access'] is not 'None':
+          <b translate>lift_access</b>
+        % endif
+
+        % if route.get('height_diff_access'):
+          <p><span translate>height_diff_access</span>: <b>${route['height_diff_access']}</b></p>
+        % endif
+
+      </span>
     </div>
-    <span class="detail-text accordion" ng-init="lift_access = ${route['lift_access']}">
-
-      <span translate>Has lift access</span>:
-      <b ng-cloak>{{lift_access == 'None' ? mainCtrl.translate('No'): mainCtrl.translate('Yes')}}</b>
-
-      % if route.get('height_diff_access'):
-        <p><span translate>height_diff_access</span>: <b>${route['height_diff_access']}</b></p>
-      % endif
-      
-    </span>
-  </div>
+  % endif
 </%def>
 
 ## MAPS

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -59,7 +59,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     % endif
   
   <div class="thumbnail view-details-informations tab  col-sm-12">
-    <h3 class="heading informations" data-toggle="collapse" data-target="#document-informations">
+    <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
@@ -131,7 +131,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
       <section>
         % if 'waypoints' in route['associations'] and  len(route['associations']['waypoints']) > 0 :
         <article>
-          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-waypoints">
+          <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-waypoints">
             <span translate>Associated waypoints</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
           <div class="associated-documents collapse in" id="associated-waypoints">
@@ -144,7 +144,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
         % endif
         % if 'routes' in route['associations'] and  len(route['associations']['routes']) > 0 :
         <article>
-          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-routes">
+          <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-routes">
             <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
           <div class="associated-documents collapse in" id="associated-routes">
@@ -170,7 +170,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 ${show_float_buttons('routes', route_id, lang, other_langs, missing_langs)}
 
 <div class="text-center">
-  <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span> <span class="glyphicon glyphicon-menu-up"></span></button>
+  <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span>&nbsp;<span class="glyphicon glyphicon-menu-up"></span></button>
 </div>
 
 <script>

--- a/c2corg_ui/templates/waypoint/create_edit_summary.html
+++ b/c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1,0 +1,284 @@
+
+<figure>
+  ## TITLE & TYPES
+  <h3>ttle & types</h3>
+  <p><label translate>title</label>  
+    <input disabled class="form-control" value="{{waypoint.locales[0].title}}">
+  </p>
+  <p><label translate>waypoint_type</label> 
+    <input disabled class="form-control" value="{{mainCtrl.translate(waypoint.waypoint_type)}}">
+  </p>
+  <p><label translate>lang</label>
+    <input disabled class="form-control" value="{{mainCtrl.translate(waypoint.locales[0].lang)}}">
+  </p>
+  <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'">
+    <label translate>orientation</label>  {{waypoint.orientation}}</p>
+  <p ng-if="waypoint.areas[0].locales[0].title"><label translate>country</label>  {{waypoint.areas[0].locales[0].title}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>children_proof</label>  {{waypoint.children_proof}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>rain_proof</label>  {{waypoint.rain_proof}}</p>
+
+  <article ng-if="waypoint.waypoint_type == 'weather_station'">
+    <label translate>weather_station_types</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['weather_station_types']" >{{type| translate}}</li>
+    </ul>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'local_product'">
+    <label translate>product_types</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['product_types']" >{{type | translate}}</li>
+    </ul>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' && waypoint.climbing_outdoor_types[0] != ''">
+    <label translate>climbing_outdoor_types</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['climbing_outdoor_types']">{{type| translate}}</li>
+    </ul>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>climbing_indoor_types</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['climbing_indoor_types']">{{type| translate}}</li>
+    </ul>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>climbing_styles</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['climbing_styles']">{{type| translate}}</li>
+    </ul>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+    <label translate>rock_types</label><br>
+    <ul class="types">
+      <li ng-repeat="type in waypoint['rock_types']">{{type| translate}}</li>
+    </ul>
+  </article>
+
+</figure>
+
+## DESCRIPTION
+<figure>
+  <h3>text</h3>
+  <p><label translate>description</label>
+    "{{waypoint.locales[0].description}}"
+  <p><label translate>summary</label>
+    "{{waypoint.locales[0].summary}}"
+</figure>
+
+## NUMBERS
+<figure>
+  <h3>numbers</h3>
+
+  <article>
+    <label translate>elevation</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.elevation}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'access'">
+    <label translate>elevation_min</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.elevation_min}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">
+    <label translate>length</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.length}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">
+    <label translate>slope</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.slope}}">
+      <span class="input-group-addon"> &#176;</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'summit'">
+    <label translate>prominence</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.prominence}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>height_max</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_max}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>height_min</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_min}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>height_median</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_median}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+    <label translate>routes_quantity</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.routes_quantity}}">
+      <span class="input-group-addon">m</span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
+    <label translate>capacity</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.capacity}}">
+      <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
+    <label translate>capacity_staffed</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.capacity_staffed}}">
+      <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
+    </div>
+  </article>
+
+</figure>
+
+## RATINGS
+<figure ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'access'
+          ||  waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
+  <h3>ratings</h3>
+  <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"><label translate>paragliding_rating</label>  {{waypoint.paragliding_rating}}</p>
+  <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"><label translate>exposition_rating</label>  {{waypoint.exposition_rating}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_max</label>  {{waypoint.climbing_rating_max}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_min</label>  {{waypoint.climbing_rating_min}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_median</label>  {{waypoint.climbing_rating_median}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>equipment_rating</label>  {{waypoint.equipment_rating}}</p>
+</figure>
+
+## TRANSPORTS
+<figure ng-if="waypoint.waypoint_type == 'access'">
+  <h3>transports</h3>
+  <article>
+    <label translate>public_transportation_types</label><br>
+    <ul >
+      <li ng-repeat="type in waypoint['public_transportation_types']" >{{type | translate}}</li>
+    </ul>
+  </article>
+  <p><label translate>public_transportation_rating</label>  
+    <input class="form-control" disabled value="{{waypoint.public_transportation_rating | translate}}">
+  </p>
+  <p><label translate >parking_fee</label> 
+  <input class="form-control" disabled value=" {{waypoint.parking_fee}}">
+  </p>
+  <p><label translate>parking_fee_type</label>  
+    <input class="form-control" disabled value="{{waypoint.parking_fee_type | translate}}">
+  </p>
+  <p><label translate>lift_access</label>  
+    <input class="form-control" disabled value="{{waypoint.lift_access | translate}}">
+  </p>
+</figure>
+
+## MAPS
+<figure>
+  <h3>maps</h3>
+  <p><label translate>lonlat</label> 
+    <input class="form-control" disabled value=" {{waypoint.lonlat.longitude}} °W / {{waypoint.lonlat.latitude}} °N">
+  </p>
+  <label translate>maps_info</label>
+  <p  ng-repeat="map in waypoint.maps">{{map.code}}  {{map.editor}}   {{map.locales[0].title}}</p>
+</figure>
+
+## CONTACT
+<figure  ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite'
+            || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'webcam'
+            || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'climbing_outdoor'">
+  <h3>contact</h3>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product'
+              || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'weather_station'
+              || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'webcam'">
+    <label translate>url</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.url}}">
+      <span class="input-group-addon">@</span></span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite'
+              || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut'">
+    <label translate>phone</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.phone}}">
+      <span class="input-group-addon"><span class="glyphicon glyphicon-earphone"></span></span>
+    </div>
+  </article>
+
+  <article ng-if="waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite'">
+    <label translate>phone_custodian</label>
+    <div class="input-group">
+      <input type="text" class="form-control" disabled value="{{waypoint.phone_custodian}}">
+      <span class="input-group-addon"><span class="glyphicon glyphicon-earphone"></span></span>
+    </div>
+  </article>
+
+  <p ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'camp_site'"><label translate>custodianship</label>  {{waypoint.custodianship}}</p>
+</figure>
+
+## EQUIPMENT
+<figure ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
+  <h3>equipment</h3>
+  <p><label translate>matress_unstaffed</label>  {{waypoint.matress_unstaffed}}</p>               
+  <p><label translate>heating_unstaffed</label>  {{waypoint.heating_unstaffed}}</p>
+  <p><label translate >blanket_unstaffed</label>  {{waypoint.blanket_unstaffed}}</p>
+  <p><label translate>gas_unstaffed</label>  {{waypoint.gas_unstaffed}}</p>
+</figure>
+
+## ACCESS
+<figure  ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'camp_site'">
+  <h3>access</h3>
+  <p ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product'">
+    <label translate>access</label>
+    "{{waypoint.locales[0].access}}"
+
+  <p ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site'">
+    <label translate>access_period</label>
+    "{{waypoint.locales[0].access_period}}"
+  <p ng-if="waypoint.waypoint_type == 'access'">
+    <label translate>snow_clearance_rating</label>
+    <input class="form-control" disabled value="{{waypoint.snow_clearance_rating}}">
+  </p>
+
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+    <label translate>access_time</label>  
+    {{waypoint.access_time}}
+  </p>
+  <article ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+    <label translate>best_periods</label><br>
+    <ul >
+      <li ng-repeat="month in waypoint['best_periods']">
+        {{month}}
+      </li>
+    </ul>
+  </article>
+</figure>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -1,145 +1,773 @@
 <%!
-from c2corg_common.attributes import default_langs
+  from c2corg_common.attributes import default_langs, climbing_outdoor_types, public_transportation_types, climbing_indoor_types, product_types, ground_types, weather_station_types, \
+  rain_proof_types, public_transportation_ratings, children_proof_types, snow_clearance_ratings, exposition_ratings, rock_types, orientation_types, months, parking_fee_types, climbing_styles, \
+  access_times, climbing_ratings, equipment_ratings, map_editors
 %>
+
 <%inherit file="../base.html"/>
 <%
-updating_doc = waypoint_id and waypoint_lang
+  updating_doc = waypoint_id and waypoint_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
 
-<%block name="pagetitle"><title ng-init="id=${waypoint_id if waypoint_id else 0}" 
-                                ng-bind="id ? mainCtrl.page_title('Editing a waypoint') : mainCtrl.page_title('Creating a waypoint')">${show_title('Create/edit waypoint')}</title></%block>
+<%block name="pagetitle">
+<title ng-init="id = ${waypoint_id if waypoint_id else 0}" ng-bind="id ?
+          mainCtrl.page_title('Editing a waypoint') : mainCtrl.page_title('Creating a waypoint')">${show_title('Create/edit waypoint')}
+</title>
+</%block>
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
+
 <section class="create-edit-document">
-  <h1 ng-init="id=${waypoint_id if waypoint_id else 0}" ng-bind="id ? ('Editing a waypoint' | translate) : ('Creating a waypoint' | translate)" class="text-center"></h1>
+
+  <h1 ng-init="id = ${waypoint_id if waypoint_id else 0}" class="text-center">
+    <label class="label label-primary" ng-bind="id ? ('Editing a waypoint' | translate) : ('Creating a waypoint' | translate)"></label>
+  </h1>
+
   <form app-loading app-document-editing="waypoints" app-document-editing-model="waypoint"
-  % if updating_doc:
-    app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
-  % endif
-  class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
-    <div id="lang-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid,
-                                'has-success':  editForm.lang.$valid}">
-      <label><span translate>lang</span> *</label>
-      % if waypoint_lang:
-        <span x-translate>${waypoint_lang}</span>
-      % else:
-        <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate"
-          ng-model="waypoint.locales[0].lang" class="form-control" required>
-        </select>
-        <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid"></span>
-        <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$invalid && editForm.lang.$touched"></span>
-        <div class="help-block" ng-messages="editForm.lang.$error">
-          <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-        </div>
-      % endif
+        % if updating_doc:
+        app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
+        % endif
+        class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    
+    ## Init max steps. It won't work with ng-init
+    <span class="ng-hide">
+      {{editCtrl.updateMaxSteps(waypoint.waypoint_type)}} 
+      {{editCtrl.waypoint_type = waypoint.waypoint_type}}
+    </span>
+
+    ## PROGRESS BAR
+    <ul class="progress-bar-edit">
+      <li class="nav-step-1"ng-click="editCtrl.step(1, 'waypoint',  'backwards')" ng-class="{'nav-step-selected': editCtrl.current_step == 1 }"><span class="nav-text"><span translate>title</span> & <span translate>types</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
+      <li class="nav-step-2" ng-click="editCtrl.step(2, 'waypoint', editCtrl.previous_step >= 2 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>maps</span> & <span translate>numbers</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
+      <li class="nav-step-3" ng-click="editCtrl.step(3, 'waypoint', editCtrl.previous_step >= 3 ? 'backwards' : 'forwards')" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'
+                || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
+        <span class="nav-text"><span translate>ratings</span> <span ng-if="waypoint.waypoint_type == 'climbing_outdoor'"> & <span translate>access</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
+      </li>
+      <li class="nav-step-3"  ng-click="editCtrl.step(3, 'waypoint', editCtrl.previous_step >= 3 ? 'backwards' : 'forwards')" ng-if="waypoint.waypoint_type == 'access'
+                || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'" >
+        <span class="nav-text">
+          <span translate ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'hut'" translate>access</span>
+          <span translate ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'access'"> & </span>
+          <span ng-if="waypoint.waypoint_type == 'access'" translate>transports</span>
+          <span ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'"><span translate>equipment</span></span>
+        </span>
+        <span class="bullet-container"><span class="bullet"></span></span>
+      </li>
+      <li class="nav-step-{{editCtrl.max_steps -1}}" ng-click="editCtrl.step((editCtrl.max_steps - 1), 'waypoint',  editCtrl.previous_step >= ((editCtrl.max_steps > 4) ? 4 : 3) ? 'backwards' : 'forwards')" >
+        <span class="nav-text">
+          <span translate>description</span> 
+          <span ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'webcam'
+                    || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'weather_station'">& 
+            <span translate>contact</span>
+          </span>
+        </span>
+        <span class="bullet-container"><span class="bullet"></span></span>
+      </li>
+      <li class="nav-step-{{editCtrl.max_steps}}" ng-click="editCtrl.step(editCtrl.max_steps, 'forwards')"><span translate class="nav-text">summary</span><span class="bullet-container"><span class="bullet"></span></span></li>
+    </ul>
+
+    ## NAV BUTTONS
+    <div class="nav-buttons">
+      <button class="btn btn-primary prev" type="button" ng-if="editCtrl.previous_step !== 0" ng-click="editCtrl.step(editCtrl.previous_step, 'waypoint', 'backwards')"><span class="glyphicon glyphicon-triangle-left"></span></button>
+      <button class="btn btn-primary next" type="button" ng-if="editCtrl.next_step <= editCtrl.max_steps" ng-click="editCtrl.step(editCtrl.next_step, 'waypoint', 'forwards')"><span class="glyphicon glyphicon-triangle-right"></span></button>
     </div>
-    <div id="title-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid,
-                                'has-success':  editForm.title.$valid }">
-      <label><span translate>title</span> *</label>
-      <input type="text" name="title" ng-model="waypoint.locales[0].title" class="form-control" required ng-minlength="3" />
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
-      <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-      <div class="help-block" ng-messages="editForm.title.$error">
-        <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-        <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+
+    <section class="editing">
+      <div class="step step-1">
+        <section class="section title">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#title-edit">
+            <span translate>title</span><span class="glyphicon glyphicon-menu-down"></span>
+          </h2>
+        
+          <div class="content collapse in" id="title-edit">
+            ## TITLE
+            <div id="title-group" class="form-group data full" 
+                 ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
+              <label><span translate>title</span> *</label>
+              <input type="text" name="title" ng-model="waypoint.locales[0].title" class="form-control" required ng-minlength="3" />
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
+              <div class="help-block" ng-messages="editForm.title.$error">
+                <p ng-message="required" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                <p ng-message="minlength" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : ''}}" translate>Title must have at least 3 characters.</p>
+              </div>
+            </div>
+
+            ## LANGUAGE
+            <div id="lang-group" class="form-group data half" 
+                 ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
+              <label><span translate>lang</span> *</label>
+              % if waypoint_lang:
+              <input class="form-control" disabled x-translate value="${waypoint_lang}">
+              % else:
+              <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate"
+                      ng-model="waypoint.locales[0].lang" class="form-control" required></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$invalid && editForm.lang.$touched"></span>
+              <div class="help-block" ng-messages="editForm.lang.$error">
+                <p ng-message="required" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+              </div>
+              % endif
+            </div>
+
+          </div>
+        </section>
+
+        ## TYPES & STYLES
+        <section class="section ">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-types-styles"><span translate>Types & styles</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-types-styles">
+
+            <div class="data half">
+              ## WAYPOINT TYPE
+              <div id="waypoint_type-group" class="form-group data full" ng-class="{ 'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid, 'has-success': editForm.waypoint_type.$valid }">
+                <label><span translate>waypoint_type</span> *</label>
+                <select name="waypoint_type" ng-change="editCtrl.updateMaxSteps(waypoint.waypoint_type)" ng-options="type as mainCtrl.translate(type) for type in ['${"','".join(waypoint_types) |n}'] | translate" ng-model="waypoint.waypoint_type" class="form-control " required></select>
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.waypoint_type.$valid"></span>
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched"></span>
+                <div class="help-block" ng-messages="editForm.waypoint_type.$error">
+                  <p ng-message="required" style="{{ (editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                </div>
+              </div>
+
+              ## RAIN PROOF
+              <div class="form-group data full" ng-if="waypoint.waypoint_type == 'climbing_outdoor'" ng-class="{ 'has-error': editForm.rain_proof.$touched && editForm.rain_proof.$invalid, 'has-success': editForm.rain_proof.$valid }">
+                <label><span translate>rain_proof</span></label>
+                <select class="form-control " ng-model="waypoint.rain_proof" ng-options="type as mainCtrl.translate(type) for type in ${rain_proof_types}"></select>
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.rain_proof"></span>
+              </div>
+
+              ## CHILDREN PROOF
+              <div class="form-group data full" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+                <label translate>children_proof</label>
+                <select ng-options="type as type for type in ${children_proof_types}" ng-model="waypoint.children_proof" class="form-control "></select>
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.children_proof"></span>
+              </div>
+
+            </div>
+
+            ## ORIENTATION
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'"
+                 ng-class="{ 'has-error': editForm.orientation.$touched && editForm.orientation.$invalid,'has-success': editForm.orientation.$valid }">
+              <label><span translate>orientation</span></label>
+              <ul class="types long" id="orientation-list">
+                <li ng-repeat="type in ${orientation_types}" ng-click="editCtrl.pushToArray(waypoint, 'orientation', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.orientation.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+              <%include file="c2corg_ui:static/img/orientation.svg" />
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.orientation.$valid"></span>
+            </div>
+
+            ## WEATHER STATION TYPES
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'weather_station'"
+                 ng-class="{ 'has-error': editForm.weather_station_types.$touched && editForm.weather_station_types.$invalid, 'has-success': editForm.weather_station_types.$valid }">
+              <label><span translate>weather_station_types</span></label>
+              <ul class="types">
+                <li ng-repeat="type in ${weather_station_types}" ng-click="editCtrl.pushToArray(waypoint, 'weather_station_types', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.weather_station_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+            ## CLIMBING OUT TYPES
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+              <label translate>climbing_outdoor_types</label>
+              <ul class="types">
+                <li ng-repeat="type in ${climbing_outdoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_outdoor_types', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_outdoor_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+            ## CLIMBING STYLES
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+              <label translate>climbing_styles</label>
+              <ul class="types">
+                <li ng-repeat="type in ${climbing_styles}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_styles', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_styles.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+            ## CLIMBING INT TYPES
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor'">
+              <label translate>climbing_indoor_types</label>
+              <ul class="types">
+                <li ng-repeat="type in ${climbing_indoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_indoor_types', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_indoor_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+
+            ## ROCK TYPES
+            <div id="rock_types-group" class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+              <label translate>rock_types</label>
+              <ul class="types long">
+                <li ng-repeat="type in ${rock_types}" ng-click="editCtrl.pushToArray(waypoint, 'rock_types', type, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.rock_types.indexOf(type) > - 1"><span translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+            ## PRODUCT TYPES
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'local_product'">
+              <label><span translate>product_types</span><span ng-if="waypoint.waypoint_type == 'local_product'"> *</span></label>
+              <ul class="types" required>
+                <li ng-repeat="type in ${product_types}" ng-click="editCtrl.pushToArray(waypoint, 'product_types', type, $event)">
+                  <div class="checkbox"><input type="checkbox"><span x-translate>{{type}}</span></div>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+        </section>
       </div>
-    </div>
-    <div id="waypoint_type-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid,
-                                'has-success': editForm.waypoint_type.$valid }">
-      <label><span translate>waypoint_type</span> *</label>
-      <select name="waypoint_type" ng-options="type as mainCtrl.translate(type) for type in ['${"','".join(waypoint_types) |n}'] | translate"
-        ng-model="waypoint.waypoint_type" class="form-control" required>
-      </select>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.waypoint_type.$valid"></span>
-      <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched"></span>
-      <div class="help-block" ng-messages="editForm.waypoint_type.$error">
-        <p ng-message="required" class="label label-danger" style="{{ (editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+      
+      <div class="step step-2">
+        ## NUMBERS
+        <section class="section numbers">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-numbers"><span translate>Numbers</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-numbers">
+
+            ## ELEVATION
+            <div id="elevation-group" class="form-group data half" ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid, 'has-success': editForm.elevation.$valid && waypoint.elevation }">
+              <label><span translate>elevation</span> <span ng-if="waypoint.waypoint_type != 'climbing_indoor'">*</span></label>
+              <div class="input-group">
+                <input type="number" name="elevation" min="0" ng-model="waypoint.elevation" class="form-control" ng-required="waypoint.waypoint_type != 'climbing_indoor'" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation.$valid && waypoint.elevation"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && editForm.elevation.$touched"></span>
+              <div class="help-block" ng-messages="editForm.elevation.$error">
+                <p ng-message="required" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                <p ng-message="max" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be  than 9999 m.</p>
+                <p ng-message="number" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## ELEVATION MIN
+            <div id="elevation_min-group" ng-if="waypoint.waypoint_type == 'access'" class="form-group data half" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid, 'has-success': editForm.elevation_min.$valid && waypoint.elevation_min}">
+              <label translate>elevation_min</label>
+              <div class="input-group">
+                <input type="number" name="elevation_min" min="0" ng-model="waypoint.elevation_min" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_min.$valid && elevation.elevation_min"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$invalid && editForm.elevation_min.$touched"></span>
+              <div class="help-block" ng-messages="editForm.elevation_min.$error">
+                <p ng-message="required" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                <p ng-message="max" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be  than 9999 m.</p>
+                <p ng-message="number" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ##  PROMINENCE
+            <div id="prominence-group" ng-if="waypoint.waypoint_type == 'summit'" class="form-group data half" ng-class="{ 'has-error': editForm.prominence.$touched && editForm.prominence.$invalid, 
+                      'has-success': editForm.prominence.$valid && waypoint.prominence }">
+              <label><span translate>prominence</span></label>
+              <div class="input-group">
+                <input type="number" name="prominence" min="0" ng-model="waypoint.prominence" class="form-control"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.prominence.$valid && waypoint.prominence"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.prominence.$invalid && editForm.prominence.$touched"></span>
+              <div class="help-block" ng-messages="editForm.prominence.$error">
+                <p ng-message="number" style="{{ (editForm.prominence.$invalid && editForm.prominence.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## LENGTH
+            <div id="length-group" class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+                 ng-class="{ 'has-error': editForm.length.$touched && editForm.length.$invalid, 'has-success': editForm.length.$valid && waypoint.length  }">
+              <label translate>length</label>
+              <div class="input-group">
+                <input type="number" name="length" min="0" ng-model="waypoint.length" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.length.$valid && waypoint.length"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.length.$invalid && editForm.length.$touched"></span>
+              <div class="help-block" ng-messages="editForm.length.$error">
+                <p ng-message="number" style="{{ (editForm.length.$invalid && editForm.length.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## SLOPE
+            <div id="slope-group" class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+                 ng-class="{ 'has-error': editForm.slope.$touched && editForm.slope.$invalid, 'has-success': editForm.slope.$valid && waypoint.slope }">
+              <label translate>slope</label>
+              <div class="input-group">
+                <input type="number" name="slope" min="0" ng-model="waypoint.slope" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.slope.$valid && waypoint.slope"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.slope.$invalid && editForm.slope.$touched"></span>
+              <div class="help-block" ng-messages="editForm.slope.$error">
+                <p ng-message="number" style="{{ (editForm.slope.$invalid && editForm.slope.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## HEIGHT MAX
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.height_max.$touched && editForm.height_max.$invalid,
+                                      'has-success': editForm.height_max.$valid && waypoint.height_max}">
+              <label><span translate>height_max</span></label>
+              <div class="input-group">
+                <input type="number" name="height_max" min="0" ng-model="waypoint.height_max" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_max.$valid && waypoint.height_max"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_max.$invalid && editForm.height_max.$touched"></span>
+              <div class="help-block" ng-messages="editForm.height_max.$error">
+                <p ng-message="number" style="{{ (editForm.height_max.$invalid && editForm.height_max.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## HEIGHT MIN
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.height_min.$touched && editForm.height_min.$invalid,'has-success': editForm.height_min.$valid && waypoint.height_min}">
+              <label><span translate>height_min</span></label>
+              <div class="input-group">
+                <input type="number" name="height_min" min="0" ng-model="waypoint.height_min" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_min.$valid && waypoint.height_min"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_min.$invalid && editForm.height_min.$touched"></span>
+              <div class="help-block" ng-messages="editForm.height_min.$error">
+                <p ng-message="number" style="{{ (editForm.height_min.$invalid && editForm.height_min.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## HEIGHT MEDIAN
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.height_median.$touched && editForm.height_median.$invalid,
+                                      'has-success': editForm.height_median.$valid && waypoint.height_median }">
+              <label><span translate>height_median</span></label>
+              <div class="input-group">
+                <input type="number" name="height_median" min="0" ng-model="waypoint.height_median" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_median.$valid && waypoint.height_median"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_median.$invalid && editForm.height_median.$touched"></span>
+              <div class="help-block" ng-messages="editForm.height_median.$error">
+                <p ng-message="number" style="{{ (editForm.height_median.$invalid && editForm.height_median.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## ROUTES QUANTITY
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid,
+                                      'has-success': editForm.routes_quantity.$valid && waypoint.routes_quantity }">
+              <label><span translate>routes_quantity</span></label>
+              <div class="input-group">
+                <input type="number" name="routes_quantity" min="0" ng-model="waypoint.routes_quantity" class="form-control" max="9999"/>
+                <span class="input-group-addon">m</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.routes_quantity.$valid && waypoint.routes_quantity"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.routes_quantity.$invalid && editForm.routes_quantity.$touched"></span>
+              <div class="help-block" ng-messages="editForm.routes_quantity.$error">
+                <p ng-message="number" style="{{ (editForm.routes_quantity.$invalid && editForm.routes_quantity.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## CAPACITY
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'shelter'"
+                 ng-class="{ 'has-error': editForm.capacity.$touched && editForm.capacity.$invalid, 'has-success': editForm.capacity.$valid && waypoint.capacity }">
+              <label translate>capacity</label>
+              <div class="input-group">
+                <input type="number" name="capacity" ng-model="waypoint.capacity"class="form-control" min="0" />
+                <span class="input-group-addon glyphicon glyphicon-user"></span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.capacity.$valid && waypoint.capacity"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.capacity.$invalid && editForm.capacity.$touched"></span>
+              <div class="help-block" ng-messages="editForm.capacity.$error">
+                <p ng-message="number" style="{{ (editForm.capacity.$invalid && editForm.capacity.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+            ## CAPACITY STAFFED
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'"
+                 ng-class="{ 'has-error': editForm.capacity_staffed.$touched && editForm.capacity_staffed.$invalid, 'has-success': editForm.capacity_staffed.$valid && waypoint.capacity_staffed }">
+              <label translate>capacity_staffed</label>
+              <div class="input-group">
+                <input type="number" name="capacity_staffed" ng-model="waypoint.capacity_staffed"class="form-control" min="0" />
+                <span class="input-group-addon glyphicon glyphicon-user"></span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.capacity_staffed.$valid && waypoint.capacity_staffed"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.capacity_staffed.$invalid && editForm.capacity_staffed.$touched"></span>
+              <div class="help-block" ng-messages="editForm.capacity_staffed.$error">
+                <p ng-message="number" style="{{ (editForm.capacity_staffed.$invalid && editForm.capacity_staffed.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              </div>
+            </div>
+
+          </div>
+        </section>
+        
+       ## MAPS
+        <section class="section maps-info">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-maps"><span translate>geolocation</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-maps">
+
+             ## LONGITUDE
+            <div id="longitude-group" class="form-group data half" ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
+                                      'has-success': editForm.longitude.$valid && waypoint.lonlat.longitude}">
+              <label><span translate>longitude</span> *</label>
+              <div class="input-group">
+                <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" required required min="-90" max="90" />
+                <span class="input-group-addon">°N</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && waypoint.lonlat.longitude"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
+              <div class="help-block" ng-messages="editForm.longitude.$error">
+                <p ng-message="required" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                <p ng-message="number" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+                <p ng-message="min" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+              </div>
+            </div>
+
+            ## LATITUDE
+            <div id="latitude-group" class="form-group data half" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
+                                      'has-success': editForm.latitude.$valid && waypoint.lonlat.latitude}">
+              <label><span translate>Latitude</span> *</label>
+              <div class="input-group">
+                <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" required required min="-90" max="90" />
+                <span class="input-group-addon">°N</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.latitude.$valid && waypoint.lonlat.latitude"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
+              <div class="help-block" ng-messages="editForm.latitude.$error">
+                <p ng-message="required" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+                <p ng-message="number" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+                <p ng-message="min" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+              </div>
+            </div>
+
+            <app-map app-map-edit-ctrl="editCtrl" app-map-draw-type="Point" class="map-edit"></app-map>
+
+            ## MAPS REF
+            <div id="maps_info-group" class="input-group">
+              <label translate>maps_references</label>
+              <div ng-repeat="map in waypoint.maps" class="map-info">
+                <input disabled value="{{map.code}} - {{map.editor}} - {{map.locales[0].title}}" class="form-control">
+                <span class="glyphicon glyphicon-trash"></span>
+              </div>
+              <div class="map-info">
+                <input type="text" name="maps_info" ng-model="waypoint.maps_info" class="form-control" placeholder="{{maps_info}}"/>
+                <button id="document-add-maps" type="button" class="btn btn-default" ng-click="editCtrl.addAnotherMapsInfo()"><span class="glyphicon glyphicon-plus"></span></button>
+              </div>
+            </div>
+
+          </div>
+        </section>
       </div>
-    </div>
-    <div id="elevation-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid,
-                               'has-success': editForm.elevation.$valid }">
-      <label><span translate>elevation</span> *</label>
-      <div class="input-group">
-        <input type="number" name="elevation" min="0" ng-model="waypoint.elevation" class="form-control" required max="9999"/>
-        <span class="input-group-addon">m</span>
+
+      <div class="step step-{{(editCtrl.max_steps == 5) ? 3 : 3}}" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'access' ||
+                waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
+        ##RATINGS
+        <section class="section ratings" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-ratings"><span translate>ratings</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-ratings">
+
+            ## PARAGLIDING RATING
+            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+                 ng-class="{ 'has-error': editForm.paragliding_rating.$touched && editForm.paragliding_rating.$invalid, 'has-success': editForm.paragliding_rating.$valid }">
+              <label><span translate>paragliding_rating</span></label><br>
+              <uib-rating ng-model="waypoint.paragliding_rating" max="6" on-hover="hoverRating(value)" on-leave="overStar = null" titles="['one','two','three']" aria-labelledby="default-rating"></uib-rating>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.paragliding_rating"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.paragliding_rating.$invalid && editForm.paragliding_rating.$touched"></span>
+            </div>
+
+            ## EXPOSITION RATING
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+                 ng-class="{ 'has-error': editForm.exposition_rating.$touched && editForm.exposition_rating.$invalid, 'has-success': editForm.exposition_rating.$valid }">
+              <label translate>exposition_rating</label>
+              <select class="form-control " ng-model="waypoint.exposition_rating" ng-options="rat as mainCtrl.translate(rat) for rat in ${exposition_ratings}"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.exposition_rating"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.exposition_rating.$invalid && editForm.exposition_rating.$touched"></span>
+            </div>
+
+            ## EQUIPMENT RATINGS
+            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor'"
+                 ng-class="{ 'has-error': editForm.equipment_ratings.$touched && editForm.equipment_ratings.$invalid,'has-success': editForm.equipment_ratings.$valid }">
+              <label><span translate>equipment_ratings</span></label><br>
+              <select ng-model="waypoint.equipment_rating" ng-options="rat as rat for rat in ${equipment_ratings}" class="form-control"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.equipment_ratings"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.equipment_ratings.$invalid && editForm.equipment_ratings.$touched"></span>
+            </div>
+
+            ## CLIMBING RATING MIN
+            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.climbing_rating_min.$touched && editForm.climbing_rating_min.$invalid, 'has-success': editForm.climbing_rating_min.$valid }">
+              <label><span translate>climbing_rating_min</span></label><br>
+              <select ng-model="waypoint.climbing_rating_min" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_min"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.climbing_rating_min.$invalid && editForm.climbing_rating_min.$touched"></span>
+            </div>
+
+            ## CLIMBING RATING MAX
+            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.climbing_rating_max.$touched && editForm.climbing_rating_max.$invalid, 'has-success': editForm.climbing_rating_max.$valid }">
+              <label><span translate>climbing_rating_max</span></label><br>
+              <select ng-model="waypoint.climbing_rating_max" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_max"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.climbing_rating_max.$invalid && editForm.climbing_rating_max.$touched"></span>
+            </div>
+
+            ## CLIMBING RATING MEDIAN
+            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.climbing_rating_median.$touched && editForm.climbing_rating_median.$invalid, 'has-success': editForm.climbing_rating_median.$valid }">
+              <label><span translate>climbing_rating_median</span></label><br>
+              <select ng-model="waypoint.climbing_rating_median" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_median"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.climbing_rating_median.$invalid && editForm.climbing_rating_median.$touched"></span>
+            </div>
+
+          </div>
+        </section>
+
+        ## ACCESS
+        <section class="section access" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'camp_site'">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-access"><span translate>access</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-access">
+
+            ## ACCESS PERIOD
+            <div id="access-period" class="form-group data full" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site'">
+              <label translate>access_period</label>
+              <article> 
+                <textarea name="access_period" ng-model="waypoint.locales[0].access_period" class="form-control" placeholder="{{'Describe access_period'|translate}}"></textarea>
+              </article>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access_period"></span>
+            </div>
+
+            ## ACCESS
+            <div class="form-group data full" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product'">
+              <label translate>access</label>
+              <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control" placeholder="{{'Describe access'|translate}}"></textarea>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access"></span>
+            </div>
+
+            ## ACCESS TIME
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+              <label translate>access_time</label>
+              <select class="form-control" ng-model="waypoint.access_time" ng-options="time as time for time in ${access_times}"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access_period"></span>
+            </div>
+
+            ## BEST PERIODS
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+              <label translate>best_periods</label>
+              <ul class="types data half long">
+                <li ng-click="editCtrl.pushToArray(waypoint, 'best_periods', month, $event)" ng-repeat="month in ${months}">
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.best_periods.indexOf(month) > - 1"><span x-translate>{{month}}</span></div>
+                </li>
+              </ul>
+            </div>
+
+          </div>
+        </section>
+
+        ## TRANSPORTS
+        <section class="section transports" ng-if="waypoint.waypoint_type == 'access'">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-transports"><span translate>transports</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-transports">
+
+            ## PUBLIC TRANSPORT TYPES
+            <div class="form-group data half">
+              <label translate>public_transportation_types</label>
+              <ul class="types">
+                <li ng-repeat="type in ${public_transportation_types}" ng-click="editCtrl.pushToArray(waypoint, 'public_transportation_types', type, $event)">
+                  <div class="checkbox">
+                    <input type="checkbox" ng-checked="waypoint.public_transportation_types.indexOf(type) > - 1"><span x-translate>{{type}}</span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            ## PUBLIC TRANSPORT RATINGS
+            <div class="form-group data half">
+              <label translate>public_transportation_ratings</label>
+              <div class="input-group">
+                <select class="form-control" ng-options="rat as mainCtrl.translate(rat) for rat in ${public_transportation_ratings}" ng-model="waypoint.public_transportation_rating"></select>
+                <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.public_transportation_rating"></span>
+            </div>
+
+            ## SNOW CLEARANCE RATINGS
+            <div class="form-group data half">
+              <label translate>snow_clearance_ratings</label>
+              <div class="input-group">
+                <select class="form-control" ng-options="rat as mainCtrl.translate(rat) for rat in ${snow_clearance_ratings}" ng-model="waypoint.snow_clearance_rating"></select>
+                <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.snow_clearance_rating"></span>
+            </div>
+
+            ## LIFT ACCESS
+            <div class="form-group data half">
+              <label translate>lift_access</label>
+              <div class="input-group">
+                <select class="form-control" ng-model="waypoint.lift_access">
+                  <option value="true"><span translate>yes</span></option>
+                  <option value="false"><span translate>no</span></option>
+                </select>
+                <span class="input-group-addon"><span class="glyphicon glyphicon-resize-vertical"></span></span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.lift_access"></span>
+            </div>
+
+            ## PARKING FEE TYPES
+            <div class="form-group data half">
+              <label translate>parking_fee_types</label>
+              <select ng-options="type as mainCtrl.translate(type) for type in ${parking_fee_types}" ng-model="waypoint.parking_fee" class="form-control"></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.parking_fee"></span>
+            </div>
+          </div>
+        </section>
+
+        ## EQUIPMENT
+        <section class="section equipment" ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-equipment"><span translate>Equipment</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-equipment">
+
+            ## MATRESS 
+            <div class="form-group data">
+              <label translate>matress_unstaffed</label>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.matress_unstaffed" value="true"><span translate>Yes</span></label><br/>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.matress_unstaffed" value="false"><span translate>No</span></label><br/>
+            </div>
+
+            ## BLANKET
+            <div class="form-group data">
+              <label translate>blanket_unstaffed</label>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.blanket_unstaffed" value="true"><span translate>Yes</span></label><br/>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.blanket_unstaffed" value="false"><span translate>No</span></label><br/>
+            </div>
+
+            ## GAS
+            <div class="form-group data">
+              <label translate>gas_unstaffed</label>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.gas_unstaffed" value="true"><span translate>Yes</span></label><br/>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.gas_unstaffed" value="false"><span translate>No</span></label><br/>
+            </div>
+
+            ## HEATING
+            <div class="form-group data">
+              <label translate>heating_unstaffed</label>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.heating_unstaffed" value="true"><span translate>Yes</span></label><br/>
+              <label class="yes-no-radio"><input type="radio" ng-model="waypoint.heating_unstaffed" value="false"><span translate>No</span></label><br/>
+            </div>
+
+          </div>
+        </section>
       </div>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation.$valid"></span>
-      <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && editForm.elevation.$touched"></span>
-      <div class="help-block" ng-messages="editForm.elevation.$error">
-        <p ng-message="required" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-        <p ng-message="max" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : '' }}" translate>This field must be smaller than 9999 m.</p>
-        <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+
+
+      ## DESCRIPTION
+      <div class="step step-{{editCtrl.max_steps -1}}">
+
+        <section class="section description">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-description" ><span translate>description</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-description">
+
+            ## SUMMARY
+            <div id="summary-group" class="form-group data">
+              <label translate>summary</label>
+              <textarea name="summary" ng-model="waypoint.locales[0].summary" rows="4" class="form-control"></textarea>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].summary"></span>
+            </div>
+
+            ## DESCRIPTION
+            <div id="description-group" class="form-group data">
+              <label translate>description</label>
+              <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the waypoint'|translate}}"></textarea>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].description"></span>
+            </div>
+          </div>
+        </section>
+
+        ## CONTACT
+        <section class="section contact" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'webcam'
+                  || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'climbing_outdoor'">
+          <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-contact" ><span translate>Contact</span><span class="glyphicon glyphicon-menu-down"></span></h2>
+          <div class="content collapse in" id="edit-contact">
+
+            ## URL
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product'
+                      || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'weather_station'
+                      || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'webcam'">
+              <label><span translate>url</span> <span ng-if="waypoint.waypoint_type == 'webcam' || waypoint.waypoint_type == 'weather_station'">*</span></label>
+              <div class="input-group">
+                <input type="text" name="message" ng-model="waypoint.url" class="form-control" placeholder="www.adress.com" ng-required="['webcam', 'weather_station']. indexOf(waypoint.waypoint_type) > -1"/>
+                <span class="input-group-addon">@</span>
+              </div>
+            </div>
+
+            ## PHONE
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite'
+                      || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut'">
+              <label translate>phone</label>
+              <div class="input-group">
+                <input type="tel" name="message" ng-model="waypoint.phone" class="form-control " placeholder="phone" />
+                <span class="input-group-addon"><span class="glyphicon glyphicon-earphone"></span></span>
+              </div>
+            </div>
+
+            ## PHONE CUSTODIAN
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite'">
+              <label translate>phone_custodian</label>
+              <div class="input-group">
+                <input type="tel" name="message" ng-model="waypoint.phone_custodian" class="form-control " placeholder="phone_custodian" />
+                <span class="input-group-addon"><span class="glyphicon glyphicon-earphone"></span></span>
+              </div>
+            </div>
+
+            ## CUSTODIANSHIP
+            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'camp_site'">
+              <label><span translate>custodianship</span> <span ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut'">*</span></label>
+              <input type="tel" name="message" ng-model="waypoint.custodianship" class="form-control " placeholder="custodianship" ng-required="['gite', 'camp_site', 'hut'].indexOf(waypoint.waypoint_type) > -1"/>
+              <div class="help-block" ng-messages="editForm.custodianship.$error">
+                <p ng-message="number" style="{{ (editForm.custodianship.$invalid && editForm.custodianship.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+                <p ng-message="required" style="{{ (editForm.custodianship.$invalid && editForm.custodianship.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+              </div>
+            </div>
+
+          </div>
+        </section>
       </div>
-    </div>
-    <div id="longitude-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
-                                'has-success': editForm.longitude.$valid }">
-      <label><span translate>Longitude</span> *</label> 
-     <div class="input-group">
-        <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-180" max="180"/>
-        <span class="input-group-addon">°E</span>
+
+      ##SUMMARY
+      <div class="step step-{{editCtrl.max_steps}}">
+        <section class="section summary">
+          <h2 class="heading show-phone"><span translate>summary</span></span></h2>
+          <div class="content collapse in">
+            <%include file="create_edit_summary.html" />
+
+            % if updating_doc:
+            <div id="message-group" class="form-group data">
+              <label translate>Comment about the changes</label>
+              <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes'|translate}}" />
+            </div>
+            % endif
+            
+          </div>
+        </section>
+        
+        <p class="bottom-btns">
+          <button type="submit" class="btn btn-primary btn-lg" ng-disabled="editForm.$invalid || editForm.$pristine" translate>Save</button>
+          <%
+          view_url = request.route_url('waypoints_view', id=waypoint_id, lang=waypoint_lang) if updating_doc else ''
+          index_url = request.route_url('waypoints_index_default')
+          %>
+          <button type="button" class="btn btn-default btn-lg" ng-click="editCtrl.cancel('${view_url}', '${index_url}')" translate>Cancel</button>
+        </p>
       </div>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid"></span>
-      <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
-       <div class="help-block" ng-messages="editForm.longitude.$error">
-        <p ng-message="required" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-        <p ng-message="number" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-        <p ng-message="min" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : '' }}" translate>This field must be between -180° and 180°.</p>
-        <p ng-message="max" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : '' }}" translate>This field must be between -180° and 180°.</p>
-      </div>
-    </div>
-    <div id="latitude-group" class="form-group" 
-         ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
-                                'has-success': editForm.latitude.$valid }">
-      <label><span translate>Latitude</span> *</label>
-      <div class="input-group">
-        <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-90" max="90" />
-        <span class="input-group-addon">°N</span>
-      </div>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.latitude.$valid"></span>
-      <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
-      <div class="help-block" ng-messages="editForm.latitude.$error">
-        <p ng-message="required" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-        <p ng-message="number" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-        <p ng-message="min" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : '' }}" translate>This field must be between -90° and 90°.</p>
-        <p ng-message="max" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : '' }}" translate>This field must be between -90° and 90°.</p>
-      </div>
-    </div>
-    <div id="maps_info-group" class="form-group">
-      <label translate>maps_info</label>
-      <input type="text" name="maps_info" ng-model="waypoint.maps_info" class="form-control" />
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.maps_info"></span>
-    </div>
-    <div id="summary-group" class="form-group">
-      <label translate>summary</label>
-      <textarea name="summary" ng-model="waypoint.locales[0].summary" class="form-control"></textarea>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].summary"></span>
-    </div>
-    <div id="description-group" class="form-group">
-      <label translate>description</label>
-      <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control" placeholder="{{'Describe here the waypoint'|translate}}"></textarea>
-      <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].description"></span>
-    </div>
-    % if updating_doc:
-    <div id="message-group" class="form-group">
-      <label translate>Comment about the changes</label>
-      <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes'|translate}}" />
-    </div>
-    % endif
-    <p>
-      <button type="submit" class="btn btn-primary" ng-disabled="editForm.$invalid || editForm.$pristine" translate>Save</button>
-      <%
-      view_url = request.route_url('waypoints_view', id=waypoint_id, lang=waypoint_lang) if updating_doc else ''
-      index_url = request.route_url('waypoints_index_default')
-      %>
-      <button type="button" class="btn btn-default" ng-click="editCtrl.cancel('${view_url}', '${index_url}')" translate>Cancel</button>
-    </p>
-    <app-map app-map-edit-ctrl="editCtrl" app-map-draw-type="Point"></app-map>
+
+    </section>
   </form>
 </section>

--- a/c2corg_ui/templates/waypoint/helpers/create_edit_summary.html
+++ b/c2corg_ui/templates/waypoint/helpers/create_edit_summary.html
@@ -1,66 +1,76 @@
+
+
+
 <figure>
+
   ## TITLE & TYPES
-  <h3><span translate>title</span> & <span translate>types</span></h3>
-  <p><label translate>title</label>
-    <input required class="form-control" ng-model="waypoint.locales[0].title">
-    <p class="text-danger" translate ng-if="!waypoint.locales[0].title">This field is required.</p>
+  <h3>ttle & types</h3>
+  <p><label translate>title</label>  
+    <input disabled class="form-control" value="{{waypoint.locales[0].title}}">
   </p>
   <p><label translate>waypoint_type</label> 
-    <input disabled required class="form-control" value="{{mainCtrl.translate(waypoint.waypoint_type)}}">
-    <p class="text-danger" translate ng-if="!waypoint.waypoint_type">This field is required.</p>
+    <input disabled class="form-control" value="{{mainCtrl.translate(waypoint.waypoint_type)}}">
   </p>
   <p><label translate>lang</label>
-    <input disabled required class="form-control" value="{{mainCtrl.translate(waypoint.locales[0].lang)}}">
-    <p class="text-danger" translate ng-if="!waypoint.locales[0].lang">This field is required.</p>
+    <input disabled class="form-control" value="{{mainCtrl.translate(waypoint.locales[0].lang)}}">
   </p>
   <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'">
-    <label translate>orientation</label>{{waypoint.orientation}}</p>
-  <p ng-if="waypoint.areas[0].locales[0].title"><label translate>country</label>{{waypoint.areas[0].locales[0].title}}</p>
-  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>children_proof</label>{{waypoint.children_proof}}</p>
-  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>rain_proof</label>{{waypoint.rain_proof}}</p>
+    <label translate>orientation</label>  {{waypoint.orientation}}</p>
+  <p ng-if="waypoint.areas[0].locales[0].title"><label translate>country</label>  {{waypoint.areas[0].locales[0].title}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>children_proof</label>  {{waypoint.children_proof}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>rain_proof</label>  {{waypoint.rain_proof}}</p>
 
   <article ng-if="waypoint.waypoint_type == 'weather_station'">
     <label translate>weather_station_types</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['weather_station_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['weather_station_types']" >{{type| translate}}</li>
     </ul>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'local_product'">
     <label translate>product_types</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['product_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['product_types']" >{{type | translate}}</li>
     </ul>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' && waypoint.climbing_outdoor_types[0] != ''">
     <label translate>climbing_outdoor_types</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['climbing_outdoor_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['climbing_outdoor_types']">{{type| translate}}</li>
     </ul>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>climbing_indoor_types</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['climbing_indoor_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['climbing_indoor_types']">{{type| translate}}</li>
     </ul>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>climbing_styles</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['climbing_styles']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['climbing_styles']">{{type| translate}}</li>
     </ul>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
     <label translate>rock_types</label><br>
     <ul class="types">
-      <li ng-repeat="type in waypoint['rock_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['rock_types']">{{type| translate}}</li>
     </ul>
   </article>
 
+</figure>
+
+## DESCRIPTION
+<figure>
+  <h3>text</h3>
+  <label translate>description</label>
+  <textarea class="form-control">{{waypoint.locales[0].description}}</textarea>
+  <label translate>summary</label>
+  <textarea class="form-control">{{waypoint.locales[0].summary}}</textarea>
 </figure>
 
 ## NUMBERS
@@ -70,25 +80,23 @@
   <article>
     <label translate>elevation</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.elevation">
+      <input type="text" class="form-control" disabled value="{{waypoint.elevation}}">
       <span class="input-group-addon">m</span>
     </div>
-    <p class="text-danger" translate ng-if="!waypoint.elevation">This field is required.</p>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'access'">
     <label translate>elevation_min</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" required ng-model="waypoint.elevation_min">
+      <input type="text" class="form-control" disabled value="{{waypoint.elevation_min}}">
       <span class="input-group-addon">m</span>
     </div>
-    <p class="text-danger" translate ng-if="!waypoint.elevation_min">This field is required.</p>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">
     <label translate>length</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.length">
+      <input type="text" class="form-control" disabled value="{{waypoint.length}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -96,15 +104,15 @@
   <article ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">
     <label translate>slope</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.slope">
-      <span class="input-group-addon">&#176;</span>
+      <input type="text" class="form-control" disabled value="{{waypoint.slope}}">
+      <span class="input-group-addon"> &#176;</span>
     </div>
   </article>
 
   <article ng-if="waypoint.waypoint_type == 'summit'">
     <label translate>prominence</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.prominence">
+      <input type="text" class="form-control" disabled value="{{waypoint.prominence}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -112,7 +120,7 @@
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>height_max</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control"  ng-model="waypoint.height_max">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_max}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -120,7 +128,7 @@
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>height_min</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.height_min">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_min}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -128,7 +136,7 @@
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>height_median</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.height_median">
+      <input type="text" class="form-control" disabled value="{{waypoint.height_median}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -136,7 +144,7 @@
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
     <label translate>routes_quantity</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.routes_quantity">
+      <input type="text" class="form-control" disabled value="{{waypoint.routes_quantity}}">
       <span class="input-group-addon">m</span>
     </div>
   </article>
@@ -144,7 +152,7 @@
   <article ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
     <label translate>capacity</label>
     <div class="input-group">
-      <input type="number" min="0" class="form-control" ng-model="waypoint.capacity">
+      <input type="text" class="form-control" disabled value="{{waypoint.capacity}}">
       <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
     </div>
   </article>
@@ -152,44 +160,23 @@
   <article ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
     <label translate>capacity_staffed</label>
     <div class="input-group">
-      <input type="number" min="0"  class="form-control" ng-model="waypoint.capacity_staffed">
+      <input type="text" class="form-control" disabled value="{{waypoint.capacity_staffed}}">
       <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
     </div>
   </article>
 
 </figure>
 
-## MAPS
-<figure>
-  <h3>maps</h3>
-  <p><label translate>lonlat</label> 
-    <input class="form-control" disabled value=" {{waypoint.lonlat.longitude}} °W / {{waypoint.lonlat.latitude}} °N">
-    <p class="text-danger" translate ng-if="!waypoint.lonlat.longitude || !waypoint.lonlat.longitude">Longitude and latitude are required.</p>
-  </p>
-  <label translate>maps_info</label>
-  <p  ng-repeat="map in waypoint.maps">{{map.code}} {{map.editor}}  {{map.locales[0].title}}</p>
-</figure>
-
-
-## DESCRIPTION
-<figure class="summary-description">
-  <h3>text</h3>
-  <label translate>description</label>
-  <textarea class="form-control">{{waypoint.locales[0].description}}</textarea>
-  <label translate>summary</label>
-  <textarea class="form-control">{{waypoint.locales[0].summary}}</textarea>
-</figure>
-
 ## RATINGS
 <figure ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'access'
           ||  waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
   <h3>ratings</h3>
-  <p ng-if="waypoint.paragliding_rating && (waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing')"><label translate>paragliding_rating</label>  {{waypoint.paragliding_rating}}</p>
-  <p ng-if="waypoint.exposition_rating && (waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing')"><label translate>exposition_rating</label>  {{waypoint.exposition_rating}}</p>
-  <p ng-if="waypoint.climbing_rating_max && (waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor')"><label translate>climbing_rating_max</label>  {{waypoint.climbing_rating_max}}</p>
-  <p ng-if="waypoint.climbing_rating_min && (waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor')"><label translate>climbing_rating_min</label>  {{waypoint.climbing_rating_min}}</p>
-  <p ng-if="waypoint.climbing_rating_median && (waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor')"><label translate>climbing_rating_median</label>  {{waypoint.climbing_rating_median}}</p>
-  <p ng-if="waypoint.equipment_rating && waypoint.waypoint_type == 'climbing_outdoor'"><label translate>equipment_rating</label>{{waypoint.equipment_rating}}</p>
+  <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"><label translate>paragliding_rating</label>  {{waypoint.paragliding_rating}}</p>
+  <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"><label translate>exposition_rating</label>  {{waypoint.exposition_rating}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_max</label>  {{waypoint.climbing_rating_max}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_min</label>  {{waypoint.climbing_rating_min}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"><label translate>climbing_rating_median</label>  {{waypoint.climbing_rating_median}}</p>
+  <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>equipment_rating</label>  {{waypoint.equipment_rating}}</p>
 </figure>
 
 ## TRANSPORTS
@@ -198,20 +185,32 @@
   <article>
     <label translate>public_transportation_types</label><br>
     <ul >
-      <li ng-repeat="type in waypoint['public_transportation_types']" x-translate>{{type}}</li>
+      <li ng-repeat="type in waypoint['public_transportation_types']" >{{type | translate}}</li>
     </ul>
   </article>
-  <p><label translate>public_transportation_rating</label>
+  <p><label translate>public_transportation_rating</label>  
     <input class="form-control" disabled value="{{waypoint.public_transportation_rating | translate}}">
   </p>
   <p><label translate >parking_fee</label> 
   <input class="form-control" disabled value=" {{waypoint.parking_fee}}">
   </p>
-  <p><label translate>lift_access</label>
+  <p><label translate>parking_fee_type</label>  
+    <input class="form-control" disabled value="{{waypoint.parking_fee_type | translate}}">
+  </p>
+  <p><label translate>lift_access</label>  
     <input class="form-control" disabled value="{{waypoint.lift_access | translate}}">
   </p>
 </figure>
 
+## MAPS
+<figure>
+  <h3>maps</h3>
+  <p><label translate>lonlat</label> 
+    <input class="form-control" disabled value=" {{waypoint.lonlat.longitude}} °W / {{waypoint.lonlat.latitude}} °N">
+  </p>
+  <label translate>maps_info</label>
+  <p  ng-repeat="map in waypoint.maps">{{map.code}}  {{map.editor}}   {{map.locales[0].title}}</p>
+</figure>
 
 ## CONTACT
 <figure  ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite'
@@ -252,10 +251,10 @@
 ## EQUIPMENT
 <figure ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
   <h3>equipment</h3>
-  <p><label translate>matress_unstaffed</label>{{waypoint.matress_unstaffed}}</p>
-  <p><label translate>heating_unstaffed</label>{{waypoint.heating_unstaffed}}</p>
-  <p><label translate >blanket_unstaffed</label>{{waypoint.blanket_unstaffed}}</p>
-  <p><label translate>gas_unstaffed</label>{{waypoint.gas_unstaffed}}</p>
+  <p><label translate>matress_unstaffed</label>  {{waypoint.matress_unstaffed}}</p>               
+  <p><label translate>heating_unstaffed</label>  {{waypoint.heating_unstaffed}}</p>
+  <p><label translate >blanket_unstaffed</label>  {{waypoint.blanket_unstaffed}}</p>
+  <p><label translate>gas_unstaffed</label>  {{waypoint.gas_unstaffed}}</p>
 </figure>
 
 ## ACCESS
@@ -274,13 +273,16 @@
   </p>
 
   <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
-    <label translate>access_time</label>
+    <label translate>access_time</label>  
     {{waypoint.access_time}}
   </p>
   <article ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
     <label translate>best_periods</label><br>
     <ul >
-      <li ng-repeat="month in waypoint['best_periods']" x-translate>{{month}}</li>
+      <li ng-repeat="month in waypoint['best_periods']">
+        {{month}}
+      </li>
     </ul>
   </article>
+
 </figure>

--- a/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+++ b/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -195,7 +195,7 @@
 <%def name="get_waypoint_access(waypoint, locale)">\
   % if locale.get('access_period') or waypoint.get('access_period') or waypoint.get('access_time') or \
    waypoint.get('best_periods') or  waypoint.get('public_transportation_types') or  waypoint.get('public_transportation_rating') or \
-   waypoint.get('parking_fee') or waypoint.get('snow_clearance_rating') or waypoint.get('lift_access') :
+   waypoint.get('parking_fee') or waypoint.get('snow_clearance_rating') or waypoint.get('lift_access') or waypoint.get('routes_quantity') :
 
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Access</span><span class="glyphicon glyphicon-menu-right"></span></h4>
@@ -209,7 +209,7 @@
         <p><span translate>access_period</span>: <b>${locale['access_period']}</b></p>
       % endif
 
-      % if waypoint.get('access_period'):
+      % if waypoint.get('routes_quantity'):
         <p><span translate>routes_quantity</span>: <b>${waypoint['routes_quantity']}</b></p>
       % endif
 
@@ -220,7 +220,7 @@
       % if waypoint.get('best_periods'):
       <article>
         <b translate>best_periods</b><br>
-        <ul>
+        <ul class="types">
           % for month in waypoint['best_periods'] :
           <li x-translate>${month}</li>
           % endfor
@@ -393,3 +393,20 @@
     </div>
   % endif
 </%def>
+
+## ORIENTATION  
+<%def name="get_waypoint_orientation(waypoint)">\
+  % if waypoint.get('orientation') :
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>orientation</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="glyphicon glyphicon-move"></span>
+        <p translate>orientation</p>
+      </div>
+      <span class="detail-text accordion" id="detail-orientation" ng-init="waypoint.orientation = ${waypoint.get('orientation')}">
+         <%include file="c2corg_ui:static/img/orientation.svg" />
+      </span>
+    </div>
+  % endif
+</%def>
+if

--- a/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+++ b/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -34,75 +34,51 @@
     % endif
 
     % if waypoint.get('orientation'):
-      <p><span translate>orientation</span>:</p>
-      % for orient in waypoint['orientation'] :
-        <span x-translate>${orient}</span>
-      % endfor
+      <p>
+        <span translate>orientation</span>:
+       ${', '.join(waypoint['orientation'])}
+      </p>
     % endif
 
     % if waypoint.get('climbing_indoor_types'):
-      <article>
+      <article ng-init="climbing_indoor_types = ${waypoint['climbing_indoor_types']}" class="value">
         <b translate>climbing_indoor_types</b><br>
-        <ul>
-          % for style in waypoint['climbing_indoor_types'] :
-          <li x-translate>${style}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in climbing_indoor_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
     % if waypoint.get('rock_types'):
-      <article>
+      <article ng-init="rock_types = ${waypoint['rock_types']}" class="value">
         <b translate>rock_types</b><br>
-        <ul>
-          % for type in waypoint['rock_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in rock_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
     % if waypoint.get('climbing_outdoor_types') and waypoint['climbing_outdoor_types'][0] != '':
-      <article>
+      <article ng-init="climbing_outdoor_types = ${waypointp['climbing_outdoor_types']}" class="value">
         <b translate>climbing_outdoor_types</b><br>
-        <ul>
-          % for type in waypoint['climbing_outdoor_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in climbing_outdoor_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
     % if waypoint.get('product_types'):
-      <article>
+      <article ng-init="product_types = ${waypoint['product_types']}" class="value">
         <b translate>product_types</b><br>
-        <ul>
-          % for type in waypoint['product_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in product_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
     % if waypoint.get('ground_types'):
-      <article>
+      <article ng-init="ground_types = ${waypoint['ground_types']}" class="value">
         <b translate>ground_types</b><br>
-        <ul>
-          % for type in waypoint['ground_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in ground_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
     % if waypoint.get('weather_station_types'):
-      <article>
+      <article ng-init="weather_station_types = ${waypoint['weather_station_types']}" class="value">
         <b translate>weather_station_types</b><br>
-        <ul>
-          % for type in waypoint['weather_station_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in weather_station_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
     % endif
 
@@ -218,24 +194,16 @@
       % endif
       
       % if waypoint.get('best_periods'):
-      <article>
+      <article ng-init="best_periods = ${waypoint['best_periods']}" class="value">
         <b translate>best_periods</b><br>
-        <ul class="types">
-          % for month in waypoint['best_periods'] :
-          <li x-translate>${month}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in best_periods">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
       
       % if waypoint.get('public_transportation_types'):
-      <article>
+      <article ng-init="public_transportation_types = ${waypoint['public_transportation_types']}" class="value">
         <b translate>public_transportation_types</b><br>
-        <ul>
-          % for type in waypoint['public_transportation_types'] :
-          <li x-translate>${type}</li>
-          % endfor
-        </ul>
+        <span x-translate ng-repeat="type in public_transportation_types">{{type}}{{$last ? '' : ', '}}</span>
       </article>
       % endif
       
@@ -252,7 +220,7 @@
       % endif
 
       % if waypoint.get('lift_access'):
-        <p><span translate>lift_access</span>: <b>${waypoint['lift_access']}</b></p>
+      <b x-translate>lift_access</b>
       % endif
     </span>
   </div>
@@ -283,14 +251,7 @@
         % endif
         
         % if waypoint.get('equipment_ratings'):
-        <article>
-          <b translate>equipment_ratings</b><br>
-          <ul>
-            % for activity in waypoint['equipment_ratings'] :
-            <li x-translate>${equipment_ratings}</li>
-            % endfor
-          </ul>
-        </article>
+         <p><span translate>equipment_rating</span>: <b>${waypoint['equipment_ratings']}</b></p>
         % endif
 
         % if waypoint.get('paragliding_rating'):
@@ -316,13 +277,9 @@
       </div>
       <span class="detail-text accordion">
         % if waypoint.get('climbing_styles'):
-        <article>
+        <article ng-init="climbing_styles = ${waypoint['climbing_styles']}" class="value">
           <b translate>climbing_styles</b><br>
-          <ul>
-            % for type in waypoint['climbing_styles'] :
-            <li x-translate>${type}</li>
-            % endfor
-          </ul>
+          <span x-translate ng-repeat="style in climbing_styles">{{style}}{{$last ? '' : ', '}}</span>
         </article>
         % endif
       </span>
@@ -397,7 +354,7 @@
 ## ORIENTATION  
 <%def name="get_waypoint_orientation(waypoint)">\
   % if waypoint.get('orientation') :
-    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+    <div class="name-icon-value orientation" ng-click="detailsCtrl.openTab($event)">
       <h4><span translate>orientation</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">
         <span class="glyphicon glyphicon-move"></span>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -3,7 +3,7 @@ from c2corg_ui.templates.utils import get_lang_lists
 %>
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="helpers/detailed_waypoint_attributes.html" import="get_waypoint_equipment, get_waypoint_contact, get_waypoint_style, get_waypoint_rating, get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general, get_waypoint_maps_info"/>
+<%namespace file="helpers/detailed_waypoint_attributes.html" import="get_waypoint_equipment, get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating, get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general, get_waypoint_maps_info"/>
 <%namespace file="../helpers/view.html" import="show_attr, show_short_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title, show_associated_waypoints,
     show_associated_routes, show_areas, show_maps, show_float_buttons"/>
@@ -84,11 +84,12 @@ module.value('mapFeatureCollection', {
   </uib-tabset>
   
   <div class="thumbnail view-details-informations col-xs-12 tab">
-    <h3 class="heading informations" data-toggle="collapse" data-target="#document-informations">
+    <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_waypoint_general(waypoint)}
+      ${get_waypoint_orientation(waypoint)}
       ${get_waypoint_location(waypoint, geometry4326)}
       ${get_waypoint_contact(waypoint)}
       ${get_waypoint_maps_info(waypoint)}
@@ -97,9 +98,9 @@ module.value('mapFeatureCollection', {
       ${get_waypoint_equipment(waypoint)}
       ${get_waypoint_style(waypoint)}
       ${get_waypoint_access(waypoint, locale)}
+  
     </section>
   </div>
-    
   
   ## DESCRIPTION
   <div class="view-details-description col-xs-12 tab ">
@@ -162,7 +163,7 @@ module.value('mapFeatureCollection', {
       <section>
         % if 'waypoints' in waypoint['associations'] and  len(waypoint['associations']['waypoints']) > 0 :
         <article>
-          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-waypoints">
+          <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-waypoints">
             <span class="glyphicon glyphicon-map-marker"></span>
             <span translate>Associated waypoints</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
@@ -176,7 +177,7 @@ module.value('mapFeatureCollection', {
         % endif
         % if 'routes' in waypoint['associations'] and  len(waypoint['associations']['routes']) > 0 :
         <article>
-          <h3 class="heading show-phone" data-toggle="collapse" data-target="#associated-routes">
+          <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-routes">
             <span class="glyphicon glyphicon-road"></span>
             <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
@@ -194,7 +195,7 @@ module.value('mapFeatureCollection', {
   % endif
 
   <div class="text-center col-xs-12">
-    <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span><span class="glyphicon glyphicon-menu-up"></span></button>
+    <button class="btn btn-default scroll-top-btn" onclick="window.scrollTo(0, 0);"><span translate>To page head</span>&nbsp;<span class="glyphicon glyphicon-menu-up"></span></button>
   </div>
 </section>
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -386,9 +386,7 @@ main {
   cursor: pointer;
   
   background-color: white;
-  max-height: auto;
   min-height: 50px;
-  width:100%;
   margin-right: 3%;
   margin-bottom: 5%;
   
@@ -397,7 +395,6 @@ main {
   -webkit-border-radius: 7px;
   
   border: 2px solid rgba(88, 150, 165, 0.2);
-  display: inline-table;
   position:relative;
   
   transition: .2s;
@@ -543,6 +540,10 @@ p {
 }
 .list {
   padding: 2%;
+  .list-item {
+    width: 100%;
+    display: inline-table;
+  }
 }
 
 .search-icon {

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -9,15 +9,17 @@
 @import "stickyfilters.less";
 @import "filters.less";
 @import "documentdetailsview.less";
+@import "documentedit.less";
 @import "variables.less";
 
 
 html, body{
   padding: 0;
   margin: 0;
-  min-height:  100%;
-  min-width: 100%;
+  width: 100%;
+  overflow-x: hidden;
   background-color: rgba(235,228,209,.1);
+
 }
 
 .ol-zoom {
@@ -121,13 +123,6 @@ h1 {
   font-size: 3em;
 }
 
-.form-control-feedback {
-  position: relative;
-  top: -34px;
-  left: 102%;
-  width: 14px;
-  height:14px;
-}
 
 .glyphicon-ok {
   color: #3c763d !important;
@@ -243,7 +238,9 @@ main {
      box-shadow: 0 4px 10px #D5D5D5;
     margin-top: 1%;
     margin-bottom: 1%;
-    
+    >span {
+      pointer-events: none;
+    }
     &.informations {
       border-radius: 0;
       font-size: 1.5em;
@@ -326,26 +323,16 @@ main {
   }
 }
 .help-block {
-  margin-top: -6px;
-  
+  margin-top: -13px;
+  position: absolute;
   p {
-    font-size: 1em;
-    color: white;
     display: none;
+    font-size: 1em;
+    color: #B70000 !important;
   }
 }
 
-.document-editing {
-  width: 80%;
-  margin: auto;
-  @media @tablet {
-    width: 85%;
-  }
-  @media @phone {
-    width: 89%;
-    margin-left: 15px;
-  }
-}
+
 
 .list {
   width:100%;
@@ -895,26 +882,6 @@ app-alerts {
 
 }
 
-.create-edit-document {
-  margin-top: @page-header-height;
-  @media @tablet {
-    margin-top: -20px;
-  }
-  @media @phone {
-    margin-top: 50px;
-  }
-  h1 {
-    @media @tablet {
-      font-size: 2.3em;
-      margin-top: 35px;
-    }
-    @media @phone {
-      font-size: 1.8em;
-      padding-top: 10px;
-    }
-  }
-}
-
 .archive-data {
   div {
     display: table;
@@ -967,4 +934,8 @@ app-alerts {
         display: none;
       }
     }
+  }
+  
+  button:focus {
+    outline: none !important;
   }

--- a/less/documentdetailsview.less
+++ b/less/documentdetailsview.less
@@ -285,11 +285,10 @@
       .flex();
       flex-basis: 33.33%;
       padding: 0;
-      min-height: 130px;
+      min-height: 110px;
       background-color: white;
       border-bottom: 1px solid #dfd6c5;
       transition: 0.3s;
-      margin: auto;
 
       @media @big {
         padding-top: 2%;
@@ -310,9 +309,7 @@
         &:not(:first-of-type) {
           border-top: 1px solid #dfd6c5;
         }
-      }
-
-    
+      }    
       &.location {
         display: none;
         @media @phone {
@@ -463,7 +460,7 @@ app-add-association {
 
 }
 
-.view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos, .view-details-informations{
+.view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos, .view-details-informations {
   ul li {
     list-style: none;
     &:before {
@@ -476,6 +473,11 @@ app-add-association {
       color: @brand-success;
     }
   }
+  ul.types li {
+    width: 50%;
+    float: left;
+  }
+  
 }
 
 .scroll-top-btn {
@@ -511,51 +513,7 @@ app-add-association {
   @media @desktop {
      right: 50px;
   }
-  .pin {
-    background-color: #aaa;
-    display: block;
-    height: 32px;
-    width: 2px;
-    position: absolute;
-    left: 50%;
-    top: -20px;
-    z-index: 1;
 
-    &:after {
-      background-color: #A31;
-      background-image: radial-gradient(25% 25%, circle, hsla(0,0%,100%,.3), hsla(0,0%,0%,.3));
-      border-radius: 50%;
-      box-shadow: inset 0 0 0 1px hsla(0,0%,0%,.1),
-        inset 3px 3px 3px hsla(0,0%,100%,.2),
-        inset -3px -3px 3px hsla(0,0%,0%,.2),
-        23px 20px 3px hsla(0,0%,0%,.15);
-      content: '';
-      height: 12px;
-      left: -5px;
-      position: absolute;
-      top: -10px;
-      width: 12px;
-    }
-    &:before {
-      background-color: hsla(0,0%,0%,0.1);
-      box-shadow: 0 0 .25em hsla(0,0%,0%,.1);
-      content: '';
-      height: 24px;
-      width: 2px;
-      left: 0;
-      position: absolute;
-      top: 8px;
-      transform: rotate(57.5deg);
-      -moz-transform: rotate(57.5deg);
-      -webkit-transform: rotate(57.5deg);
-      -o-transform: rotate(57.5deg);
-      -ms-transform: rotate(57.5deg);
-      transform-origin: 50% 100%;
-      -moz-transform-origin: 50% 100%;
-      -webkit-transform-origin: 50% 100%;
-      -o-transform-origin: 50% 100%;
-    }
-  }
   p {
     margin-top: 2px;
     margin-bottom: 0;
@@ -590,3 +548,13 @@ app-add-association {
      display: block;
   }
 }
+#detail-orientation {
+  .flex();
+  justify-content: center;
+  #orientation-svg{
+    height: 110px;
+    width: 110px;
+    margin-bottom: 10px;
+  }
+}
+

--- a/less/documentdetailsview.less
+++ b/less/documentdetailsview.less
@@ -43,8 +43,7 @@
 
 .view-details-section {
   height: 73%;
-  margin-left: 4%;
-  margin-right: 0;
+  margin-left: 2%;
   width: 90%;
   margin-top: -30px;
   padding-top: 15px;
@@ -58,6 +57,9 @@
     width: 100%;
     margin-left: 0%;
     margin-right: 0%;
+  }
+  @media @big {
+    margin-left: 4%;
   }
 
   .nav-tabs {
@@ -94,7 +96,7 @@
     }
 
     @media @big {
-      width: 72.5%;
+      width: 71.5%;
       margin-left: 2.5%;
     }
 
@@ -144,10 +146,11 @@
     .list-item {
       padding: 1%;
       margin: 0;
-      min-height: 105px;
       margin-bottom: 10px;
+      margin-right: 1.5%;
       background: #EEE;
-      width: 44%;
+      min-width: 48%;
+      flex-grow: 1;
 
       a {
         text-align: left; 
@@ -167,21 +170,14 @@
 
     .associated-documents {
       margin-top: 10px;
-      padding: 0 10px;
       max-height: 600px;
       overflow-y: scroll;
       -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
       -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
       box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
       .flex();
-      flex-flow: wrap;
-      justify-content: space-around;
-      @media @big {
-        justify-content: space-between;
-      }
-      @media @phone{
-        justify-content: space-between;
-      }
+      flex-wrap: wrap;
+
       app-delete-association {
         position: absolute;
         bottom: 0;
@@ -214,7 +210,7 @@
       display: none;
     }
     @media @big {
-      width: 25%;
+      width: 26%;
     }
     #document-informations {
       .flex();
@@ -283,21 +279,24 @@
     }
     .name-icon-value {
       .flex();
-      flex-basis: 33.33%;
       padding: 0;
-      min-height: 110px;
+      flex-grow: 1;
+      min-height: 80px;
       background-color: white;
       border-bottom: 1px solid #dfd6c5;
       transition: 0.3s;
 
       @media @big {
         padding-top: 2%;
-        flex-basis: 100%;
+        min-width: 100%;
         min-height: 0;
         height: auto;
       }
-      @media @tablet {
-        flex-basis: 50%;
+      @media (min-width: @screen-sm-max) {
+        min-width: 33.3%;
+      }
+      @media (max-width : @screen-sm-max) {
+        min-width:  50%;
         padding: 0;
       }
       @media @phone {
@@ -310,10 +309,21 @@
           border-top: 1px solid #dfd6c5;
         }
       }    
+      .value {
+        margin-bottom: 10px;
+      }
       &.location {
         display: none;
         @media @phone {
           .flex();
+        }
+      }
+      &.maps {
+        order: 10;
+      }
+      &.orientation {
+        @media @phone {
+          display: none;
         }
       }
     }
@@ -350,10 +360,6 @@
       margin: auto 5px auto 10px;
       transition: 0.3s;
 
-      @media (max-width: @screen-xs-max) {
-        margin-left: 5%;
-        width: 60px;
-      }
       @media @phone {
         display: none;
       }

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -1,0 +1,472 @@
+@import: 'variables.less';
+
+
+.create-edit-document {
+  margin-top: @page-header-height;
+
+  @media @tablet {
+    margin-top: -20px;
+  }
+  @media @phone {
+    margin-top: 50px;
+  }
+  .document-editing {
+    width: 80%;
+    margin: auto;
+    @media @tablet {
+      width: 85%;
+    }
+    @media @phone {
+      width: 89%;
+      margin-left: 15px;
+    }
+  }
+  .nav-buttons {
+
+    @media @phone {
+      display: none;
+    }
+
+    .prev, .next {
+      position: fixed;
+      top: 50vh;
+      z-index: 4;
+      .glyphicon {
+        color: white;
+      }
+      @media @tablet {
+        padding: 3px 7px;
+      }
+    }
+    .prev {
+      left: @menu-width + 20;
+      @media @tablet {
+        left: @menu-width-tablet + 10;
+      }
+    }
+    .next {
+      right: 20px;
+      @media @tablet {
+        right: 10px;
+      }
+    }
+  }
+  .editing {
+    position: relative;
+    width: 600%;
+    @media @phone {
+      position: static;
+    }
+  }
+  .form-group {
+    padding: 0;
+  }
+  h1 {
+    margin-top: 70px;
+    font-size: 2em;
+
+    label {
+      background: slategray;
+      padding: 3px 6px 3px 6px;
+    }
+    @media @tablet {
+      font-size: 2.0em;
+      margin-top: 45px;
+    }
+    @media @phone {
+      font-size: 1.8em;
+      padding-top: 10px;
+      margin-top: 0;
+    }
+  }
+
+  .section.description {
+    .data {
+      width: 100%;
+    }
+    textarea {
+      resize: vertical;
+    }
+    #summary-group textarea {
+      height: 70px !important
+    }
+    #description-group textarea {
+      height: 130px !important;
+    }
+  }
+  .section.title {
+    #title-group {
+      flex-basis: 74%;
+      float:left;
+      margin:0;
+    }
+    #title-edit {
+      width: 94%;
+    }
+  }
+
+  #maps_info-group {
+    width: 100%;
+    margin-top: 15px;
+    
+    input:not(last-of-type) {
+      margin-bottom: 10px;
+    }
+    .map-info {
+      .flex();
+      align-items: center;
+
+      .glyphicon-trash {
+        margin-left: 20px;
+        font-size: 1.2em;
+      }
+    }
+    #document-add-maps {
+      margin-left: 20px;
+      font-size: 1.4em;
+      border-radius: 50%;
+      height: 40px;
+      width: 40px;
+      background:  @C2C-orange;
+      .glyphicon {
+        color:white;
+      }
+    }
+  }
+
+  #title-group, .section {
+    margin-bottom: 15px;
+  }
+
+  .section {
+    .flex();
+    flex-flow: wrap row;
+    justify-content: space-between;
+    border: 2px solid #eee;  
+    border-radius: 5px;
+    background: white;
+    h2, #message-group {
+      width: 100%;
+    }
+    .data.third {
+      width: 30%;
+      margin-right: 1.5%;
+      float: left;
+    }
+    .data.half {
+      flex-basis: 45%;
+      margin-right: 3%;
+      float: left;
+      @media @phone {
+        margin-right: 0;
+        flex-basis: 41%;
+      }
+      .glyphicon-warning-sign, .glyphicon-ok {
+        left: 102%;
+      }
+    }
+    .data.full {
+      flex-basis: 100%;
+      margin-right: 1.5%;
+    }
+
+    .content {
+      padding: 10px 20px 10px 20px;
+      width: 100%;
+      overflow: hidden;
+      .flex();
+      flex-flow: wrap row;
+      justify-content: space-between;
+    }
+    .heading {
+      margin: 0;
+      font-size: 1.5em;
+      >span {
+        margin-left: 10px;
+        margin-right: 10px;
+      }
+    }
+    &.summary {
+      .content {
+        @media @phone {
+          padding: 15px;
+        }
+        figure {
+          flex: 1;
+          min-width: 32%;
+          margin: .5%;
+          background-color: rgba(243, 243, 243, 0.57);
+          padding: 10px;
+          border: 1px solid #eee;
+          border-radius: 5px;
+          
+          @media @tablet {
+            flex-basis: 49%;
+          }
+          @media @phone {
+            flex-basis: 100%;
+          }
+          h3 {
+            font-variant: small-caps;
+            text-align: center;
+            color: #FFB862;
+            margin-bottom: 10px;
+            border-radius: 7px;
+            background-color: white;
+          }
+        }
+      }
+      #summary-description {
+        min-width: 99%;;
+      }
+    }
+    &.maps-info {
+      margin-bottom: 100px;
+      @media @phone {
+        margin: 0;
+      }
+    }
+  }
+
+  .form-control-feedback {
+    position: relative;
+    top: -34px;
+    left: 103%;
+    width: 14px;
+    height:14px;
+    z-index: 0;
+  }
+  .map-edit {
+    margin-top: -5px;
+    flex-basis: 100%;
+    .map{
+      height: 300px;
+    }
+  }
+
+  .progress-bar-edit {
+    position: relative;
+    .flex();
+    justify-content: space-around;
+    width: 95%;
+    margin: 50px 20px 20px 20px;
+    height: 4px;
+    background-image: -moz-linear-gradient(left, #7EFF1F 0,#7EFF1F  15%,#B4B4B4 20%,#B4B4B4 0%);  /*green to gray*/
+    background-image: -o-linear-gradient(left, #7EFF1F 0,#7EFF1F  15%,#B4B4B4 20%,#B4B4B4 0%);  /*green to gray*/
+    background-image: -ms-linear-gradient(left, #7EFF1F 0,#7EFF1F  15%,#B4B4B4 20%,#B4B4B4 0%);  /*green to gray*/
+    background-image: linear-gradient(left, #7EFF1F 0,#7EFF1F  15%,#B4B4B4 0%,#B4B4B4 20%);  /*green to gray*/
+    background-image: -webkit-linear-gradient(left, #7EFF1F 0,#7EFF1F  15%,#B4B4B4 20%,#B4B4B4 0%);  /*green to gray*/
+    background-size: 100%;
+
+    @media @phone {
+      display: none;
+    }
+
+    .edit-progress {
+      position: absolute;
+      left: -10px;
+      width: 103%;
+    }
+
+    &::before, &::after {
+      content: "";
+      position: absolute;
+      top: -8px;
+      display: block;
+      width: 0;
+      height: 0;
+      border-radius: 10px;
+      border: 10px solid #7EFF1F;
+    }
+    &::before {
+      left: -5px;
+    }
+    &::after {
+      right: -10px;
+      border: 10px solid transparent;
+      border-right: 0;
+      border-left: 20px solid #7EFF1F;
+      border-radius: 3px;
+    }
+
+    li {
+      transition: 0.3s ease-in-out;
+      position: relative;
+      top: -24px;
+      display: inline-block;
+      font: bold 14px arial;
+      color: graytext;
+      &:hover {
+        cursor: pointer;
+        color: #28e;
+      }
+      span {
+        font-variant: small-caps;
+      }
+    }
+  }
+}
+
+.section {
+  .form-control.smaller {
+    width: 90%;
+  }
+  ul {
+    padding: 0;
+    list-style: none;
+  }
+  .months, .types {
+    column-count: 2;
+    -webkit-column-count: 2;
+    -moz-column-count: 2;
+    list-style: none;
+    margin-bottom: 0;
+    @media @phone {
+      column-count: 1;
+      -webkit-column-count: 1;
+      -moz-column-count: 1;
+    }
+    &.long {
+      column-count: 2 !important;
+      -webkit-column-count: 2 !important;
+      -moz-column-count: 2 !important;
+    }
+
+    li {
+      cursor: pointer;
+    }
+
+    input {
+      margin-right: 5px !important;
+      margin-left: 0;
+      position: initial;
+    }
+    .checkbox {
+      margin: 0;
+    }
+  }
+  article ul{
+    padding-left: 20px;
+    li:before {
+      /*Using a Bootstrap glyphicon as the bullet point*/
+      content: "\e080";
+      font-family: 'Glyphicons Halflings';
+      font-size: 12px;
+      float: left;
+      margin-left: -10px;
+      margin-right: 5px;
+      color: @brand-success;
+    }
+  }
+  label, .months, .types {
+    width: 100% !important;
+  }
+}
+
+.bottom-btns {
+  text-align: center;
+  margin-bottom: 50px;
+}
+#lang-group {
+  float:left;
+  flex-basis: 17%;
+  margin: 0;
+}
+#rock_types-group {
+  @media @phone { 
+    flex-basis: 100%;
+  }
+}
+#waypoint_type-group {
+  height: 70px;
+}
+#access-period {
+  ul {
+    flex-basis: 46%;
+  }
+  article {
+    display: flex;
+    justify-content: space-between;
+    flex-flow: wrap row;
+  }
+}
+.step {
+  will-change: right, left;
+  position: relative;
+  float: left;
+  margin-right: 2%;
+  width: 17%;
+
+  @media @phone {
+    float: none;
+    width: 18%;
+  }
+}
+.bullet-container {
+  position: absolute;
+  width: 100%;
+  left: 0%;
+  display: flex;
+  justify-content: space-around;
+  top: 22px;
+  .bullet {
+    border: 4px solid #9b2;
+    border-radius: 10px;
+    background: #eee;
+  }
+}
+label.yes-no-radio {
+  font-weight: normal;
+}
+
+input[type="radio"] {
+  margin-right: 10px;
+}
+
+#orientation-list {
+  display: none;
+  @media @phone {
+    display: block;
+  }
+}
+#orientation-svg {
+  position: relative;
+  width: 100%;
+  @media @phone {
+    display: none;
+  }
+
+  #circle-N, #circle-S, #circle-W, #circle-E,
+  #circle-SE, #circle-NE, #circle-SW, #circle-NW, #text-N, #text-E, #text-W,
+  #text-S, #text-SE, #text-SW, #text-NW, #text-NE{
+    cursor: pointer;
+    transition: 0.3s ease-in-out;
+  }
+}
+
+.circle-selected {
+  transition: 0.3s ease-in-out;
+  fill: @C2C-orange;
+}
+
+.half-circle-selected {
+  transition: 0.3s ease-in-out;
+  stroke: #2F8D20 !important;
+}
+
+.orientation-text-selected {
+  font-weight: bold !important;
+  transition: 0.3s ease-in-out;
+  text-decoration: underline;
+}
+
+.nav-step-selected {
+  .nav-text {
+    color: black;
+    transition: 0.3s ease-in-out;
+  }
+  .bullet {
+    border-color: @C2C-orange;
+    transition: 0.3s ease-in-out;
+  }
+}

--- a/less/filters.less
+++ b/less/filters.less
@@ -54,6 +54,7 @@
   #moreFilters {
     background-color: white;
     position: absolute;
+    width: 100%;
     z-index: 5;
     padding: 0;
     box-shadow: 0 14px 14px -14px #332;

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -2,6 +2,7 @@
 
 .menu-open {
   width: @menu-width !important;
+  will-change: width;
   left: 0 !important;
 
   .menu-text, .logo {
@@ -18,6 +19,7 @@
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
     background-color: slategray;
     width: @menu-width;
+    will-change: width;
     margin: 0;
     position: fixed;
     top: 0;
@@ -51,7 +53,7 @@
     }
     @media @tablet {
       width: @menu-width-tablet;
-
+      will-change: width;
       .menu-text, .logo {
         display: none;
       }


### PR DESCRIPTION
![screenshot from 2016-03-03 17 06 44](https://cloud.githubusercontent.com/assets/7814311/13500432/c875d39a-e162-11e5-8e31-9a57bbe4b650.png)
![screenshot from 2016-03-03 17 09 29](https://cloud.githubusercontent.com/assets/7814311/13500434/c93dd264-e162-11e5-851e-595cb3cb9f7c.png)
![screenshot from 2016-03-03 17 09 44](https://cloud.githubusercontent.com/assets/7814311/13500436/ca1831e8-e162-11e5-862b-e63690f1279e.png)

that was HELLOTA work !! and hopefully it works as it should. Gimmie a break

- step by step waypoint creation/edition
- animated progress bar that adapts to the number of steps (4-5)
- the progress bar titles change depending on the waypoint type and its contents
- nice SVG orientation picker
- form inputs change depending on the waypoint type
- the *required* values change depending on the waypoint type
- lists checkboxes should have their values prechecked if the waypoint contains them

- maybe to do -> validation : user should not be allowed to step further if he hasn't filled all the required inputs.