### PR TITLE
Add instructions for installing required software packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Requirements
  * gettext (0.18 or higher)
  * virtualenv (1.7 or higher)
 
+On Debian/Ubuntu systems the required components may be installed using
+
+    sudo apt-get install virtualenv python3-dev nodejs-legacy npm openjdk-7-jdk gettext
+
 Checkout
 --------
 


### PR DESCRIPTION
I had to reinstall the UI on my new laptop. Here are the packages I had to install before the ``make install`` completed.

There are probably other packages to install since ``make check`` tells me that
> ImportError: No module named 'venusian'

and ``make serve`` complains that
> ImportError: No module named 'paste'

Do you remember how to install them? Should they be added to ``requirements.txt``?