### PR TITLE
Outing update

### DIFF
--- a/c2corg_ui/templates/outing/card.html
+++ b/c2corg_ui/templates/outing/card.html
@@ -1,6 +1,6 @@
 <a>
   <div class="outing-author text-center">
-    <div class="outing-date">{{ outing['date_start'] | date: 'dd/MM/yyyy'}}</div>
+    <div class="outing-date">{{ outing['date_end'] | date: 'dd/MM/yyyy'}}</div>
     <span class="icon-user"></span><br>
     <b class="author-name">{{outing['author']['username']}}</b>
   </div>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -376,7 +376,7 @@ updating_doc = outing_id and outing_lang
           <div class="content outing-route" id="track-edit">
 
             ## ACCESS COMMENT
-            <div class="form-group data full" ng-class="{'has-success': outing.public_transport}">
+            <div class="form-group data full" ng-class="{'has-success': outing.locales[0].access_comment"}">
               <label translate>access_comment</label>
               <textarea class="form-control " ng-model="outing.locales[0].access_comment"></textarea>
             </div>
@@ -396,6 +396,12 @@ updating_doc = outing_id and outing_lang
                 <span class="input-group-addon"><span class="glyphicon glyphicon-resize-vertical"></span></span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.lift_status"></span>
+            </div>
+            
+            ## HUT COMMENT
+            <div class="form-group data full" ng-class="{'has-success': outing.locales[0].hut_comment}">
+              <label translate>hut_comment</label>
+              <textarea class="form-control " ng-model="outing.locales[0].hut_comment"></textarea>
             </div>
 
             ## HUT STATUS

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -156,6 +156,8 @@ input[type=checkbox]:checked + * {
 .loading {
   opacity: 0.5;
   transition: .3s;
+  pointer-events: none;
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
- use "date_end" instead of "date_start"
- added "hut_comment" field
- small add-on : you can't click or do whatever while the screen is loading or if there is an error modal, unless you close it . Please don't hit me cause i didn't create a separate pr for this, it were just 2 small little cute css lines :sweat_smile: 
fixes #295 
fixes #300 
fixes #299