### PR TITLE
Add captcha to registration form

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ To see the debug output:
 
     .build/venv/bin/nosetests -s
 
+
+Captcha
+-------
+
+Captcha configuration is done through https://www.google.com/recaptcha/admin .
+The public key is used in the UI. The corresponding secret key is used in the API.
+
+
 Developer Tips
 --------------
 

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -11,4 +11,5 @@ goog.require('ngeo');
  * @const
  * @type {!angular.Module}
  */
-app.module = angular.module('app', [ngeo.module.name, 'gettext', 'ngMessages', 'ngCookies', 'ui.bootstrap', 'angularMoment']);
+app.module = angular.module('app', [ngeo.module.name, 'gettext', 'ngMessages',
+    'ngCookies', 'ui.bootstrap', 'angularMoment', 'vcRecaptcha']);

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -1,3 +1,6 @@
+<%!
+from pyramid.settings import asbool
+%>
 <%inherit file="base.html"/>
 <%namespace file="helpers/common.html" import="show_title"/>
 <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Authentication')">${show_title('Authentication')}</title></%block>
@@ -92,6 +95,11 @@
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
+%if not asbool(request.registry.settings['skip.captcha.validation']):
+        <div id="register-captcha-group" class="form-group">
+          <div vc-recaptcha ng-model="register.captcha" required></div>
+        </div>
+%endif
         <p>
           <button type="submit" class="btn blue-btn" ng-disabled="registerForm.$invalid" translate>Register</button>
         </p>
@@ -159,3 +167,4 @@
 
   </section>
 </div>
+<script src="https://www.google.com/recaptcha/api.js?onload=vcRecaptchaApiLoaded&render=explicit" async defer></script>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -86,6 +86,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/moment/moment.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-moment/angular-moment.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-recaptcha/release/angular-recaptcha.js' % node_modules_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>
     <script src="${request.static_url('c2corg_ui:static/js/main.js')}"></script>
 % else:
@@ -101,6 +102,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/moment/min/moment.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-moment/angular-moment.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-recaptcha/release/angular-recaptcha.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('c2corg_ui:static/build/build.js')}"></script>
 % endif
 
@@ -113,6 +115,9 @@ closure_library_path = settings.get('closure_library_path')
          module.constant('apiUrl', '${api_url}');
          module.constant('authUrl', '${request.route_url('auth')}');
          module.constant('langs', ['${"','".join(default_langs) |n}']);
+         module.config(function(vcRecaptchaServiceProvider) {
+           vcRecaptchaServiceProvider.setSiteKey('${settings["recaptcha_site_key"]}');
+         });
          <%block name="moduleConstantsValues">
          module.value('mapFeatureCollection', null);
          </%block>

--- a/common.ini.in
+++ b/common.ini.in
@@ -24,3 +24,5 @@ pyramid_closure.roots_with_prefix =
 # used for the "node_modules" and "closure" static views
 node_modules_path = %(here)s/node_modules/
 closure_library_path = __CLOSURE_LIBRARY_PATH__
+recaptcha_site_key = 6LdWkR4TAAAAAJEW4VaASKHU55wP42yYNy7Mbgdb
+skip.captcha.validation = {skip_captcha_validation}

--- a/config/default
+++ b/config/default
@@ -14,3 +14,4 @@ export api_url_internal =
 export api_url_host =
 
 export logging_level = WARNING
+export skip_captcha_validation = False

--- a/config/gberaudol
+++ b/config/gberaudol
@@ -4,3 +4,4 @@ export debug_port = 6556
 export instanceid = gberaudo
 export base_url = /${instanceid}
 export api_url = http://127.0.0.1:6546
+export skip_captcha_validation = False

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "closure-util": "1.10.0",
     "angular-moment": "^1.0.0-beta.4",
     "angular-ui-bootstrap": "1.1.2",
+    "angular-recaptcha": "git://github.com/VividCortex/angular-recaptcha#3.0.1",
     "async": "1.5.2",
     "bootstrap": "3.3.6",
     "bootstrap-slider": "6.0.16",
@@ -15,18 +16,18 @@
   },
   "devDependencies": {
     "angular": "1.5.0",
-    "angular-messages": "1.5.0",
     "angular-cookies": "1.5.0",
     "angular-gettext": "2.2.1",
     "angular-gettext-tools": "2.1.11",
-    "openlayers": "git://github.com/openlayers/ol3#9baa296a49a75045e756089516f610c58cdc82eb",
-    "ngeo": "git://github.com/camptocamp/ngeo#fd9174ae4ee49c0ace7265f6263d7bf24c658786",
+    "angular-messages": "1.5.0",
+    "eslint": "2.1.0",
+    "eslint-config-openlayers": "4.0.0",
+    "jquery": "2.2.0",
     "less": "git://github.com/less/less.js#ec04a03f1cba3a092d5cd7f7c5d8e28bb43c1932",
     "less-plugin-clean-css": "1.5.1",
+    "ngeo": "git://github.com/camptocamp/ngeo#fd9174ae4ee49c0ace7265f6263d7bf24c658786",
     "nomnom": "1.8.1",
-    "typeahead.js": "git://github.com/corejavascript/typeahead.js#v0.11.1",
-    "jquery": "2.2.0",
-    "eslint": "2.1.0",
-    "eslint-config-openlayers": "4.0.0"
+    "openlayers": "git://github.com/openlayers/ol3#9baa296a49a75045e756089516f610c58cdc82eb",
+    "typeahead.js": "git://github.com/corejavascript/typeahead.js#v0.11.1"
   }
 }


### PR DESCRIPTION
- add the public key associated with the recaptcha dev secret key;
- load google javascript;
- add recaptcha directive and service;
- update auth.html to use captcha for registration.
It is possible to disable captcha for development; see corresponding
setting in API. https://github.com/c2corg/v6_api/pull/268

Related to https://github.com/c2corg/v6_api/issues/218