### PR TITLE
don't show associated outings in wp editing form

### DIFF
--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -721,7 +721,6 @@
             ## wr = waypoints, routes
             <app-add-association parent-id="document.document_id" added-documents="added" dataset="wr"></app-add-association>
             <%include file="../route/associated.html"/>
-            <%include file="../outing/associated.html"/>
             <%include file="../waypoint/associated.html"/>
           </div>
         </section>


### PR DESCRIPTION
I forgot about this one!