### PR TITLE
Fix typo in equipement_ratings fields in waypoint editing form

### DIFF
--- a/c2corg_ui/templates/waypoint/create_edit_summary.html
+++ b/c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -184,14 +184,14 @@
 ## RATINGS
 <figure ng-if="(waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'access'
           ||  waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff') && (waypoint.paragliding_rating || waypoint.exposition_rating 
-          || waypoint.climbing_rating_max || waypoint.climbing_rating_min || waypoint.climbing_rating_median || waypoint.equipment_rating)">
+          || waypoint.climbing_rating_max || waypoint.climbing_rating_min || waypoint.climbing_rating_median || waypoint.equipment_ratings)">
   <h3>ratings</h3>
   <p ng-if="waypoint.paragliding_rating"><label translate>paragliding_rating</label>  {{waypoint.paragliding_rating}}</p>
   <p ng-if="waypoint.exposition_rating"><label translate>exposition_rating</label>  {{waypoint.exposition_rating}}</p>
   <p ng-if="waypoint.climbing_rating_max"><label translate>climbing_rating_max</label>  {{waypoint.climbing_rating_max}}</p>
   <p ng-if="waypoint.climbing_rating_min"><label translate>climbing_rating_min</label>  {{waypoint.climbing_rating_min}}</p>
   <p ng-if="waypoint.climbing_rating_median"><label translate>climbing_rating_median</label>  {{waypoint.climbing_rating_median}}</p>
-  <p ng-if="waypoint.equipment_rating"><label translate>equipment_rating</label>{{waypoint.equipment_rating}}</p>
+  <p ng-if="waypoint.equipment_ratings"><label translate>equipment_rating</label>{{waypoint.equipment_ratings}}</p>
 </figure>
 
 ## TRANSPORTS

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -519,8 +519,8 @@
             ## EQUIPMENT RATINGS
             <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor'"
                  ng-class="{ 'has-error': editForm.equipment_ratings.$touched && editForm.equipment_ratings.$invalid,'has-success': editForm.equipment_ratings.$valid }">
-              <label><span translate>equipment_ratings</span></label><br>
-              <select ng-model="waypoint.equipment_rating" ng-options="rat as rat for rat in ${equipment_ratings}" class="form-control"><option value=""></option></select>
+              <label><span translate>equipment_rating</span></label><br>
+              <select ng-model="waypoint.equipment_ratings" ng-options="rat as rat for rat in ${equipment_ratings}" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.equipment_ratings"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.equipment_ratings.$invalid && editForm.equipment_ratings.$touched"></span>
             </div>


### PR DESCRIPTION
While trying to figure out the problem with https://github.com/c2corg/v6_ui/issues/110 I realized that there was a missing trailing "s" in ``equipement_ratings``!

For waypoints (climbing_outdoor), there may be several equipment rating values for the same WP (if it has several routes):
https://github.com/c2corg/v6_api/blob/master/c2corg_api/models/waypoint.py#L67
whereas routes have ``equipment_rating`` (one value per route):
https://github.com/c2corg/v6_api/blob/master/c2corg_api/models/route.py#L97

I have used ``equipment_rating`` (no s) for the field title in order not to add another translation.
