### PR TITLE
Add support of line geometries when editing routes/outings

### DIFF
--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -188,8 +188,8 @@ app.DocumentEditingController = function($scope, $element, $attrs,
     return;
   }
 
-  this.scope_.$root.$on('mapFeatureChange', function(event, feature) {
-    this.handleMapFeatureChange_(feature);
+  this.scope_.$root.$on('mapFeaturesChange', function(event, features) {
+    this.handleMapFeaturesChange_(features);
     this.scope_.$apply();
   }.bind(this));
 };
@@ -361,11 +361,13 @@ app.DocumentEditingController.prototype.updateMap = function() {
 
 
 /**
- * @param {ol.Feature} feature
+ * @param {Array.<ol.Feature>} features
  * @private
  */
-app.DocumentEditingController.prototype.handleMapFeatureChange_ = function(
-    feature) {
+app.DocumentEditingController.prototype.handleMapFeaturesChange_ = function(
+    features) {
+  // TODO handle multiple features?
+  var feature = features[0];
   var geometry = feature.getGeometry();
   goog.asserts.assert(geometry);
   var isPoint = geometry instanceof ol.geom.Point;

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -109,6 +109,12 @@ app.DocumentEditingController = function($scope, $element, $attrs,
    * @type {boolean}
    * @private
    */
+  this.hasGeomChanged_ = false;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
   this.isNewLang_ = false;
 
   /**
@@ -299,6 +305,10 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
 
   if (this.id_) {
     // updating an existing document
+    if (!this.hasGeomChanged_) {
+      // no need to push the unchanged geometry back
+      delete data['geometry'];
+    }
     if ('available_langs' in data) {
       delete data['available_langs'];
     }
@@ -396,6 +406,7 @@ app.DocumentEditingController.prototype.handleMapFeaturesChange_ = function(
     data['geometry']['geom'] = this.geojsonFormat_.writeGeometry(centerPoint);
     data['geometry']['geom_detail'] = this.geojsonFormat_.writeGeometry(geometry);
   }
+  this.hasGeomChanged_ = true;
 };
 
 

--- a/c2corg_ui/static/js/gpxupload.js
+++ b/c2corg_ui/static/js/gpxupload.js
@@ -1,0 +1,80 @@
+goog.provide('app.GpxUploadController');
+goog.provide('app.gpxUploadDirective');
+
+goog.require('app');
+/** @suppress {extraRequire} */
+goog.require('ngeo.filereaderDirective');
+goog.require('ol.format.GPX');
+
+
+/**
+ * This directive is used to display a GPX file upload button.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.gpxUploadDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'AppGpxUploadController',
+    controllerAs: 'gpxCtrl',
+    bindToController: true,
+    template:
+      '<div class="upload-file">' +
+        '<button class="orange-btn btn" type="button" ' +
+          'translate>upload a GPS track <span ' +
+          'class="glyphicon glyphicon-upload"></span></button>' +
+        '<input type="file" ngeo-filereader="gpxCtrl.fileContent" ' +
+          'ngeo-filereader-supported="gpxCtrl.fileReaderSupported" />' +
+      '</div>'
+  };
+};
+
+
+app.module.directive('appGpxUpload', app.gpxUploadDirective);
+
+
+/**
+ * @param {angular.Scope} $scope Scope.
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.GpxUploadController = function($scope) {
+
+  this.scope_ = $scope;
+
+  /**
+   * @type {boolean|undefined}
+   * @export
+   */
+  this.fileReaderSupported = undefined;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.fileContent = '';
+
+  $scope.$watch(function() {
+    return this.fileContent;
+  }.bind(this), this.importGpx_.bind(this));
+};
+
+
+/**
+ * @param {string} gpx GPX document.
+ * @private
+ */
+app.GpxUploadController.prototype.importGpx_ = function(gpx) {
+  var gpxFormat = new ol.format.GPX();
+  var features = gpxFormat.readFeatures(gpx, {
+    featureProjection: 'EPSG:3857'
+  });
+  if (features.length > 0) {
+    this.scope_.$root.$emit('featuresUpload', features);
+  }
+};
+
+
+app.module.controller('AppGpxUploadController', app.GpxUploadController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -18,6 +18,7 @@ goog.require('app.deleteAssociationDirective');
 goog.require('app.diffMapDirective');
 goog.require('app.protectedUrlBtnDirective');
 goog.require('app.documentEditingDirective');
+goog.require('app.gpxUploadDirective');
 goog.require('app.langDirective');
 goog.require('app.loadingDirective');
 goog.require('app.mapDirective');

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -35,7 +35,7 @@ app.mapDirective = function() {
   return {
     restrict: 'E',
     scope: {
-      'editCtrl': '=appMapEditCtrl',
+      'edit': '=appMapEdit',
       'drawType': '@appMapDrawType',
       'disableWheel': '=appMapDisableWheel',
       'zoom': '@appMapZoom'
@@ -91,16 +91,6 @@ app.MapController = function($scope, mapFeatureCollection) {
   this.styleCache = {};
 
   /**
-   * @type {?app.DocumentEditingController}
-   * @private
-   */
-  this.editCtrl_ = this['editCtrl'];
-  if (this.editCtrl_) {
-    this.scope_.$root.$on('documentDataChange',
-        this.handleEditModelChange_.bind(this));
-  }
-
-  /**
    * @type {Array<ol.Feature>}
    * @private
    */
@@ -124,6 +114,12 @@ app.MapController = function($scope, mapFeatureCollection) {
       })
     ]
   });
+
+  // editing mode
+  if (this['edit']) {
+    this.scope_.$root.$on('documentDataChange',
+        this.handleEditModelChange_.bind(this));
+  }
 
   if (!(this['disableWheel'] || false)) {
     var mouseWheelZoomInteraction = new ol.interaction.MouseWheelZoom();

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -392,7 +392,8 @@ app.MapController.prototype.showFeatures_ = function(features) {
  * @private
  */
 app.MapController.prototype.handleEditModelChange_ = function(event, data) {
-  var geomstr = data['geometry'] ? data['geometry']['geom'] : null;
+  var geomattr = this.drawType == 'Point' ? 'geom' : 'geom_detail';
+  var geomstr = data['geometry'] ? data['geometry'][geomattr] : null;
   if (geomstr) {
     var geometry = this.geojsonFormat_.readGeometry(geomstr);
     var features = [new ol.Feature(geometry)];
@@ -425,11 +426,6 @@ app.MapController.prototype.handleDraw_ = function(event) {
  * @private
  */
 app.MapController.prototype.handleModify_ = function(event) {
-  // TODO handle lines as well, not only points
-  if (this.drawType != 'Point') {
-    alert('Feature type not supported for editing');
-    return;
-  }
   var feature = event.features.item(0);
   this.scope_.$root.$emit('mapFeatureChange', feature);
 };

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -449,7 +449,7 @@ app.MapController.prototype.addTrackImporter_ = function() {
       var source = this.getVectorLayer_().getSource();
       // TODO: keep associated features?
       source.clear();
-      var feature = features[0];
+      var feature = this.processFeature_(features[0]);
       source.addFeature(feature);
       this.map.getView().fit(
           source.getExtent(), /** @type {ol.Size} */ (this.map.getSize()));
@@ -457,6 +457,20 @@ app.MapController.prototype.addTrackImporter_ = function() {
     }
   }.bind(this));
   this.map.addInteraction(dragAndDropInteraction);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature to process.
+ * @return {ol.Feature}
+ * @private
+ */
+app.MapController.prototype.processFeature_ = function(feature) {
+  var geometry = feature.getGeometry();
+  // simplify geometry with a tolerance of 20 meters
+  geometry = geometry.simplify(20);
+  feature.setGeometry(geometry);
+  return feature;
 };
 
 

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -64,7 +64,7 @@ app.utils.pushToArray = function(object, property, value, event) {
       return false;
     }
   }
-}
+};
 
 
 /**
@@ -86,7 +86,7 @@ app.utils.animateHeaderIcon = function(e) {
     menuUp.toggleClass('rotate-arrow-down');
   }
   return;
-}
+};
 
 
 /**
@@ -109,4 +109,4 @@ app.utils.areDifferentDates = function(date1, date2) {
   if (date1 !== null && date2 !== null) {
     return date1.toDateString() !== date2.toDateString();
   }
-}
+};

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -71,7 +71,7 @@ updating_doc = outing_id and outing_lang
               <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
               <input type="file" />
             </div>
-            <app-map app-map-edit-ctrl="editCtrl" class="map-edit"></app-map>
+            <app-map app-map-edit="true" class="map-edit"></app-map>
 
             ## ROUTE TAKEN
             <div class="data full" class="form-group">

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -67,10 +67,7 @@ updating_doc = outing_id and outing_lang
             </div>
             
             ## MAP
-            <div class="upload-file">
-              <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
-              <input type="file" />
-            </div>
+            <app-gpx-upload></app-gpx-upload>
             <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
 
             ## ROUTE TAKEN

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -71,7 +71,7 @@ updating_doc = outing_id and outing_lang
               <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
               <input type="file" />
             </div>
-            <app-map app-map-edit="true" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
 
             ## ROUTE TAKEN
             <div class="data full" class="form-group">

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -86,7 +86,7 @@ updating_doc = route_id and route_lang
               <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
               <input type="file" />
             </div>
-            <app-map app-map-edit="true" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
             
           </div>
         </section>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -86,7 +86,7 @@ updating_doc = route_id and route_lang
               <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
               <input type="file" />
             </div>
-            <app-map app-map-edit-ctrl="editCtrl" class="map-edit"></app-map>
+            <app-map app-map-edit="true" class="map-edit"></app-map>
             
           </div>
         </section>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -82,10 +82,7 @@ updating_doc = route_id and route_lang
             </div>
             
             ## MAP + upload
-            <div class="upload-file">
-              <button class="orange-btn btn" type="button" translate>upload a GPS track <span class="glyphicon glyphicon-upload"></span></button>
-              <input type="file" />
-            </div>
+            <app-gpx-upload></app-gpx-upload>
             <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
             
           </div>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -203,7 +203,7 @@
               </div>
             </div>
 
-            <app-map app-map-edit-ctrl="editCtrl" app-map-draw-type="Point" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-draw-type="Point" class="map-edit"></app-map>
 
             ## MAPS REF
             <div id="maps_info-group" class="input-group" ng-if="type != 'climbing_indoor' ">


### PR DESCRIPTION
Fixes #303 

TODO and open questions:
* [x] display and edit/draw line geometries in the editing form map
* [x] drag-drop a GPX file on the map to upload it
* [ ] Allow to reset the current geometry (for instance to draw a brand new one)? see https://github.com/c2corg/v6_ui/issues/330
* [x] don't send the geometry to the API if it has not changed (else it creates a new geom version in the DB?)
* [ ] Make sure 3D tracks are supported
 * [ ] Elevation/timestamp are removed from  GPX tracks see https://github.com/c2corg/v6_ui/issues/331
 * [ ] API seems to not support elevation/timestamp, see  https://github.com/c2corg/v6_api/issues/262
* [x] Simplify too big geometries
* [x] ~~``ol.interaction.DragAndDrop`` returns ``MultiLineString`` geometries whereas the API expects ``LineString`` and throw an error back. Is it possible to convert the ``MultiLineString`` to ``LineString`` (for instance by concatenating the ``LineString`` items of the ``MultiLineString``)? Or maybe we should change the API in order to support ``MultiLineString``? Which could be useful for instance for routes with variantes?~~
* [x] Support the "Add a GPS track" button (as for now it is a dummy one). ngeo has ``ngeo-filereader`` (http://camptocamp.github.io/ngeo/master/examples/importfeatures.html) but I don't know if it is that easy to combine with our ``app-map`` directive?