### PR TITLE
Fix associated docs blocks

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -125,6 +125,15 @@
               ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           </div>
         % endfor
+        % if type == 'all_routes' and associations['all_routes']['total'] > len(routes):
+          <%
+              _query = {}
+              _query[document['type']] = document['document_id']
+          %>
+          <div class="list-item vertical-align" onclick="window.location='${request.route_url('routes_index', _query=_query)}';">
+            <button class="gray-btn btn show-more" translate>show more</button>
+          </div>
+        % endif
         <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'routes'}">
           <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
         </article>
@@ -178,7 +187,7 @@
         <div class="list-item vertical-align" protected-url-btn
              url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
           <a>
-            <button class="btn orange-btn">add a new outing to this document</button>
+            <button class="btn orange-btn" translate>add a new outing to this document</button>
           </a>
         </div>
         % for outing in associations['recent_outings']['outings']:
@@ -195,7 +204,7 @@
               _query[document['type']] = document['document_id']
           %>
           <div class="list-item vertical-align" onclick="window.location='${request.route_url('outings_index', _query=_query)}';">
-            <button class="gray-btn btn show-more">show more</button>
+            <button class="gray-btn btn show-more" translate>show more</button>
           </div>
         % endif
 

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -121,7 +121,8 @@
         % for route in routes:
           <div class="list-item">
             ${route_card(route)}
-            <app-delete-association parent-id="${document['document_id']}" child-id="${route['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+            <app-delete-association parent-id="${document['document_id']}" child-id="${route['document_id']}"
+              ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           </div>
         % endfor
         <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'routes'}">
@@ -151,7 +152,8 @@
                % endif
               >
             ${waypoint_card(waypoint)}
-            <app-delete-association parent-id="${document['document_id']}" child-id="${waypoint['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+            <app-delete-association parent-id="${document['document_id']}" child-id="${waypoint['document_id']}"
+              ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           </div>
         % endfor
         <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'waypoints'}">
@@ -173,7 +175,8 @@
         <span translate>Associated outings</span><span class="glyphicon glyphicon-menu-down"></span>
       </h3>
       <div class="associated-documents collapse in" id="associated-outings">
-        <div class="list-item vertical-align" protected-url-btn url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
+        <div class="list-item vertical-align" protected-url-btn
+             url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
           <a>
             <button class="btn orange-btn">add a new outing to this document</button>
           </a>
@@ -181,7 +184,8 @@
         % for outing in associations['recent_outings']['outings']:
         <div class="list-item outing">
           ${outing_card(outing)}
-          <app-delete-association parent-id="${document['document_id']}" child-id="${outing['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+          <app-delete-association parent-id="${document['document_id']}" child-id="${outing['document_id']}"
+            ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
         </div>
         % endfor
 

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -103,96 +103,103 @@
 </%def>
 
 
-<%def name="get_associated_documents(document, associatedDocuments)">\
-  ##ROUTES
-  % if associatedDocuments == 'routes':
-  
-    % if 'routes' in document['associations'] and  len(document['associations']['routes']) > 0 :
+<%def name="show_associated_routes(document, type='routes')">\
+  ## Possible values for type: routes, all_routes
+  <%
+      associations = document['associations']
+      routes = []
+      if type in associations:
+          routes = associations['all_routes']['routes'] if type == 'all_routes' else associations['routes']
+  %>
+  % if len(routes) > 0 :
     <article>
-      <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-${associatedDocuments}">
+      <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-routes">
         <span class="glyphicon glyphicon-map-marker"></span>
-        <span x-translate>associated ${associatedDocuments}</span><span class="glyphicon glyphicon-menu-down"></span>
+        <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
       </h3>
-      <div class="associated-documents collapse in" id="associated-${associatedDocuments}">
-        % for route in document['associations']['routes']:
+      <div class="associated-documents collapse in" id="associated-routes">
+        % for route in routes:
           <div class="list-item">
             ${route_card(route)}
             <app-delete-association parent-id="${document['document_id']}" child-id="${route['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           </div>
         % endfor
-        <article class="list-item" ng-repeat="doc in added | filter:{'documentType': '${associatedDocuments}'}">
+        <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'routes'}">
           <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
         </article>
       </div>
     </article>
-    % endif
-    
-    ##WAYPOINTS
-    % elif associatedDocuments == 'waypoints':
-    
-      % if 'waypoints' in document['associations'] and  len(document['associations']['waypoints']) > 0 :
-      <article>
-        <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-${associatedDocuments}">
-          <span class="glyphicon glyphicon-map-marker"></span>
-          <span x-translate>associated ${associatedDocuments}</span><span class="glyphicon glyphicon-menu-down"></span>
-        </h3>
-        <div class="associated-documents collapse in" id="associated-${associatedDocuments}">
-          % for waypoint in document['associations']['waypoints']:
-            <div class="list-item" 
-                 % if document.get('route_types'):
-                    ng-class="{'main-waypoint': ${document['main_waypoint_id']} === ${waypoint['document_id']} } "
-                 % endif
-                >
-              ${waypoint_card(waypoint)}
-              <app-delete-association parent-id="${document['document_id']}" child-id="${waypoint['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
-            </div>
-          % endfor
-          <article class="list-item" ng-repeat="doc in added | filter:{'documentType': '${associatedDocuments}'}">
-            <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
-          </article>
-        </div>
-      </article>
-      % endif
+  % endif
+</%def>
 
-    ##OUTINGS
-    % elif associatedDocuments == 'recent_outings':
-    
-      % if document['associations']['recent_outings']['total'] > 0 :
-        <article>
-          <h3 class="heading show-phone outings" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-${associatedDocuments}">
-            <span class="glyphicon glyphicon-map-marker"></span>
-            <span x-translate>associated ${associatedDocuments}</span><span class="glyphicon glyphicon-menu-down"></span>
-          </h3>
-          <div class="associated-documents collapse in" id="associated-${associatedDocuments}">
-            <div class="list-item vertical-align" protected-url-btn url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
-              <a>
-                <button class="btn orange-btn">add a new outing to this document</button>
-              </a>
-            </div>
-            % for outing in document['associations']['recent_outings']['outings']:
-            <div class="list-item outing">
-              ${outing_card(outing)}
-              <app-delete-association parent-id="${document['document_id']}" child-id="${outing['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
-            </div>
-            % endfor
-            
-            % if document['associations']['recent_outings']['total'] > 10 :
-              <%
-                  _query = {}
-                  _query[document['type']] = document['document_id']
-              %>
-              <div class="list-item vertical-align" onclick="window.location='${request.route_url('outings_index', _query=_query)}';">
-                <button class="gray-btn btn show-more">show more</button>
-              </div>
-            % endif
-            
-            <article class="list-item" ng-repeat="doc in added | filter:{'documentType': '${associatedDocuments}'}">
-              <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
-            </article>
+<%def name="show_associated_waypoints(document, type='waypoints')">\
+  ## Possible values for type: waypoints, waypoint_parents, waypoint_children
+  <%
+      associations = document['associations']
+  %>
+  % if type in associations and len(associations[type]) > 0 :
+    <article>
+      <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-waypoints">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <span x-translate>Associated ${type}</span><span class="glyphicon glyphicon-menu-down"></span>
+      </h3>
+      <div class="associated-documents collapse in" id="associated-waypoints">
+        % for waypoint in associations[type]:
+          <div class="list-item"
+               % if document.get('type') == 'r':
+                  ng-class="{'main-waypoint': ${document['main_waypoint_id']} === ${waypoint['document_id']} } "
+               % endif
+              >
+            ${waypoint_card(waypoint)}
+            <app-delete-association parent-id="${document['document_id']}" child-id="${waypoint['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           </div>
+        % endfor
+        <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'waypoints'}">
+          <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
         </article>
-      % endif
-    
+      </div>
+    </article>
+  % endif
+</%def>
+
+<%def name="show_associated_outings(document)">\
+  <%
+      associations = document['associations']
+  %>
+  % if 'recent_outings' in associations and associations['recent_outings']['total'] > 0:
+    <article>
+      <h3 class="heading show-phone outings" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-outings">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <span translate>Associated outings</span><span class="glyphicon glyphicon-menu-down"></span>
+      </h3>
+      <div class="associated-documents collapse in" id="associated-outings">
+        <div class="list-item vertical-align" protected-url-btn url="'${request.route_url('outings_add')}' + '?${document['doctype']}=${document['document_id']}'">
+          <a>
+            <button class="btn orange-btn">add a new outing to this document</button>
+          </a>
+        </div>
+        % for outing in associations['recent_outings']['outings']:
+        <div class="list-item outing">
+          ${outing_card(outing)}
+          <app-delete-association parent-id="${document['document_id']}" child-id="${outing['document_id']}" ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+        </div>
+        % endfor
+
+        % if associations['recent_outings']['total'] > 10 :
+          <%
+              _query = {}
+              _query[document['type']] = document['document_id']
+          %>
+          <div class="list-item vertical-align" onclick="window.location='${request.route_url('outings_index', _query=_query)}';">
+            <button class="gray-btn btn show-more">show more</button>
+          </div>
+        % endif
+
+        <article class="list-item" ng-repeat="doc in added | filter:{'documentType': 'outings'}">
+          <app-association-card parent-id="${document['document_id']}" doc="doc" added-documents="added"></app-association-card>
+        </article>
+      </div>
+    </article>
   % endif
 </%def>
 

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -5,10 +5,12 @@ from c2corg_ui.templates.utils import get_lang_lists
 
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title, show_fulldate"/>
-<%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow, get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_min_max, get_document_locale_text, show_attr, show_missing_langs_links,
-    show_other_langs_links, show_archive_data, show_route_title, get_route_activities, 
-    show_areas, show_float_buttons, get_associated_documents"/>
+<%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow,
+    get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
+<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_min_max,
+    get_document_locale_text, show_attr, show_missing_langs_links, show_other_langs_links,
+    show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
+    show_associated_waypoints, show_associated_routes"/>
     
 <%
 outing_id = outing['document_id']
@@ -132,7 +134,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   </div>
 
   ## ASSOCIATIONS
-  % if not version and ('waypoint' in outing['associations'] and  len(outing['associations']['waypoints']) > 0 or 'routes' in outing['associations'] and  len(outing['associations']['routes']) > 0):
+  % if not version:
   <div class="view-details-associations col-xs-12 tab associations">
     <span class="lead">
       <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
@@ -140,8 +142,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
         <app-add-association parent-id="${outing_id}" added-documents="added"></app-add-association>
       </div>
       <section>
-        ${get_associated_documents(outing, 'routes')}
-        ${get_associated_documents(outing, 'waypoints')}
+        ${show_associated_routes(outing)}
+        ${show_associated_waypoints(outing)}
       </section>
     </span>
   </div>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -4,9 +4,11 @@ from c2corg_ui.templates.utils import get_lang_lists
 %>
 
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text, get_document_locale_text, show_attr, show_missing_langs_links,
+<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text,
+    get_document_locale_text, show_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title,
-    get_associated_documents, show_areas, show_float_buttons, show_maps, get_route_activities" />
+    show_areas, show_float_buttons, show_maps, get_route_activities,
+    show_associated_waypoints, show_associated_routes, show_associated_outings" />
     
 <%namespace file="helpers/detailed_route_attributes.html" import="get_route_location, 
   get_route_rating, get_route_general, get_route_heights, get_route_access, get_route_associated_maps" 
@@ -147,17 +149,6 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     
   ## ASSOCIATIONS
   % if not version:
-
-    % if len(route['associations']['recent_outings']['outings']) > 0:
-      <div class="view-details-associations col-xs-12 tab associations">
-        <span class="lead">
-          <section>
-            ${get_associated_documents(route, 'recent_outings')}
-          </section>
-        </span>
-      </div>
-    % endif
-
     <div class="view-details-associations col-xs-12 tab associations">
       <span class="lead">
         <section>
@@ -168,14 +159,26 @@ other_langs, missing_langs = get_lang_lists(route, lang)
           % if len(route['associations']['recent_outings']['outings']) == 0:
             <div class="add-outing">
               <p class="text-center"><strong>no outings yet?</strong><p>
-                <button type="button" class="btn gray-btn" protected-url-btn url="'${request.route_url('outings_add')}' + '?routes=${route_id}'" translate>add a new one to this document</button>
+                <button type="button" class="btn gray-btn" protected-url-btn
+                        url="'${request.route_url('outings_add')}' + '?routes=${route_id}'"
+                        translate>add a new one to this document</button>
             </div>
           % endif
-          ${get_associated_documents(route, 'waypoints')}
-          ${get_associated_documents(route, 'routes')}
+          ${show_associated_waypoints(route)}
+          ${show_associated_routes(route)}
         </section>
       </span>
     </div>
+
+    % if len(route['associations']['recent_outings']['outings']) > 0:
+      <div class="view-details-associations col-xs-12 tab associations">
+        <span class="lead">
+          <section>
+            ${show_associated_outings(route)}
+          </section>
+        </span>
+      </div>
+    % endif
   % endif
   
   ## OTHER BUTTON contents

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -9,7 +9,6 @@
   updating_doc = waypoint_id and waypoint_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/view.html" import="get_associated_documents"/>
 
 <%block name="pagetitle">
 <title ng-init="id = ${waypoint_id if waypoint_id else 0}" ng-bind="id ?

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -5,10 +5,14 @@ from c2corg_ui.templates.utils import get_lang_lists
 
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="helpers/detailed_waypoint_attributes.html" import="get_waypoint_equipment, get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating, get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general, get_waypoint_maps_info"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text, show_attr, show_missing_langs_links,
-    show_other_langs_links, show_archive_data, show_route_title, get_associated_documents,
-    show_areas, show_maps, show_float_buttons"/>
+<%namespace file="helpers/detailed_waypoint_attributes.html" import="get_waypoint_equipment,
+    get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
+    get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
+    get_waypoint_maps_info"/>
+<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text,
+    show_attr, show_missing_langs_links, show_other_langs_links, show_archive_data, 
+    show_route_title, show_areas, show_maps, show_float_buttons,
+    show_associated_waypoints, show_associated_routes, show_associated_outings"/>
     
 <%
 waypoint_id = waypoint['document_id']
@@ -125,27 +129,27 @@ geometry4326 = geometry
     </section>
   </div>
   
-    ## DESCRIPTION
-    % if locale['summary'] or locale['description']:
-      <div class="view-details-description col-xs-12 tab description">
-        <h3 class="heading"><span translate>description</span></h3>
-        <span class="lead">
-          <div id="document-description" class="collapse in">
-            % if locale['summary']:
-              <summary class="document-summary">
-                <label translate>summary</label><br>
-                ${show_attr(locale, 'summary')}
-              </summary>
-            % endif
+  ## DESCRIPTION
+  % if locale['summary'] or locale['description']:
+    <div class="view-details-description col-xs-12 tab description">
+      <h3 class="heading"><span translate>description</span></h3>
+      <span class="lead">
+        <div id="document-description" class="collapse in">
+          % if locale['summary']:
+            <summary class="document-summary">
+              <label translate>summary</label><br>
+              ${show_attr(locale, 'summary')}
+            </summary>
+          % endif
 
-            % if locale['description'] :
-              ${show_attr(locale, 'description')}
-            % else :
-              <h3 class="text-center" translate>No description available</h3>
-            % endif
-          </div>
-        </span>
-      </div>
+          % if locale['description'] :
+            ${show_attr(locale, 'description')}
+          % else :
+            <h3 class="text-center" translate>No description available</h3>
+          % endif
+        </div>
+      </span>
+    </div>
   % endif
 
   
@@ -155,9 +159,7 @@ geometry4326 = geometry
   </div>
   
   ## ASSOCIATIONS
-  % if not version and (('waypoints' in waypoint['associations'] and \
-       len(waypoint['associations']['waypoints']) > 0) or \
-       ('routes' in waypoint['associations'] and len(waypoint['associations']['routes']) > 0)):
+  % if not version:
     <div class="view-details-associations col-xs-12 tab associations">
       <span class="lead">
       <section>
@@ -165,8 +167,9 @@ geometry4326 = geometry
           <label translate>Add association</label>:
           <app-add-association parent-id="${waypoint_id}" added-documents="added"></app-add-association>
         </div>
-        ${get_associated_documents(waypoint, 'routes')}
-        ${get_associated_documents(waypoint, 'waypoints')}
+        ${show_associated_waypoints(waypoint, 'waypoint_parents')}
+        ${show_associated_waypoints(waypoint, 'waypoint_children')}
+        ${show_associated_routes(waypoint, 'all_routes')}
       </section>
       </span>
     </div>
@@ -176,7 +179,7 @@ geometry4326 = geometry
   <div class="view-details-associations col-xs-12 tab associations">
     <span class="lead">
       <section>
-        ${get_associated_documents(waypoint, 'recent_outings')}
+        ${show_associated_outings(waypoint)}
       </section>
     </span>
   </div>


### PR DESCRIPTION
Fixes #376 
Fixes #367 

Done:
* take into account the new ``associations`` format of the API
* split the ``get_associated_documents`` mako helper into 3 helpers since it was getting a bit too big.
* some indent and too-long-lines fixing
* add a "show more" button for the list of routes cards as well (as for outings). The generated URL is currently not supported by the API, see https://github.com/c2corg/v6_api/issues/297

Questions:
* the margin below the association tool is incorrect (same with the master branch). @ginold do you know how we could fix this? I think it's ok in some other branches.
![sans titre](https://cloud.githubusercontent.com/assets/1192331/15654585/b9c9ed0e-2695-11e6-89d8-51f19187a109.png)
* not sure the ``documentType`` filtering is OK for displaying cards of the newly associated documents (but that could be done in another PR since we should work on the cards directive/partials for the association tools).
* I have noticed that the outings detail view calls the associated-documents helper for associated WP as well but it seems the API always returns an empty ``waypoints`` list in ``associations``. Either there is something missing in the API or we don't need this helper call here?