### PR TITLE
Add new outing to existing route from the details-view

### DIFF
--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -207,6 +207,21 @@ app.Api.prototype.updateDocument = function(module, id, json) {
   return promise;
 };
 
+/**
+ * @export
+ * @param {number} id Document id.
+ * @param {string} doctype the first letter of document type (o, w, r...)
+ * @return {!angular.$q.Promise<!angular.$http.Response>}
+ */
+app.Api.prototype.getDocumentByIdAndDoctype = function(id, doctype) {
+  var alerts = this.alerts_;
+  var promise = this.getJson_('/search?q=' + id + '&t=' + doctype);
+  promise.catch(function(response) {
+    alerts.addError(response);
+  });
+  return promise;
+};
+
 
 /**
  * @param {Object} response Response from the API server.

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -46,6 +46,7 @@ app.module.directive('appDocumentEditing', app.documentEditingDirective);
  * @param {angular.JQLite} $element Element.
  * @param {angular.Attributes} $attrs Attributes.
  * @param {app.Authentication} appAuthentication
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {app.Alerts} appAlerts
  * @param {app.Api} appApi Api service.
  * @param {string} authUrl Base URL of the authentication page.
@@ -54,7 +55,14 @@ app.module.directive('appDocumentEditing', app.documentEditingDirective);
  * @export
  */
 app.DocumentEditingController = function($scope, $element, $attrs,
-    appAuthentication, appAlerts, appApi, authUrl) {
+    appAuthentication, ngeoLocation, appAlerts, appApi, authUrl) {
+
+  /**
+   * @type {ngeo.Location}
+   * @private
+   */
+  this.ngeoLocation_ = ngeoLocation;
+
 
   /**
    * @type {angular.Scope}
@@ -147,6 +155,11 @@ app.DocumentEditingController = function($scope, $element, $attrs,
    */
   this.max_steps;
 
+ /**
+  * @type {boolean}
+  * @private
+  */
+  this.submit_ = false;
 
   /**
    * Waypoint init
@@ -164,6 +177,12 @@ app.DocumentEditingController = function($scope, $element, $attrs,
    * @private
    */
   this.api_ = appApi;
+
+  // allow association only new outing  to existing route
+  if (this.ngeoLocation_.hasParam('routes')) {
+    this.urlParams_ = {'routes': this.ngeoLocation_.getParam('routes')};
+    this.pushDocToAssociations_();
+  }
 
   // When creating a new document, the model is not created until
   // the form is touched. At least create an empty object.
@@ -257,10 +276,9 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
   }
 
   if (!this.auth_.isAuthenticated()) {
-    this.alerts_.addError('You have no permission to modify this document');
+    this.alerts_.addError('You must log in to edit this document.');
     return;
   }
-
   // push to API
   var data = angular.copy(this.scope_[this.modelName_]);
   if (!goog.isArray(data['locales'])) {
@@ -295,6 +313,8 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
     delete data['read_lonlat'];
   }
 
+  this.submit_ = true;
+
   if (this.id_) {
     // updating an existing document
     if ('available_langs' in data) {
@@ -317,6 +337,16 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
   } else {
     // creating a new document
     this.lang_ = data['locales'][0]['lang'];
+    if (this.modelName_ === 'outing') {
+      // adapt the Object for what's expected at the API side + format the outing
+      this.formatOuting_(data);
+      data = {
+        'outing': data,
+        'route_id': data['associations']['routes'][0]['document_id'],
+        'user_ids': [this.auth_.userData.id]
+      };
+    }
+
     this.api_.createDocument(this.module_, data).then(function(response) {
       this.id_ = response['data']['document_id'];
       window.location.href = app.utils.buildDocumentUrl(
@@ -377,6 +407,18 @@ app.DocumentEditingController.prototype.handleMapFeatureChange_ = function(
       'latitude': coords[1]
     };
   }
+};
+
+
+/**
+ * It doesn't associate, it just pushes it into associations array.
+ * @private
+ */
+app.DocumentEditingController.prototype.pushDocToAssociations_ = function() {
+  var doctype = Object.keys(this.urlParams_)[0];
+  this.api_.getDocumentByIdAndDoctype(this.urlParams_[doctype], doctype[0]).then(function(doc) {
+    this.scope_[this.modelName_]['associations'][doctype].push(doc.data[doctype].documents[0]);
+  }.bind(this));
 };
 
 
@@ -524,7 +566,6 @@ app.DocumentEditingController.prototype.animateBar_ = function(step, direction) 
  */
 
 app.DocumentEditingController.prototype.updateMaxSteps = function(waypointType) {
-
   if (app.constants.STEPS[waypointType]) {
     this.max_steps = app.constants.STEPS[waypointType];
   } else {
@@ -536,31 +577,52 @@ app.DocumentEditingController.prototype.updateMaxSteps = function(waypointType) 
  * @param {Object} outing
  * @private
  */
-
 app.DocumentEditingController.prototype.formatOuting_ = function(outing) {
-  // creating a new outing -> init locales
+  if (this.submit_) {
+    if (outing['locales'][0]['conditions_levels'][0]['level_place'].length > 0) {
+      // transform condition_levels to a string
+      outing['locales'][0]['conditions_levels'] = JSON.stringify(outing['locales'][0]['conditions_levels']);
+    } else {
+      delete outing['locales'][0]['conditions_levels'][0];
+    }
+    // if no date end -> make it the same as date start
+    if (!outing['date_end'] && outing['date_start'] instanceof Date) {
+      outing['date_end'] = outing['date_start'];
+    }
+  }
+  // creating a new outing -> init locales and associations
   if (!outing['locales']) {
     outing['locales'] = [{}];
   }
-
-  outing['date_start'] = app.utils.formatDate(outing['date_start']);
-  outing['date_end'] = app.utils.formatDate(outing['date_end']);
-
-  // conditions_levels -> to JSON and snow -> INT
-  if (outing['locales'][0]['conditions_levels']) {
-    outing['locales'][0]['conditions_levels'] = JSON.parse(outing['locales'][0]['conditions_levels']);
-    for (var i = 0; i < outing['locales'][0]['conditions_levels'].length; i++) {
-      var cond = outing['locales'][0]['conditions_levels'][i];
-      cond['level_snow_height_soft'] = parseInt(cond['level_snow_height_soft'], 10);
-      cond['level_snow_height_total'] = parseInt(cond['level_snow_height_total'], 10);
-    }
-  } else {
-    // init empty conditions_levels for ng-repeat
-    outing['locales'][0]['conditions_levels'] = [{'level_snow_height_soft': '', 'level_snow_height_total': '', 'level_comment': '', 'level_place': ''}];
+  if (!outing['associations']) {
+    outing['associations'] = {'routes': [], 'waypoints': [], users: []};
   }
 
+  // convert existing date from string to a date object
+  if (outing['date_end'] && typeof outing['date_end'] === 'string') {
+    outing['date_end'] = app.utils.formatDate(outing['date_end']);
+  }
+
+  if (outing['date_start'] && outing['date_start'] === 'string') {
+    outing['date_start'] = app.utils.formatDate(outing['date_start']);
+  }
+
+  var conditions = outing['locales'][0]['conditions_levels'];
+  // conditions_levels -> to Object, snow_height -> to INT
+  if (conditions && typeof conditions === 'string') {
+    conditions = JSON.parse(conditions);
+    for (var i = 0; i < conditions.length; i++) {
+      conditions[i]['level_snow_height_soft'] = parseInt(conditions[i]['level_snow_height_soft'], 10);
+      conditions[i]['level_snow_height_total'] = parseInt(conditions[i]['level_snow_height_total'], 10);
+    }
+  } else {
+    if (!this.submit_) {
+      // init empty conditions_levels for ng-repeat
+      outing['locales'][0]['conditions_levels'] = [{'level_snow_height_soft': '', 'level_snow_height_total': '', 'level_comment': '', 'level_place': ''}];
+    }
+  }
   return outing;
-}
+};
 
 
 /**
@@ -573,7 +635,7 @@ app.DocumentEditingController.prototype.formatOuting_ = function(outing) {
  */
 app.DocumentEditingController.prototype.pushToArray = function(object, property, value, event) {
   app.utils.pushToArray(object, property, value, event);
-}
+};
 
 
 /**

--- a/c2corg_ui/static/js/protectedurlbtn.js
+++ b/c2corg_ui/static/js/protectedurlbtn.js
@@ -12,7 +12,6 @@ app.protectedUrlBtnDirective = function() {
     restrict: 'A',
     controller: 'AppProtectedUrlBtnController',
     scope: {
-      'lang': '=',
       'url': '='
     },
     link: function(scope, el, attr, ctrl) {

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -164,7 +164,7 @@
             <span x-translate>associated ${associatedDocuments}</span><span class="glyphicon glyphicon-menu-down"></span>
           </h3>
           <div class="associated-documents collapse in" id="associated-${associatedDocuments}">
-            <div class="list-item vertical-align" protected-url-btn url="'${request.route_url('outings_add')}'">
+            <div class="list-item vertical-align" protected-url-btn url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
               <a>
                 <button class="btn orange-btn">add a new outing to this document</button>
               </a>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -376,7 +376,7 @@ updating_doc = outing_id and outing_lang
           <div class="content outing-route" id="track-edit">
 
             ## ACCESS COMMENT
-            <div class="form-group data full" ng-class="{'has-success': outing.locales[0].access_comment"}">
+            <div class="form-group data full" ng-class="{'has-success': outing.locales[0].access_comment}">
               <label translate>access_comment</label>
               <textarea class="form-control " ng-model="outing.locales[0].access_comment"></textarea>
             </div>
@@ -458,11 +458,18 @@ updating_doc = outing_id and outing_lang
               </div>
             </div>
 
-            ## AWESOMENESS
-            <div id="lang-group" class="form-group">
-              <label translate>awesomeness</label>
-              <div class="input-group awesomeness">
-                <uib-rating ng-model="outing.awesomeness" max="5"  ></uib-rating>
+            ## LANGUAGE
+            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
+              <label><span translate>lang</span> *</label>
+              % if outing_lang:
+                <input disabled x-translate class="form-control" value="${outing_lang}">
+              % else:
+                <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="outing.locales[0].lang" class="form-control" required><option value=""></option></select>
+              % endif
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.locales[0].lang"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.lang.$error">
+                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -12,6 +12,7 @@ import json
     show_areas, show_float_buttons, get_associated_documents"/>
 <%
 outing_id = outing['document_id']
+outing['doctype'] = 'outings'
 other_langs, missing_langs = get_lang_lists(outing, lang)
 %>
 
@@ -140,7 +141,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   % if not version and ('waypoint' in outing['associations'] and  len(outing['associations']['waypoints']) > 0 or 'routes' in outing['associations'] and  len(outing['associations']['routes']) > 0):
   <div class="view-details-associations col-xs-12 tab associations">
     <span class="lead">
-      <div ng-show="userCtrl.auth.isAuthenticated()">
+      <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
         <label translate>Add association</label>:
         <app-add-association parent-id="${outing_id}" added-documents="added"></app-add-association>
       </div>

--- a/c2corg_ui/templates/route/card.html
+++ b/c2corg_ui/templates/route/card.html
@@ -1,5 +1,5 @@
 <a>
-  <span class="list-item-title">{{route['locales'][0]['title']}}</span>
+  <span class="list-item-title">{{route['locales'][0]['title_prefix']}} : {{route['locales'][0]['title']}}</span>
   <span class="list-item-lang"> ({{route['locales'][0]['lang']}})</span><br>
   <div class="list-item-info">
     {{route['elevation']}}

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -12,6 +12,7 @@ from c2corg_ui.templates.utils import get_lang_lists
 
 <%
 route_id = route['document_id']
+route['doctype'] = 'routes'
 other_langs, missing_langs = get_lang_lists(route, lang)
 %>
 
@@ -105,69 +106,76 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   </div>
   % endif
   
-  <div class="thumbnail view-details-informations tab  col-sm-12 informations">
-    <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
-    </h3>
-    <section id="document-informations" class="collapse in">
-      ${get_route_general(route, locale)}
-      ${get_route_location(route)}
-      ${get_route_heights(route)}
-      ${get_route_rating(route)}
-      ${get_route_access(route)}
-      ${get_route_associated_maps(route)}
-    </section>
-  </div> 
-
-  ## DESCRIPTION
-  % if locale['summary'] or locale['description']:
-  <div class="view-details-description col-xs-12 tab description">
-    <h3 class="heading show-phone"><span translate>description</span></h3>
-    <span class="lead">
-      <div id="document-description" class="collapse in">
-
-        % if locale['summary']:
-        <summary class="document-summary">
-          <label translate>summary</label><br>
-          ${show_attr(locale, 'summary')}
-        </summary>
-        % endif
-
-        % if locale['description']:
-        ${show_attr(locale, 'description')}
-        % endif
-
-      </div>
-    </span>
-  </div>
-  % endif
-  
-  <div class="description tab">
-    ${get_document_locale_text(locale, 'remarks')}
-    ${get_document_locale_text(locale, 'gear')}
-    ${get_document_locale_text(locale, 'route_history')}
-  </div>
-  
-  ## ASSOCIATIONS
-  % if not version:
-  
-    % if len(route['associations']['recent_outings']['outings']) > 0:
-    <div class="view-details-associations col-xs-12 tab associations">
-      <span class="lead">
-        <section>
-          ${get_associated_documents(route, 'recent_outings')}
+      <div class="thumbnail view-details-informations tab  col-sm-12 informations">
+        <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
+          <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+        </h3>
+        <section id="document-informations" class="collapse in">
+          ${get_route_general(route, locale)}
+          ${get_route_location(route)}
+          ${get_route_heights(route)}
+          ${get_route_rating(route)}
+          ${get_route_access(route)}
+          ${get_route_associated_maps(route)}
         </section>
+      </div>
+  
+    ## DESCRIPTION
+    % if locale['summary'] or locale['description']:
+    <div class="view-details-description col-xs-12 tab description">
+      <h3 class="heading show-phone"><span translate>description</span></h3>
+      <span class="lead">
+        <div id="document-description" class="collapse in">
+
+          % if locale['summary']:
+          <summary class="document-summary">
+            <label translate>summary</label><br>
+            ${show_attr(locale, 'summary')}
+          </summary>
+          % endif
+
+          % if locale['description']:
+          ${show_attr(locale, 'description')}
+          % endif
+
+        </div>
       </span>
     </div>
+    % endif
+
+    <div class="description tab">
+      ${get_document_locale_text(locale, 'remarks')}
+      ${get_document_locale_text(locale, 'gear')}
+      ${get_document_locale_text(locale, 'route_history')}
+    </div>
+    
+    
+  ## ASSOCIATIONS
+  % if not version:
+
+    % if len(route['associations']['recent_outings']['outings']) > 0:
+      <div class="view-details-associations col-xs-12 tab associations">
+        <span class="lead">
+          <section>
+            ${get_associated_documents(route, 'recent_outings')}
+          </section>
+        </span>
+      </div>
     % endif
 
     <div class="view-details-associations col-xs-12 tab associations">
       <span class="lead">
         <section>
-          <div ng-show="userCtrl.auth.isAuthenticated()">
+          <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
             <label translate>Add association</label>:
             <app-add-association parent-id="${route_id}" added-documents="added"></app-add-association>
           </div>
+          % if len(route['associations']['recent_outings']['outings']) == 0:
+            <div class="add-outing">
+              <p class="text-center"><strong>no outings yet?</strong><p>
+                <button type="button" class="btn gray-btn" protected-url-btn url="'${request.route_url('outings_add')}' + '?docToAssociateId=${route_id}?doctype=routes'" translate>add a new one to this document</button>
+            </div>
+          % endif
           ${get_associated_documents(route, 'waypoints')}
           ${get_associated_documents(route, 'routes')}
         </section>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -10,6 +10,7 @@ from c2corg_ui.templates.utils import get_lang_lists
 <%
 waypoint_id = waypoint['document_id']
 other_langs, missing_langs = get_lang_lists(waypoint, lang)
+waypoint['doctype'] = 'waypoints'
 
 ## FIXME: transform() makes server crash in apache mode. Reprojection is then temporarly deactivated.
 ##geometry4326 = transform(geometry, 'epsg:3857', 'epsg:4326')
@@ -158,7 +159,7 @@ geometry4326 = geometry
     <div class="view-details-associations col-xs-12 tab associations">
       <span class="lead">
       <section>
-        <div ng-show="userCtrl.auth.isAuthenticated()">
+        <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
           <label translate>Add association</label>:
           <app-add-association parent-id="${waypoint_id}" added-documents="added"></app-add-association>
         </div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1030,6 +1030,6 @@ ul {
 
   }
   .route-activities {
-    justify-content: flex-start;
+    justify-content: flex-start !important;
   }
 }

--- a/less/documentdetailsview.less
+++ b/less/documentdetailsview.less
@@ -82,7 +82,7 @@
   padding-bottom: 266px;
   overflow: hidden;
 
-  @media @phone{
+  @media @phone {
     padding-top: 28px;
     padding-left: 5px;
     padding-right: 5px;
@@ -165,9 +165,17 @@
         flex-grow: 1;
       }
     }
+    .add-association {
+      float: left;
+    }
     .add-outing {
       float: right;
+      background: #CACACA;
       margin-bottom: 10px;
+      padding: .5%;
+      color: white;
+      border-radius: 5px;
+      font-variant: small-caps;
     }
     .show-more {
       float: right;

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -79,43 +79,6 @@
       margin-top: 0;
     }
   }
-  .section.title {
-    
-    .route-activities { 
-      .flex();
-      justify-content: space-around;
-      flex-flow: wrap row;
-      @media @phone {
-        justify-content: space-between;
-      }
-      .activity {
-        width: 20%;
-        text-align: center;
-        cursor: pointer;
-        @media (max-width: @screen-md-min) {
-          width: 33%;
-        }
-        p {
-          text-align: center;
-        }
-      }
-     [class^="icon-"] {
-        font-size: 8em;
-        @media @big {
-          font-size: 9em;
-        }
-        @media (max-width: @screen-sm-min) {
-          font-size: 6em;
-        }
-        @media (max-width: @screen-sm-max) {
-          font-size: 7em;
-        }
-        @media @phone {
-          font-size: 5em;
-        }
-      }
-    }
-  }
 
   #maps_info-group {
     width: 100%;
@@ -152,6 +115,41 @@
     background: white;
     margin-bottom: 15px;
     width: 100%;
+    
+    .route-activities { 
+      .flex();
+      justify-content: space-around;
+      flex-flow: wrap row;
+      @media @phone {
+        justify-content: space-between;
+      }
+      .activity {
+        width: 20%;
+        text-align: center;
+        cursor: pointer;
+        @media (max-width: @screen-md-min) {
+          width: 33%;
+        }
+        p {
+          text-align: center;
+        }
+      }
+     [class^="icon-"] {
+        font-size: 8em;
+        @media @big {
+          font-size: 9em;
+        }
+        @media (max-width: @screen-sm-min) {
+          font-size: 6em;
+        }
+        @media (max-width: @screen-sm-max) {
+          font-size: 7em;
+        }
+        @media @phone {
+          font-size: 5em;
+        }
+      }
+    }
     
     .conditions-levels {
       margin-bottom: 10px;
@@ -206,9 +204,6 @@
       height: 300px !important;
     }
     .route-activities { 
-      .flex();
-      justify-content: space-around;
-      flex-flow: wrap row; 
      @media @phone {
         justify-content: space-between;
       }


### PR DESCRIPTION
We're halfway through! 
On a route view page, if you click on 'add new outing to this document' it will redirect to outings/add with a modified URL that has additional values, for example `outings/add?docToAssociateId=736485?doctype=routes`.
Then it will try to get it from the API and push into [associations][routes] and it will show up under route taken - > associated routes.
It would work for any kind of document, but for now we only want to let associate a route to a new outing (as I understood).

Now, the other half of the job is that the API should manage this case of associating a doc to an inexistent outing. 

fixes #269 