### PR TITLE
better edit-form checking before saving

### DIFF
--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -120,11 +120,11 @@ app.Alerts.prototype.formatErrorMsg_ = function(response) {
   if (len > 1) {
     var msg = '<ul>';
     for (var i = 0; i < len; i++) {
-      msg += '<li>' + this.filterStr_(errors[i]['description']) + '</li>';
+      msg += '<li>' + this.filterStr_(errors[i]['description']) + ' : ' + this.filterStr_(errors[i]['name']) + '</li>';
     }
     return msg + '</ul>';
   }
-  return this.filterStr_(errors[0]['description']);
+  return this.filterStr_(errors[0]['description']) + ' : ' + this.filterStr_(errors[0]['name']);
 };
 
 

--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -29,18 +29,9 @@ app.constants = {
     'webcam': 4
   },
   REQUIRED_FIELDS : {
-    waypoint: {
-      step_1 : ['title' , 'lang', 'waypoint_type'],
-      step_2 : ['longitude', 'latitude', 'elevation'],
-      step_3: [],
-      step_4: []
-    },
-    route : {
-      step_1: ['title', 'lang', 'waypoint_type'],
-      step_2: ['longitude', 'latitude', 'elevation'],
-      step_3: [],
-      step_4: []
-    }
+    waypoints: ['title' , 'lang', 'waypoint_type', 'elevation', 'longitude', 'latitude'],
+    routes : ['title' , 'lang', 'activities'],
+    outings : ['title' , 'lang', 'date_start', 'routes', 'activities']
   },
   documentEditing: {
     FORM_PROJ: 'EPSG:4326',

--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -41,7 +41,7 @@ app.Document = function(appAuthentication, $rootScope) {
       'recent_outings': {'total': 0, 'outings': []},
       'images': []
     },
-    'locales': [{'title': ''}],
+    'locales': [{'title': '', 'lang': ''}],
     'type': '',
     'document_id': 0,
     'quality': ''

--- a/c2corg_ui/static/partials/alert.html
+++ b/c2corg_ui/static/partials/alert.html
@@ -3,6 +3,7 @@
     <span aria-hidden="true">&times;</span>
     <span class="sr-only">Close</span>
   </button>
+  <h4 translate ng-show="alertCtrl.title">{{alertCtrl.title}}</h4>
   <div ng-bind-html="alertCtrl.msg | appTrustAsHtml" class="alert-text" translate></div>
 </div>
 

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -250,35 +250,36 @@
           % endif
 
           % if locale.get('conditions_levels') :
-            <table class="table table-striped conditions-levels">
-              <thead>
-                <tr>
-                  <th class="location"><span translate>location</span> / <span translate>altitude</span> / <span translate>orientation</span> / <span translate>time</span></th>
-                  <th class="soft-snow" translate>soft snow</th>
-                  <th class="total-snow" translate>total snow</th>
-                  <th class="comment" translate>comment</th>
-                </tr>
-              </thead>
-              <tbody>
-                % for condition in json.loads(locale['conditions_levels']):
-                <tr>
-                  <td>${condition['level_place']}</td>
-                  % if 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '':
-                  <td>${condition['level_snow_height_soft']} cm</td>
-                  % else:
-                  <td></td>
-                  % endif
-                  % if 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '':
-                  <td>${condition['level_snow_height_total']} cm</td>
-                  % else:
-                  <td></td>
-                  % endif
-                  <td >${condition['level_comment']}</td>
-                </tr>
-                % endfor
-              </tbody>
-            </table>
-          
+            <div class="table-responsive">
+              <table class="table table-striped conditions-levels">
+                <thead>
+                  <tr>
+                    <th class="location"><span translate>location</span> / <span translate>altitude</span> / <span translate>orientation</span> / <span translate>time</span></th>
+                    <th class="soft-snow" translate>soft snow</th>
+                    <th class="total-snow" translate>total snow</th>
+                    <th class="comment" translate>comment</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  % for condition in json.loads(locale['conditions_levels']):
+                  <tr>
+                    <td>${condition['level_place']}</td>
+                    % if 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '':
+                    <td>${condition['level_snow_height_soft']} cm</td>
+                    % else:
+                    <td></td>
+                    % endif
+                    % if 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '':
+                    <td>${condition['level_snow_height_total']} cm</td>
+                    % else:
+                    <td></td>
+                    % endif
+                    <td >${condition['level_comment']}</td>
+                  </tr>
+                  % endfor
+                </tbody>
+              </table>
+            </div>
           % endif
         </div>
       </section>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -558,9 +558,17 @@ updating_doc = outing_id and outing_lang
           </div>
         </section>
 
-        <p  class="action-buttons float-buttons">
-          <button type="submit" class="btn btn-lg orange-btn float-button" ng-disabled="editForm.$invalid || editForm.$pristine"  tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
+        <div class="action-buttons float-buttons">
+          <button type="submit" class="btn btn-lg orange-btn float-button" ng-if="!editForm.$invalid && !editCtrl.hasMissingProps(outing, false)" 
+            tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
             <span class="glyphicon glyphicon-ok"></span>
+            <p class="float-button-text" translate>Save</p>
+          </button>
+          <button type="button" class="btn btn-lg orange-btn float-button" 
+                  ng-style="(editForm.$invalid || editCtrl.hasMissingProps(outing, false)) && {'opacity': 0.5}" tooltip-placement="left" uib-tooltip="{{'What is missing?' | translate}}" 
+                  ng-if="editForm.$invalid || editCtrl.hasMissingProps(outing, false)" ng-click="editCtrl.hasMissingProps(outing, true)">
+            <span class="glyphicon glyphicon-ok"></span>
+            <p class="float-button-text" translate>What is missing?</p>
           </button>
           <%
           view_url = request.route_url('outings_view', id=outing_id, lang=outing_lang) if updating_doc else ''
@@ -568,8 +576,9 @@ updating_doc = outing_id and outing_lang
           %>
           <button type="button" class="btn btn-lg gray-btn float-button" ng-click="editCtrl.cancel('${view_url}', '${index_url}')"  tooltip-placement="left" uib-tooltip="{{'Cancel' | translate}}">
             <span class="glyphicon glyphicon-remove"></span>
+            <p class="float-button-text" translate>Cancel</p>
           </button>
-        </p>
+        </div>
         
       </div>
     </section>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -95,6 +95,9 @@ updating_doc = route_id and route_lang
             ## wr = waypoints, routes
             <app-simple-search parent-id="route.document_id"
               app-select="editCtrl.documentService.pushToAssociations(doc)" dataset="wr"></app-simple-search>
+            <h5 translate ng-show="editCtrl.documentService.document.associations.routes.length == 0 && editCtrl.documentService.document.associations.waypoints.length == 0">
+              You can add associated routes and waypoints by searching in the field.
+            </h5>
             ${show_editing_associated_waypoints('route')}
             ${show_editing_associated_routes('route')}
           </div>
@@ -150,7 +153,7 @@ updating_doc = route_id and route_lang
             <div class="form-group data half">
               
               ## ROUTE TYPES      
-              <label><span translate>route_types</span> *</label>
+              <label translate>route_types</label>
               <ul class="types">
                 <li ng-repeat="type in ${route_types}" ng-click="editCtrl.pushToArray(route, 'route_types', type, $event)">
                   <div class="checkbox"><input type="checkbox" ng-checked="route.route_types.indexOf(type) > -1"><span>{{type|| translate}}</span></div>
@@ -667,8 +670,14 @@ updating_doc = route_id and route_lang
           </div>
         </section>
 
-        <p  class="action-buttons float-buttons">
-          <button type="submit" class="btn btn-lg orange-btn float-button" ng-disabled="editForm.$invalid || editForm.$pristine"  tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
+        <div class="action-buttons float-buttons">
+          <button type="submit" class="btn btn-lg orange-btn float-button" ng-if="!editForm.$invalid && !editCtrl.hasMissingProps(route, false)" 
+                  tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
+            <span class="glyphicon glyphicon-ok"></span>
+          </button>
+          
+          <button type="button" class="btn btn-lg orange-btn float-button" ng-style="(editForm.$invalid || editCtrl.hasMissingProps(route, false)) && {'opacity': 0.5}" 
+                  tooltip-placement="left" uib-tooltip="{{'What is missing?' | translate}}" ng-if="editForm.$invalid || editCtrl.hasMissingProps(route, false)" ng-click="editCtrl.hasMissingProps(route, true)">
             <span class="glyphicon glyphicon-ok"></span>
           </button>
           <%
@@ -678,7 +687,7 @@ updating_doc = route_id and route_lang
           <button type="button" class="btn btn-lg gray-btn float-button" ng-click="editCtrl.cancel('${view_url}', '${index_url}')"  tooltip-placement="left" uib-tooltip="{{'Cancel' | translate}}">
             <span class="glyphicon glyphicon-remove"></span>
           </button>
-        </p>
+        </div>
       </div>
 
     </section>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -273,21 +273,21 @@
             </div>
 
             ## ACCESS TIME
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'" ng-class="{'has-success': waypoint.access_time}">
               <label translate>access_time</label>
               <select class="form-control" ng-model="waypoint.access_time" ng-options="time as time for time in ${access_times}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.access_time"></span>
             </div>
 
             ## RAIN PROOF
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor'" ng-class="{ 'has-error': editForm.rain_proof.$touched && editForm.rain_proof.$invalid, 'has-success': editForm.rain_proof.$valid }">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'" ng-class="{'has-success': waypoint.rain_proof}">
               <label><span translate>rain_proof</span></label>
               <select class="form-control " ng-model="waypoint.rain_proof" ng-options="type as mainCtrl.translate(type) for type in ${rain_proof_types}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.rain_proof"></span>
             </div>
 
             ## CHILDREN PROOF
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor'">
+            <div class="form-group data half" ng-if="type == 'climbing_outdoor'" ng-class="{'has-success': waypoint.children_proof}">
               <label translate>children_proof</label>
               <select ng-options="type as type for type in ${children_proof_types}" ng-model="waypoint.children_proof" class="form-control "><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.children_proof"></span>
@@ -482,7 +482,7 @@
 
             ## PARAGLIDING RATING
             <div class="form-group data half rating" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
-                 ng-class="{ 'has-error': editForm.paragliding_rating.$touched && editForm.paragliding_rating.$invalid, 'has-success': editForm.paragliding_rating.$valid }">
+                 ng-class="{'has-success': waypoint.paragliding_rating }">
               <label><span translate>paragliding_rating</span></label><br>
               <select class="form-control" ng-options="rat as rat for rat in [1, 2, 3, 4, 5]" ng-model="waypoint.paragliding_rating"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.paragliding_rating"></span>
@@ -490,7 +490,7 @@
 
             ## EXPOSITION RATING
             <div class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
-                 ng-class="{ 'has-error': editForm.exposition_rating.$touched && editForm.exposition_rating.$invalid, 'has-success': editForm.exposition_rating.$valid }">
+                 ng-class="{ 'has-success': waypoint.exposition_rating }">
               <label translate>exposition_rating</label>
               <select class="form-control " ng-model="waypoint.exposition_rating" ng-options="rat as mainCtrl.translate(rat) for rat in ${exposition_ratings}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.exposition_rating"></span>
@@ -498,7 +498,7 @@
 
             ## EQUIPMENT RATINGS
             <div class="form-group data half rating" ng-if="type == 'climbing_outdoor'"
-                 ng-class="{ 'has-error': editForm.equipment_ratings.$touched && editForm.equipment_ratings.$invalid,'has-success': editForm.equipment_ratings.$valid }">
+                 ng-class="{'has-success': waypoint.equipment_ratings }">
               <label><span translate>equipment_ratings</span></label><br>
               <ul class="types">
                 <li ng-repeat="type in ${equipment_ratings}" ng-click="editCtrl.pushToArray(waypoint, 'equipment_ratings', type, $event)">
@@ -511,7 +511,7 @@
 
             ## CLIMBING RATING MIN
             <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.climbing_rating_min.$touched && editForm.climbing_rating_min.$invalid, 'has-success': editForm.climbing_rating_min.$valid }">
+                 ng-class="{ 'has-success': waypoint.climbing_rating_min }">
               <label><span translate>climbing_rating_min</span></label><br>
               <select ng-model="waypoint.climbing_rating_min" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_min"></span>
@@ -519,7 +519,7 @@
 
             ## CLIMBING RATING MAX
             <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.climbing_rating_max.$touched && editForm.climbing_rating_max.$invalid, 'has-success': editForm.climbing_rating_max.$valid }">
+                  ng-class="{ 'has-success': waypoint.climbing_rating_max }">
               <label><span translate>climbing_rating_max</span></label><br>
               <select ng-model="waypoint.climbing_rating_max" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_max"></span>
@@ -527,7 +527,7 @@
 
             ## CLIMBING RATING MEDIAN
             <div class="form-group data half rating" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.climbing_rating_median.$touched && editForm.climbing_rating_median.$invalid, 'has-success': editForm.climbing_rating_median.$valid }">
+                 ng-class="{'has-success': waypoint.climbing_rating_median }">
               <label><span translate>climbing_rating_median</span></label><br>
               <select ng-model="waypoint.climbing_rating_median" ng-options="rat as rat for rat in ${climbing_ratings}" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.climbing_rating_median"></span>
@@ -705,10 +705,14 @@
           <h2 class="heading show-phone" translate>associations</h2>
           <div class="content">
             ## w = waypoints
-            <app-simple-search parent-id="waypoint.document_id"
-              app-select="editCtrl.documentService.pushToAssociations(doc, 'waypoint_children')" dataset="w"></app-simple-search>
+            <app-simple-search parent-id="waypoint.document_id" app-select="editCtrl.documentService.pushToAssociations(doc, 'waypoint_children')" dataset="w">
+            </app-simple-search>
+            <h5 translate ng-show="editCtrl.documentService.document.associations.waypoint_children.length == 0">
+              You can add associated waypoints by searching in the field.
+            </h5>
             ${show_editing_associated_waypoints('waypoint', type='waypoint_children')}
           </div>
+          
         </section>
         
         <section class="section">
@@ -780,7 +784,13 @@
         </section>
         
         <p class="action-buttons float-buttons">
-          <button type="submit" class="btn orange-btn btn-lg float-button" ng-disabled="editForm.$invalid || editForm.$pristine" tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
+          <button type="submit" class="btn orange-btn btn-lg float-button" 
+            ng-if="!editForm.$invalid && !editCtrl.hasMissingProps(waypoint, false)" tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
+            <span class="glyphicon glyphicon-ok"></span>
+          </button>
+          <button type="button" class="btn btn-lg orange-btn float-button" 
+                  ng-style="(editForm.$invalid || editCtrl.hasMissingProps(waypoint, false)) && {'opacity': 0.5}" tooltip-placement="left" uib-tooltip="{{'What is missing?' | translate}}" 
+                  ng-if="editForm.$invalid || editCtrl.hasMissingProps(waypoint, false)" ng-click="editCtrl.hasMissingProps(waypoint, true)">
             <span class="glyphicon glyphicon-ok"></span>
           </button>
           <%

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -778,19 +778,33 @@ app-simple-search {
   }
 }
 
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
 app-alerts {
-  position: absolute;
-  bottom: 10px;
   position: fixed;
   top: 30vh;
+  left: 45vw;
   z-index: 20;
   .flex();
-  height: 0;
-  width: 100%;
   justify-content: center;
+  flex-direction: column;
+  @media @phone {
+    left: 5vw;
+    width: 90%;
+  }
   
+  ul {
+    list-style: none;
+  }
   app-alert {
-    width: 40%;
+    -webkit-animation: fadein .3s;
+    -moz-animation: fadein .3s;
+    -ms-animation: fadein .3s;
+    -o-animation: fadein .3s;
+    animation: fadein .3s;
     text-align: center;
   }
   .alert {

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -480,10 +480,14 @@
 
 .action-buttons {
   margin-top: 100px;
+  button {
+    padding: 0;
+  }
   .glyphicon-ok {
     color: white !important;
   }
 }
+
 #title-group {
   flex-basis: 75%;
   margin-bottom: 10px;
@@ -517,6 +521,9 @@
   @media @phone {
     float: none;
     width: 18%;
+    &:last-of-type {
+      margin-bottom: 5%;
+    }
   }
 }
 .bullet-container {


### PR DESCRIPTION
- save button will always be available if all default required fields are set
- if not, it will look like 'disabled' but clicking on it will list all remaining missing fields (without unnecessary sending the object to the API)
- added 'table-responsive' to conditions_levels table so it is better rendered on mobile.

Related to #410
Related partly to #414 (conditions levels)
Related partly to #412 (impossible to save the document)