### PR TITLE
Associated images

### DIFF
--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -45,5 +45,6 @@ app.constants = {
   documentEditing: {
     FORM_PROJ: 'EPSG:4326',
     DATA_PROJ: 'EPSG:3857'
-  }
-}
+  },
+  imagesURL : 'http://s.camptocamp.org/uploads/images/'
+};

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -40,12 +40,19 @@ app.module.directive('appImageUploader', app.imageUploaderDirective);
  * @param {app.Api} appApi Api service.
  * @param {app.Alerts} appAlerts
  * @param {Object} Upload ng-file-upload Upload service.
+ * @param {app.Document} appDocument service
  * @constructor
  * @struct
  * @export
  * @ngInject
  */
-app.ImageUploaderController = function($scope, Upload, $uibModal, $compile, $q, appAlerts, appApi) {
+app.ImageUploaderController = function($scope, Upload, $uibModal, $compile, $q, appAlerts, appApi, appDocument) {
+
+  /**
+   * @type {app.Document}
+   * @export
+   */
+  this.documentService = appDocument;
 
   /**
    * @type {Object} angular bootstrap modal
@@ -241,10 +248,9 @@ app.ImageUploaderController.prototype.save = function() {
   $('.img-container').each(function(i, image) {
     meta = this.files[i]['metadata'];
     id = 'image-' + (+new Date());
-    //var source = $(image).css('background-image').substring(5, $(image).css('background-image').length - 2); // remove 'url()'
-    this.files[i]['id'] = id;
+    this.files[i]['document_id'] = id;
 
-    var element = app.utils.createImageSlide(this.files[i], 'added-' + id);
+    var element = app.utils.createImageSlide(this.files[i]);
     $('.photos').slick('slickAdd', element);
 
     var scope = this.scope_.$new(true);
@@ -258,10 +264,10 @@ app.ImageUploaderController.prototype.save = function() {
       'fnumber' : meta['FocalLength'],
       'camera_name' : meta['Make'] + ' ' + meta['Model'],
       'categories': meta['categories'],
-      'id': id
+      'document_id': id
     };
-
-    this.compile_($('#added-' + id).contents())(scope);
+    this.documentService.document.associations['images'].push(scope['photo']);
+    this.compile_($('#image-' + id).contents())(scope);
 
   }.bind(this));
   $('.modal, .modal-backdrop').remove();

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -150,15 +150,23 @@ app.utils.getImageFileBase64Source = function(file) {
 
 /**
  * @param {Object} file : image object from associations or uploaded
- * @param {string} id to the figure slide
  * @return {string}
  * @export
  */
-app.utils.createImageSlide = function(file, id) {
-  return '<figure id="' + id + '">' +
-           '<a href="' + file.src + '" data-info-id="' + file['id'] + '">' +
-             '<img src="' + file.src + '">' +
-           '</a>' +
-           '<app-slide-info></app-slide-info>' +
-         '</figure>';
+app.utils.createImageSlide = function(file) {
+  var img;
+  var ahref;
+  // if !src => it's an already existing image, else it's an image that has just been uploaded
+  if (!file['src']) {
+    ahref = '<a href="' + app.constants.imagesURL + file.filename + '" data-info-id="' + file['document_id'] + '">';
+    img = '<img src="' + app.constants.imagesURL + file.filename + '">';
+  } else {
+    ahref = '<a href="' + file['src'] + '" data-info-id="' + file['document_id'] + '">';
+    img = '<img src=" ' + file['src'] + '">';
+  }
+  return '<figure id="image-' + file['document_id'] + '">' +
+               ahref + img +
+               '</a>' +
+               '<app-slide-info></app-slide-info>' +
+             '</figure>';
 };

--- a/c2corg_ui/static/partials/slideinfo.html
+++ b/c2corg_ui/static/partials/slideinfo.html
@@ -1,7 +1,7 @@
-<div id="{{id}}" class="ng-hide"> 
+<div id="{{document_id}}" class="ng-hide"> 
   <h1 class="image-title">{{locales[0].title}}</h1> 
   <div class="image-infos"> 
-    <h1 translate>Infos</h1> 
+    <h2 translate>Infos</h2> 
     <p ng-show="date_time"><span class="glyphicon glyphicon-calendar"></span>{{date_time}}</p> 
     <p><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p> 
     <span ng-show="activities">

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -104,7 +104,7 @@
   % endif
 </%def>
 
-
+## Links generated only for the search engines, hidden.
 <%def name="add_seo_association_links(documents, doctype, hide=True)">\
   % if len(documents):
     <ul ${'class="ng-hide"' if hide else '' | n}>
@@ -562,5 +562,12 @@
         <button class="btn btn-default" type="button" ng-click="delModalCtrl.dismiss()" translate>Cancel</button>
       </p>
     </div>
+  </div>
+</%def>
+
+
+<%def name="get_image_gallery()">\
+  <div class="view-details-photos col-xs-12 tab description" ng-show="detailsCtrl.documentService.document.associations.images.length > 0">
+    <div class="photos" data-slick='{"variableWidth": true, "infinite": false, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
   </div>
 </%def>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -8,7 +8,7 @@ from json import dumps
 <%namespace file="../helpers/common.html" import="show_title, show_fulldate"/>
 <%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow,
     get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_min_max,
+<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_min_max,
     get_document_locale_text, show_attr, show_missing_langs_links, show_other_langs_links,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, delete_association_confirmation_modal"/>
@@ -85,13 +85,11 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     % endif
   </uib-tabset>
   
-    ## IMAGES
+  ## IMAGES
   % if not version:
-    <div class="view-details-photos col-xs-12 tab description">
-      <div class="photos" data-slick='{"variableWidth": true, "infinite": true, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
-    </div>
+    ${get_image_gallery()}
   % endif
-  
+
   <div class="view-details-informations col-xs-12 tab informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>

--- a/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+++ b/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -120,7 +120,8 @@
 ## HEIGHTS  
 <%def name="get_route_heights(route)">\
   % if route.get('route_length') or route.get('mtb_height_diff_portages') or route.get('height_diff_difficulties') or route.get('difficulties_height') \
-        or route.get('mtb_length_asphalt') or route.get('mtb_length_trail') or locale.get('slope'):
+        or route.get('mtb_length_asphalt') or route.get('mtb_length_trail') or locale.get('slope') or route.get('elevation_max') or route.get('elevation_min') \
+        or route.get('height_diff_max') or route.get('height_diff_min'):
     <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
       <h4><span translate>heights</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -5,7 +5,7 @@ from json import dumps
 %>
 
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
     get_document_locale_text, show_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title,
     show_areas, show_float_buttons, show_maps, get_route_activities,
@@ -101,11 +101,9 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   ## IMAGES
   % if not version:
-    <div class="view-details-photos col-xs-12 tab description">
-      <div class="photos" data-slick='{"variableWidth": true, "infinite": true, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
-    </div>
+    ${get_image_gallery()}
   % endif
-  
+
       <div class="thumbnail view-details-informations tab  col-sm-12 informations">
         <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
           <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
@@ -171,15 +169,16 @@ other_langs, missing_langs = get_lang_lists(route, lang)
         </section>
       </span>
     </div>
-
-    <div class="view-details-associations col-xs-12 tab associations"
-         ng-show="document.associations.recent_outings.outings.length > 0 || filteredAddedOutings.length > 0">
+  
+    % if 'recent_outings' in route['associations'] and route['associations']['recent_outings']['total'] > 0:
+    <div class="view-details-associations col-xs-12 tab associations">
       <span class="lead">
         <section>
           ${show_associated_outings(route)}
         </section>
       </span>
     </div>
+    % endif
   % endif
   
   ## OTHER BUTTON contents

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -10,7 +10,7 @@ from json import dumps
     get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
     get_waypoint_maps_info"/>
-<%namespace file="../helpers/view.html" import="photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
     show_attr, show_missing_langs_links, show_other_langs_links, show_archive_data, 
     show_route_title, show_areas, show_maps, show_float_buttons,
     show_associated_waypoints, show_associated_routes, show_associated_outings,
@@ -111,9 +111,7 @@ geometry4326 = geometry
 
   ## IMAGES
   % if not version:
-    <div class="view-details-photos col-xs-12 tab description">
-      <div class="photos" data-slick='{"variableWidth": true, "infinite": true, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
-    </div>
+    ${get_image_gallery()}
   % endif
   
   <div class="view-details-informations col-xs-12 tab informations">
@@ -185,7 +183,7 @@ geometry4326 = geometry
       </span>
     </div>
 
-    % if 'recent_outings' in waypoint['associations'] and waypoint['associations']['recent_outings']['total'] > 0 :
+    % if 'recent_outings' in waypoint['associations'] and waypoint['associations']['recent_outings']['total'] > 0:
       <div class="view-details-associations col-xs-12 tab associations">
         <span class="lead">
           <section>

--- a/less/images.less
+++ b/less/images.less
@@ -175,9 +175,13 @@
   img {
     width: 100%;
     transition: 0.3s;
+    
     &.showing-info {
       width: 80%;
       transition: 0.3s;
+      @media @tablet {
+        width: 70%;
+      }
       @media @phone {
         width: 100%;
       }
@@ -198,18 +202,22 @@
   .image-infos {
     width: 20%;
     right: -20%;
-    padding: 1.5% 1.5% 0 2%;
+    padding: 3.5% 1.5% 0 2%;
     color: white;
     height: 100%;
     top: 0;
     position: absolute;
     transition: 0.3s;
+    @media @tablet {
+      width: 30%;
+      right: -30%;
+    }
     &.showing-info {
       right: 0;
       transition: 0.3s;
+      background-color: #1D1D1D;
       @media @phone {
         width: 70%;
-        background-color: #1D1D1D;
         padding-left: 7%;
       }
     }


### PR DESCRIPTION
Uses the real associated images of the document.

- Images that are too small will be shown in its original size, they will not be stretched
- Fixes the problem where the last two images were repeated twice

See for example /outings/736666/fr