### PR TITLE
Default map extent is on western Europe

### DIFF
--- a/c2corg_ui/static/js/map/diffmap.js
+++ b/c2corg_ui/static/js/map/diffmap.js
@@ -73,19 +73,16 @@ app.DiffMapController = function(mapFeatureCollection) {
       new ol.layer.Tile({
         source: new ol.source.OSM()
       })
-    ]
+    ],
+    view: new ol.View({
+      center: ol.extent.getCenter(app.MapController.DEFAULT_EXTENT),
+      zoom: app.MapController.DEFAULT_ZOOM
+    })
   });
 
   var mouseWheelZoomInteraction = new ol.interaction.MouseWheelZoom();
   this.map.addInteraction(mouseWheelZoomInteraction);
   app.utils.setupSmartScroll(mouseWheelZoomInteraction);
-
-  if (!mapFeatureCollection) {
-    this.map.setView(new ol.View({
-      center: app.MapController.DEFAULT_CENTER,
-      zoom: app.MapController.DEFAULT_ZOOM
-    }));
-  }
 
   if (!goog.array.isEmpty(this.features_)) {
     // Recentering on the features extent requires that the map actually
@@ -165,11 +162,13 @@ app.DiffMapController.prototype.showFeatures_ = function(features) {
   var vectorLayer = this.getVectorLayer_();
   vectorLayer.getSource().addFeatures(features);
 
-  var mapSize = this.map.getSize() || null;
-  this.map.getView().fit(vectorLayer.getSource().getExtent(), mapSize, {
-    padding: [10, 10, 10, 10],
-    maxZoom: app.MapController.DEFAULT_POINT_ZOOM
-  });
+  var mapSize = this.map.getSize();
+  if (mapSize) {
+    this.map.getView().fit(vectorLayer.getSource().getExtent(), mapSize, {
+      padding: [10, 10, 10, 10],
+      maxZoom: app.MapController.DEFAULT_POINT_ZOOM
+    });
+  }
 };
 
 app.module.controller('AppDiffMapController', app.DiffMapController);

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -166,10 +166,15 @@ app.MapController = function($scope, mapFeatureCollection) {
       this.map.addInteraction(clickInteraction);
     }
   } else {
+    // no special feature displayed on the map => use the default extent
     this.map.setView(new ol.View({
-      center: app.MapController.DEFAULT_CENTER,
-      zoom: this.zoom_ || app.MapController.DEFAULT_ZOOM
+      center: ol.extent.getCenter(app.MapController.DEFAULT_EXTENT),
+      zoom: app.MapController.DEFAULT_ZOOM
     }));
+    this.map.once('change:size', function(event) {
+      var mapSize = this.map.getSize() || null;
+      this.map.getView().fit(app.MapController.DEFAULT_EXTENT, mapSize);
+    }.bind(this));
   }
 
   if (this.drawType) {
@@ -222,7 +227,8 @@ app.MapController = function($scope, mapFeatureCollection) {
  * @const
  * @type {Array.<number>}
  */
-app.MapController.DEFAULT_CENTER = [0, 0];
+app.MapController.DEFAULT_EXTENT = [-400000, 5200000, 1200000, 6000000];
+
 
 /**
  * @const


### PR DESCRIPTION
This PR tries to fix https://github.com/c2corg/v6_ui/issues/257
Instead of giving an initial center point to the map view (which is fairly simple), it tries to use an initial extent containing the Pyrénées and the Alps.

I had several problems and am not sure if the solutions are good:
* fitting the map view on an extent requires to get the map size. Which seems to be unavailable until the map is actually rendered => I have used the map's ``postrender`` event. This works but it seems the event is launched many times whereas I only need to set the initial extent once... What would be the best event to use?
* for some reason, Closure compiler was unhappy with the ``fit`` options argument (including for the ``diffmap`` that already used it previously) because:
```
ERR! compile /home/alex/Desktop/v6_ui/c2corg_ui/static/js/map/diffmap.js:84: ERROR - actual parameter 3 of ol.View.prototype.fit does not match formal parameter
ERR! compile found   : {
ERR! compile   constrainResolution: (boolean|undefined), 
ERR! compile   maxZoom: (number|undefined), 
ERR! compile   minResolution: (number|undefined), 
ERR! compile   nearest: (boolean|undefined), 
ERR! compile   padding: (Array<number>|undefined)
ERR! compile }
ERR! compile required: (olx.view.FitOptions|undefined)
ERR! compile     this.map.getView().fit(app.MapController.DEFAULT_EXTENT, mapSize, {
```
=> I then used a casting for this argument but is it really necessary?