### PR TITLE
add lon-lat orientation + shorten 'waypoint.waypoint_type'

### DIFF
--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -25,7 +25,8 @@ app.constants = {
     'camp_site' : 4,
     'local_product' : 4,
     'paragliding_takeoff' : 4,
-    'paragliding_landing' : 4
+    'paragliding_landing' : 4,
+    'webcam': 4
   },
   REQUIRED_FIELDS : {
     waypoint: {

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -37,20 +37,19 @@
       {{editCtrl.updateMaxSteps(waypoint.waypoint_type)}} 
       {{editCtrl.waypoint_type = waypoint.waypoint_type}}
       {{document = waypoint}}
+      {{type = waypoint.waypoint_type}}
     </span>
     
     ## PROGRESS BAR
     <ul class="progress-bar-edit">
       <li class="nav-step-1"ng-click="editCtrl.step(1, 'waypoint',  'backwards')" ng-class="{'nav-step-selected': editCtrl.current_step == 1 }"><span class="nav-text"><span translate>waypoint</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
-      <li class="nav-step-2" ng-click="editCtrl.step(2, 'waypoint', editCtrl.previous_step >= 2 ? 'backwards' : 'forwards')" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor' 
-             || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'gite' 
-            || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'shelter' 
-            || waypoint.waypoint_type == 'access' ">
+      <li class="nav-step-2" ng-click="editCtrl.step(2, 'waypoint', editCtrl.previous_step >= 2 ? 'backwards' : 'forwards')" 
+          ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor', 'climbing_indoor',  'local_product', 'weather_station', 'gite',  'camp_site', 'hut',  'bivouac', 'shelter', 'access'].indexOf(type) > -1">
         <span class="nav-text"><span translate>figures</span></span><span class="bullet-container"><span class="bullet"></span></span>
       </li>
       
       <li class="nav-step-{{editCtrl.max_steps -1}}" ng-click="editCtrl.step((editCtrl.max_steps == 4 ? 3 : 2), 'waypoint',  editCtrl.previous_step >= ((editCtrl.max_steps == 4) ? 3 : 2) ? 'backwards' : 'forwards')" >
-        <span class="nav-text"><span ng-if="waypoint.waypoint_type != 'climbing_indoor' "><span translate>associations</span> & </span><span translate>descriptions</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
+        <span class="nav-text"><span ng-if="type != 'climbing_indoor' "><span translate>associations</span> & </span><span translate>descriptions</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
       </li>
       
       <li class="nav-step-{{editCtrl.max_steps}}" ng-click="editCtrl.step(editCtrl.max_steps, 'forwards')"><span translate class="nav-text">review</span>
@@ -122,10 +121,10 @@
           <div class="content" id="edit-maps">
             
             ## ELEVATION
-            <div id="elevation-group" class="form-group data third" ng-if="waypoint.waypoint_type != 'climbing_indoor' " ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid, 'has-success': editForm.elevation.$valid && waypoint.elevation }">
-              <label><span translate>elevation</span> <span ng-if="waypoint.waypoint_type != 'climbing_indoor'">*</span></label>
+            <div id="elevation-group" class="form-group data third" ng-if="type != 'climbing_indoor' " ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid, 'has-success': editForm.elevation.$valid && waypoint.elevation }">
+              <label><span translate>elevation</span> *</label>
               <div class="input-group">
-                <input type="number" name="elevation" min="0" ng-model="waypoint.elevation" class="form-control" ng-required="waypoint.waypoint_type != 'climbing_indoor'" max="9999"/>
+                <input type="number" name="elevation" min="0" ng-model="waypoint.elevation" class="form-control" ng-required="type != 'climbing_indoor'" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation.$valid && waypoint.elevation"></span>
@@ -138,7 +137,7 @@
             </div>
             
             ## ELEVATION MIN
-            <div id="elevation_min-group" ng-if="waypoint.waypoint_type == 'access'" class="form-group data third" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid, 'has-success': editForm.elevation_min.$valid && waypoint.elevation_min}">
+            <div id="elevation_min-group" ng-if="type == 'access'" class="form-group data third" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid, 'has-success': editForm.elevation_min.$valid && waypoint.elevation_min}">
               <label translate>elevation_min</label>
               <div class="input-group">
                 <input type="number" name="elevation_min" min="0" ng-model="waypoint.elevation_min" class="form-control" max="9999"/>
@@ -154,7 +153,7 @@
             </div>
             
             ##  PROMINENCE
-            <div id="prominence-group" ng-if="waypoint.waypoint_type == 'summit'" class="form-group data third" ng-class="{ 'has-error': editForm.prominence.$touched && editForm.prominence.$invalid, 
+            <div id="prominence-group" ng-if="type == 'summit'" class="form-group data third" ng-class="{ 'has-error': editForm.prominence.$touched && editForm.prominence.$invalid, 
                       'has-success': editForm.prominence.$valid && waypoint.prominence }">
               <label><span translate>prominence</span></label>
               <div class="input-group">
@@ -174,7 +173,7 @@
               <label><span translate>longitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" required required min="-90" max="90" />
-                <span class="input-group-addon">°</span>
+                <span class="input-group-addon">°E</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && waypoint.lonlat.longitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
@@ -192,7 +191,7 @@
               <label><span translate>Latitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" required required min="-90" max="90" />
-                <span class="input-group-addon">°</span>
+                <span class="input-group-addon">°N</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.lonlat.latitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
@@ -207,7 +206,7 @@
             <app-map app-map-edit-ctrl="editCtrl" app-map-draw-type="Point" class="map-edit"></app-map>
 
             ## MAPS REF
-            <div id="maps_info-group" class="input-group" ng-if="waypoint.waypoint_type != 'climbing_indoor' ">
+            <div id="maps_info-group" class="input-group" ng-if="type != 'climbing_indoor' ">
               <label translate>maps_references</label>
               <div ng-repeat="map in waypoint.maps" class="data half">
                 <input disabled value="{{map.editor}} - {{map.code}} - {{map.locales[0].title}}" class="form-control">
@@ -221,22 +220,18 @@
         </section>
       </div>
       
-      <div class="step step-2" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor' 
-             || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'gite' 
-            || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'shelter' 
-            || waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'summit' ">
+      <div class="step step-2" ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor', 'climbing_indoor',  'local_product', 'weather_station', 'gite',  'camp_site', 'hut',  'bivouac', 'shelter', 'access'].indexOf(type) > -1">
         
          ## TYPES & STYLES
-        <section class="section " ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'
-                 || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'climbing_indoor'">
+        <section class="section " ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor', 'local_product', 'weather_station', 'climbing_indoor'].indexOf(type) > -1">
           <h2 class="heading show-phone" >
-            <span translate ng-hide="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">Types & styles</span>
-            <span translate ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'">configuration</span>
+            <span translate ng-hide="type == 'paragliding_takeoff' || type == 'paragliding_landing'">Types & styles</span>
+            <span translate ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'">configuration</span>
           </h2>
           <div class="content" id="edit-types-styles">
 
             ## ROCK TYPES
-            <div id="rock_types-group" class="form-group" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+            <div id="rock_types-group" class="form-group" ng-if="type == 'climbing_outdoor'">
               <label translate>rock_types</label>
               <ul class="types long">
                 <li ng-repeat="type in ${rock_types}" ng-click="editCtrl.pushToArray(waypoint, 'rock_types', type, $event)">
@@ -245,10 +240,10 @@
               </ul>
             </div>
             
-            <div class="data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+            <div class="data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'">
 
               ## CLIMBING OUT TYPES
-              <div class="form-group" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+              <div class="form-group" ng-if="type == 'climbing_outdoor'">
                 <label translate>climbing_outdoor_types</label>
                 <ul class="types">
                   <li ng-repeat="type in ${climbing_outdoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_outdoor_types', type, $event)">
@@ -258,7 +253,7 @@
               </div>
 
               ## CLIMBING STYLES
-              <div class="form-group" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'">
+              <div class="form-group" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'">
                 <label translate>climbing_styles</label>
                 <ul class="types">
                   <li ng-repeat="type in ${climbing_styles}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_styles', type, $event)">
@@ -270,7 +265,7 @@
             </div>
             
             ## BEST PERIODS
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'">
               <label translate>best_periods</label>
               <ul class="types">
                 <li ng-click="editCtrl.pushToArray(waypoint, 'best_periods', month, $event)" ng-repeat="month in ${months}">
@@ -280,28 +275,28 @@
             </div>
 
             ## ACCESS TIME
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'">
               <label translate>access_time</label>
               <select class="form-control" ng-model="waypoint.access_time" ng-options="time as time for time in ${access_times}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.access_time"></span>
             </div>
 
             ## RAIN PROOF
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'" ng-class="{ 'has-error': editForm.rain_proof.$touched && editForm.rain_proof.$invalid, 'has-success': editForm.rain_proof.$valid }">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'" ng-class="{ 'has-error': editForm.rain_proof.$touched && editForm.rain_proof.$invalid, 'has-success': editForm.rain_proof.$valid }">
               <label><span translate>rain_proof</span></label>
               <select class="form-control " ng-model="waypoint.rain_proof" ng-options="type as mainCtrl.translate(type) for type in ${rain_proof_types}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.rain_proof"></span>
             </div>
 
             ## CHILDREN PROOF
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'">
               <label translate>children_proof</label>
               <select ng-options="type as type for type in ${children_proof_types}" ng-model="waypoint.children_proof" class="form-control "><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.children_proof"></span>
             </div>
             
             ## WEATHER STATION TYPES
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'weather_station'"
+            <div class="form-group data half" ng-if="type == 'weather_station'"
                  ng-class="{ 'has-error': editForm.weather_station_types.$touched && editForm.weather_station_types.$invalid, 'has-success': editForm.weather_station_types.$valid }">
               <label><span translate>weather_station_types</span></label>
               <ul class="types">
@@ -312,7 +307,7 @@
             </div>
 
             ## CLIMBING INT TYPES
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_indoor'">
               <label translate>climbing_indoor_types</label>
               <ul class="types">
                 <li ng-repeat="type in ${climbing_indoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_indoor_types', type, $event)">
@@ -322,8 +317,8 @@
             </div>
 
             ## PRODUCT TYPES
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'local_product'">
-              <label><span translate>product_types</span><span ng-if="waypoint.waypoint_type == 'local_product'"> *</span></label>
+            <div class="form-group data half" ng-if="type == 'local_product'">
+              <label><span translate>product_types</span><span ng-if="type == 'local_product'"> *</span></label>
               <ul class="types" required>
                 <li ng-repeat="type in ${product_types}" ng-click="editCtrl.pushToArray(waypoint, 'product_types', type, $event)">
                   <div class="checkbox"><input type="checkbox"><span x-translate>{{type}}</span></div>
@@ -332,7 +327,7 @@
             </div>
             
             ## ORIENTATION
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'"
+            <div class="form-group data half" ng-if="['paragliding_takeoff', 'paragliding_landing',' climbing_outdoor'].indexOf(type) > -1"
                  ng-class="{ 'has-error': editForm.orientations.$touched && editForm.orientations.$invalid,'has-success': editForm.orientations.$valid }">
               <label><span translate>orientations</span></label>
               <ul class="types long" id="orientation-list">
@@ -348,14 +343,12 @@
         </section>
          
         ## NUMBERS
-        <section class="section numbers" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' 
-            || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'gite' 
-            || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter' ">
+        <section class="section numbers" ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor', 'climbing_indoor', 'gite', 'camp_site', 'hut', 'shelter'].indexOf(type) > -1 ">
           <h2 class="heading show-phone" ><span translate>Numbers</span></h2>
           <div class="content" id="edit-numbers">
             
             ## LENGTH
-            <div id="length-group" class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+            <div id="length-group" class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
                  ng-class="{ 'has-error': editForm.length.$touched && editForm.length.$invalid, 'has-success': editForm.length.$valid && waypoint.length  }">
               <label translate>length</label>
               <div class="input-group">
@@ -370,7 +363,7 @@
             </div>
 
             ## SLOPE
-            <div id="slope-group" class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+            <div id="slope-group" class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
                  ng-class="{ 'has-error': editForm.slope.$touched && editForm.slope.$invalid, 'has-success': editForm.slope.$valid && waypoint.slope }">
               <label translate>slope</label>
               <div class="input-group">
@@ -386,7 +379,7 @@
 
             
             ## HEIGHT MAX
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
                  ng-class="{ 'has-error': editForm.height_max.$touched && editForm.height_max.$invalid,
                                       'has-success': editForm.height_max.$valid && waypoint.height_max}">
               <label><span translate>height_max</span></label>
@@ -402,7 +395,7 @@
             </div>
 
             ## HEIGHT MIN
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
                  ng-class="{ 'has-error': editForm.height_min.$touched && editForm.height_min.$invalid,'has-success': editForm.height_min.$valid && waypoint.height_min}">
               <label><span translate>height_min</span></label>
               <div class="input-group">
@@ -417,9 +410,8 @@
             </div>
 
             ## HEIGHT MEDIAN
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.height_median.$touched && editForm.height_median.$invalid,
-                                      'has-success': editForm.height_median.$valid && waypoint.height_median }">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.height_median.$touched && editForm.height_median.$invalid, 'has-success': editForm.height_median.$valid && waypoint.height_median }">
               <label><span translate>height_median</span></label>
               <div class="input-group">
                 <input type="number" name="height_median" min="0" ng-model="waypoint.height_median" class="form-control" max="9999"/>
@@ -433,9 +425,8 @@
             </div>
 
             ## ROUTES QUANTITY
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid,
-                                      'has-success': waypoint.routes_quantity }">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-error': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid, 'has-success': waypoint.routes_quantity }">
               <label><span translate>routes_quantity</span></label>
               <input type="number" name="routes_quantity" min="0" ng-model="waypoint.routes_quantity" class="form-control" max="9999"/>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.routes_quantity.$valid && waypoint.routes_quantity"></span>
@@ -446,7 +437,7 @@
             </div>
 
             ## CAPACITY
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'bivouac' || waypoint.waypoint_type == 'shelter'"
+            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut', 'bivouac', 'shelter'].indexOf(type) > -1"
                  ng-class="{ 'has-error': editForm.capacity.$touched && editForm.capacity.$invalid, 'has-success': editForm.capacity.$valid && waypoint.capacity }">
               <label translate>capacity</label>
               <div class="input-group">
@@ -461,14 +452,14 @@
             </div>
 
             ## CUSTODIANSHIP
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'camp_site'" ng-class="{'has-success': waypoint.custodianship}">
-              <label><span translate>custodianship</span> <span ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut'">*</span></label>
-              <select class="form-control" ng-options="type as mainCtrl.translate(type) for type in ${custodianship_types}" ng-model="waypoint.custodianship"><option value=""></option></select>
+            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut'].indexOf(type) > -1" ng-class="{'has-success': waypoint.custodianship}">
+              <label><span translate>custodianship</span> <span ng-if="type == 'gite' || type == 'camp_site' || type == 'hut'">*</span></label>
+              <select class="form-control" name="custodianship" ng-options="type as mainCtrl.translate(type) for type in ${custodianship_types}" ng-model="waypoint.custodianship" ng-required="type == 'gite' || type == 'hut' || type == 'camp_site'"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.custodianship"></span>
             </div>
             
             ## CAPACITY STAFFED
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'"
+            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut', 'shelter'].indexOf(type) > -1"
                  ng-class="{ 'has-error': editForm.capacity_staffed.$touched && editForm.capacity_staffed.$invalid, 'has-success': editForm.capacity_staffed.$valid && waypoint.capacity_staffed }">
               <label translate>capacity_staffed</label>
               <div class="input-group">
@@ -487,12 +478,12 @@
         
  
         ##RATINGS
-        <section class="section ratings" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'paragliding_takeoff'">
+        <section class="section ratings" ng-if="['climbing_outdoor', 'climbing_indoor', 'paragliding_landing', 'paragliding_takeoff'].indexOf(type) > -1">
           <h2 class="heading show-phone"><span translate>ratings</span></h2>
           <div class="content" id="edit-ratings">
 
-            ## PARAGLIDING RATINGj
-            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+            ## PARAGLIDING RATING
+            <div class="form-group data half rating" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
                  ng-class="{ 'has-error': editForm.paragliding_rating.$touched && editForm.paragliding_rating.$invalid, 'has-success': editForm.paragliding_rating.$valid }">
               <label><span translate>paragliding_rating</span></label><br>
               <select class="form-control" ng-options="rat as rat for rat in [1, 2, 3, 4, 5]" ng-model="waypoint.paragliding_rating"><option value=""></option></select>
@@ -500,7 +491,7 @@
             </div>
 
             ## EXPOSITION RATING
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing'"
+            <div class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
                  ng-class="{ 'has-error': editForm.exposition_rating.$touched && editForm.exposition_rating.$invalid, 'has-success': editForm.exposition_rating.$valid }">
               <label translate>exposition_rating</label>
               <select class="form-control " ng-model="waypoint.exposition_rating" ng-options="rat as mainCtrl.translate(rat) for rat in ${exposition_ratings}"><option value=""></option></select>
@@ -508,7 +499,7 @@
             </div>
 
             ## EQUIPMENT RATINGS
-            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor'"
+            <div class="form-group data half rating" ng-if="type == 'climbing_outdoor'"
                  ng-class="{ 'has-error': editForm.equipment_ratings.$touched && editForm.equipment_ratings.$invalid,'has-success': editForm.equipment_ratings.$valid }">
               <label><span translate>equipment_ratings</span></label><br>
               <ul class="types">
@@ -521,7 +512,7 @@
             </div>
 
             ## CLIMBING RATING MIN
-            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+            <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
                  ng-class="{ 'has-error': editForm.climbing_rating_min.$touched && editForm.climbing_rating_min.$invalid, 'has-success': editForm.climbing_rating_min.$valid }">
               <label><span translate>climbing_rating_min</span></label><br>
               <select ng-model="waypoint.climbing_rating_min" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
@@ -529,7 +520,7 @@
             </div>
 
             ## CLIMBING RATING MAX
-            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+            <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
                  ng-class="{ 'has-error': editForm.climbing_rating_max.$touched && editForm.climbing_rating_max.$invalid, 'has-success': editForm.climbing_rating_max.$valid }">
               <label><span translate>climbing_rating_max</span></label><br>
               <select ng-model="waypoint.climbing_rating_max" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
@@ -537,7 +528,7 @@
             </div>
 
             ## CLIMBING RATING MEDIAN
-            <div class="form-group data half rating" ng-if="waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'climbing_indoor'"
+            <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
                  ng-class="{ 'has-error': editForm.climbing_rating_median.$touched && editForm.climbing_rating_median.$invalid, 'has-success': editForm.climbing_rating_median.$valid }">
               <label><span translate>climbing_rating_median</span></label><br>
               <select ng-model="waypoint.climbing_rating_median" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
@@ -548,13 +539,13 @@
         </section>
 
         ## TRANSPORTS
-        <section class="section transports" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product'">
+        <section class="section transports" ng-if="type == 'access' || type == 'local_product'">
           <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-transports">
             <span><span translate>transport</span> & <span translate>access</span></span></h2>
           <div class="content" id="edit-transports">
             
             ## SNOW CLEARANCE RATINGS
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'access'" ng-class="{'has-success': waypoint.snow_clearance_rating}">
+            <div class="form-group data half" ng-if="type == 'access'" ng-class="{'has-success': waypoint.snow_clearance_rating}">
               <label translate>snow_clearance_ratings</label>
               <div class="input-group">
                 <select class="form-control" ng-options="rat as mainCtrl.translate(rat) for rat in ${snow_clearance_ratings}" ng-model="waypoint.snow_clearance_rating"><option value=""></option></select>
@@ -564,13 +555,13 @@
             </div>
 
             ## LIFT ACCESS
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'access'" ng-class="{'has-success': waypoint.lift_access}">
+            <div class="form-group data half" ng-if="type == 'access'" ng-class="{'has-success': waypoint.lift_access}">
               <label translate>lift_access</label>
               <div class="input-group">
                 <select class="form-control" ng-model="waypoint.lift_access">
+                  <option value="" translate></option>
                   <option value="true" ng-selected="waypoint.lift_access == true"><span translate>yes</span></option>
                   <option value="false" ng-selected="waypoint.lift_access == false"><span translate>no</span></option>
-                  <option value="" translate>no info</option>
                 </select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-resize-vertical"></span></span>
               </div>
@@ -578,7 +569,7 @@
             </div>
             
             ## PUBLIC TRANSPORT TYPES
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'access' ">
+            <div class="form-group data half" ng-if="type == 'access' ">
               <label translate>public_transportation_types</label>
               <ul class="types">
                 <li ng-repeat="type in ${public_transportation_types}" ng-click="editCtrl.pushToArray(waypoint, 'public_transportation_types', type, $event)">
@@ -590,7 +581,7 @@
             </div>
 
             ## PUBLIC TRANSPORT RATINGS
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'access' " ng-class="{'has-success': waypoint.public_transportation_rating}">
+            <div class="form-group data half" ng-if="type == 'access' " ng-class="{'has-success': waypoint.public_transportation_rating}">
               <label translate>public_transportation_ratings</label>
               <div class="input-group">
                 <select class="form-control" ng-options="rat as mainCtrl.translate(rat) for rat in ${public_transportation_ratings}" ng-model="waypoint.public_transportation_rating"><option value=""></option></select>
@@ -600,16 +591,16 @@
             </div>
 
             ## PARKING FEE TYPES
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'access' " ng-class="{'has-success': waypoint.parking_fee}">
+            <div class="form-group data half" ng-if="type == 'access' " ng-class="{'has-success': waypoint.parking_fee}">
               <label translate>parking_fee_types</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in ${parking_fee_types}" ng-model="waypoint.parking_fee" class="form-control"></select>
+              <select ng-options="type as mainCtrl.translate(type) for type in ${parking_fee_types}" ng-model="waypoint.parking_fee" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.parking_fee"></span>
             </div>
           </div>
         </section>
 
         ## EQUIPMENT
-        <section class="section equipment" ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'shelter'">
+        <section class="section equipment" ng-if="type == 'hut' || type == 'shelter'">
           <h2 class="heading show-phone"><span translate>Equipment</span></h2>
           <div class="content" id="edit-equipment">
 
@@ -673,24 +664,21 @@
         </section>
         
         ## CONTACT
-        <section class="section contact" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'webcam'
-                  || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'weather_station' || waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'climbing_outdoor'">
+        <section class="section contact" ng-if="['climbing_indoor', 'local_product', 'gite' , 'webcam', 'local_product', 'camp_site', 'hut', 'weather_station', 'climbing_indoor', 'climbing_outdoor'].indexOf(type) > -1">
           <h2 class="heading show-phone"><span translate>Contact</span></h2>
           <div class="content" id="edit-contact">
 
             ## URL
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product'
-                      || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'weather_station'
-                      || waypoint.waypoint_type == 'climbing_outdoor' || waypoint.waypoint_type == 'webcam'"  ng-class="{'has-success': waypoint.url}">
-              <label><span translate>url</span> <span ng-if="waypoint.waypoint_type == 'webcam' || waypoint.waypoint_type == 'weather_station'">*</span></label>
-              <input type="text" name="message" ng-model="waypoint.url" class="form-control" placeholder="www.adress.com" ng-required="['webcam', 'weather_station']. indexOf(waypoint.waypoint_type) > -1"/>
+            <div class="form-group data half" 
+                 ng-if="['climbing_indoor', 'local_product', 'gite' , 'webcam', 'local_product', 'camp_site', 'hut', 'weather_station', 'climbing_indoor', 'climbing_outdoor'].indexOf(type) >-1"ng-class="{'has-success': waypoint.url}">
+              <label><span translate>url</span> <span ng-if="type == 'webcam' || type == 'weather_station'">*</span></label>
+              <input type="text" name="message" ng-model="waypoint.url" class="form-control" placeholder="www.adress.com" ng-required="['webcam', 'weather_station']. indexOf(type) > -1"/>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.url.$invalid && editForm.url.$touched"></span>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.url"></span>
             </div>
 
             ## PHONE
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'climbing_indoor' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'gite'
-                      || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut'"  ng-class="{'has-success': waypoint.phone}">
+            <div class="form-group data half" ng-if="['climbing_indoor', 'local_product', 'gite', 'local_product', 'camp_site', 'hut'].indexOf(type) > -1"  ng-class="{'has-success': waypoint.phone}">
               <label translate>phone</label>
               <div class="input-group">
                 <input type="tel" name="message" ng-model="waypoint.phone" class="form-control " placeholder="phone" />
@@ -700,7 +688,7 @@
             </div>
 
             ## PHONE CUSTODIAN
-            <div class="form-group data half" ng-if="waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite'"  ng-class="{'has-success': waypoint.phone_custodian}">
+            <div class="form-group data half" ng-if="['camp_site', 'hut', 'gite'].indexOf(type) > -1"  ng-class="{'has-success': waypoint.phone_custodian}">
               <label translate>phone_custodian</label>
               <div class="input-group">
                 <input type="tel" name="message" ng-model="waypoint.phone_custodian" class="form-control " placeholder="phone_custodian" />
@@ -715,7 +703,7 @@
       </div>
 
       <div class="step step-{{editCtrl.max_steps -1}}">
-        <section class="section associations" ng-if="waypoint.waypoint_type != 'climbing_indoor' ">
+        <section class="section associations" ng-if="type != 'climbing_indoor' ">
           <h2 class="heading show-phone" translate>associations</h2>
           <div class="content">
             ## wr = waypoints, routes
@@ -742,22 +730,21 @@
             </div>
             
             ## ACCESS
-            <div class="form-group data full" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' || waypoint.waypoint_type == 'climbing_outdoor'">
+            <div class="form-group data full" ng-if="['access', 'local_product', 'climbing_outdoor'].indexOf(type) > -1">
               <label translate>access</label>
               <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control" placeholder="{{'Describe access'|translate}}"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access"></span>
             </div>
             
             ## ACCESS PERIOD
-            <div id="access-period" class="form-group data full" ng-if="waypoint.waypoint_type == 'access' || waypoint.waypoint_type == 'local_product' 
-                          || waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site' || waypoint.waypoint_type == 'climbing_outdoor'">
-              <label translate ng-if="waypoint.waypoint_type == 'access' ">access_period</label>
-              <label translate ng-if="waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site'">opening_periods</label>
-              <label translate ng-if="waypoint.waypoint_type == 'local_product'">opening_hours</label>
+            <div id="access-period" class="form-group data full" ng-if="['access', 'local_product', 'hut', 'gite', 'camp_site', 'climbing_outdoor'].indexOf(type) > -1">
+              <label translate ng-if="type == 'access' ">access_period</label>
+              <label translate ng-if="type == 'hut' || type == 'gite' || type == 'camp_site'">opening_periods</label>
+              <label translate ng-if="type == 'local_product'">opening_hours</label>
               <textarea name="access_period" ng-model="waypoint.locales[0].access_period" class="form-control" 
-                placeholder="{{ (waypoint.waypoint_type == 'hut' || waypoint.waypoint_type == 'gite' || waypoint.waypoint_type == 'camp_site') 
+                placeholder="{{ (type == 'hut' || type == 'gite' || type == 'camp_site') 
                                               ? mainCtrl.translate('describe opening_periods') 
-                                              : (waypoint.waypoint_type == 'local_product' ? mainCtrl.translate('describe opening_hours')  : mainCtrl.translate('describe access_period') ) 
+                                              : (type == 'local_product' ? mainCtrl.translate('describe opening_hours')  : mainCtrl.translate('describe access_period') ) 
                                          }}">
               </textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access_period"></span>


### PR DESCRIPTION
instead of writing `waypoint.waypoint_type` I init `{{type = waypoint.waypoint_type}}` which is more concise. I replaced all of the occurrences of `waypoint.waypoint_type`.

Longitude and latitude use °E and °N.
fixes #286 
 