### PR TITLE
make manual date writing impossible

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -162,11 +162,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -243,6 +243,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -584,6 +588,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -160,11 +160,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -239,6 +239,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -567,6 +571,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -161,11 +161,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -240,6 +240,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -568,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -161,11 +161,11 @@ msgid "Describe here the waypoint"
 msgstr "Describe here the waypoint"
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -240,6 +240,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -568,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -161,11 +161,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -240,6 +240,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -568,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -160,11 +160,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -239,6 +239,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -567,6 +571,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -158,12 +158,12 @@ msgid "Describe here the waypoint"
 msgstr "Décrivez ici l'itinéraire"
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
-msgstr "Le document a été déverrouillé."
-
-#: c2corg_ui/templates/i18n.html
 msgid "Document has been protected"
 msgstr "Le document a été verrouillé."
+
+#: c2corg_ui/templates/i18n.html
+msgid "Document has been unprotected"
+msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "Drop images here or click to upload"
@@ -238,6 +238,10 @@ msgstr "Filtres"
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
 msgstr "Mot de passe oublié?"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
+msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "Forum"
@@ -570,6 +574,14 @@ msgstr "Vous consultez une ancienne version de ce document."
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr "Vous n'avez pas les droits pour éditer ce document."
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
+msgstr "Vous devez être loggué pour éditer ce document."
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1282,7 +1294,7 @@ msgstr "Remontées mécaniques"
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "lift_status"
-msgstr ""
+msgstr "Remontées mécaniques"
 
 #: c2corg_ui/templates/i18n.html
 msgid "local_product"
@@ -1294,7 +1306,7 @@ msgstr "Lieu-dit"
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "location"
-msgstr ""
+msgstr "Situation"
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "longitude"
@@ -1417,7 +1429,7 @@ msgstr "novembre"
 
 #: c2corg_ui/templates/route/edit.html
 msgid "numbers"
-msgstr ""
+msgstr "Nombres"
 
 #: c2corg_ui/templates/i18n.html
 msgid "oct"
@@ -1604,7 +1616,7 @@ msgstr "aller-retour"
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "review"
-msgstr ""
+msgstr "Revue"
 
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
@@ -1673,7 +1685,7 @@ msgstr "Quantité des itinéraires"
 
 #: c2corg_ui/templates/outing/edit.html
 msgid "routes_taken"
-msgstr ""
+msgstr "Itinéraires empruntés"
 
 #: c2corg_ui/templates/i18n.html
 msgid "see more results"
@@ -1785,7 +1797,7 @@ msgstr "Conditions d'utilisation"
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "time"
-msgstr ""
+msgstr "Temps"
 
 #: c2corg_ui/templates/outing/edit.html
 msgid "timing"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -161,11 +161,11 @@ msgid "Describe here the waypoint"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been deprotected"
+msgid "Document has been protected"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
-msgid "Document has been protected"
+msgid "Document has been unprotected"
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
@@ -240,6 +240,10 @@ msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "Forgot password?"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Form is not valid"
 msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
@@ -568,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You have no rights to edit this document."
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "You must log in to edit this document."
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -263,12 +263,12 @@
                 % for condition in json.loads(locale['conditions_levels']):
                 <tr>
                   <td>${condition['level_place']}</td>
-                  % if condition['level_snow_height_soft'] != '':
+                  % if 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '':
                   <td>${condition['level_snow_height_soft']} cm</td>
                   % else:
                   <td></td>
                   % endif
-                  % if condition['level_snow_height_total'] != '':
+                  % if 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '':
                   <td>${condition['level_snow_height_total']} cm</td>
                   % else:
                   <td></td>

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -76,7 +76,7 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <!-- history and diff -->
 <span translate>imported from v4</span>
 <span translate>Document has been protected</span>
-<span translate>Document has been deprotected</span>
+<span translate>Document has been unprotected</span>
 <span translate>Edit in fr</span>
 <span translate>Edit in de</span>
 <span translate>Edit in it</span>
@@ -130,3 +130,8 @@ See https://github.com/c2corg/v6_common/blob/master/c2corg_common/attributes.py
 <span translate>boat</span>
 
 <span translate>see more results</span>
+
+<!--errors from js files -->
+<span translate>You have no rights to edit this document.</span>
+<span translate>Form is not valid</span>
+<span translate>You must log in to edit this document.</span>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -194,10 +194,11 @@ updating_doc = outing_id and outing_lang
           <div class="content outing-weather" id="title-edit">
            
             ## DATE START
-            <div class="data half remain form-group" ng-init="openDateStart = false">
+            <div class="data half form-group" ng-init="openDateStart = false">
               <label><span translate>date_start</span> *</label>
-              <div class="input-group" ng-model="outing.date_start" uib-datepicker-popup="dd MM yyyy" is-open="openDateStart">
-                <input type="text" class="form-control" value="{{outing.date_start | amDateFormat:'Do MMMM YYYY' }}"/>
+              <div class="input-group" ng-model="outing.date_start" datepicker-options="{maxDate : editCtrl.dateMaxStart}" 
+                   uib-datepicker-popup="dd MM yyyy" is-open="openDateStart" ng-change="editCtrl.dateMinEnd = outing.date_start">
+                <input type="text" disabled class="form-control" value="{{outing.date_start | amDateFormat:'Do MMMM YYYY' }}" required/>
                 <span class="input-group-btn">
                   <button type="button" class="btn btn-default" ng-click="openDateStart = true"><span class="glyphicon glyphicon-calendar"></span></button>
                 </span>
@@ -205,16 +206,17 @@ updating_doc = outing_id and outing_lang
             </div>
               
             ## DATE END
-            <div class="data half remain form-group baseline-align" ng-init="openDateEnd = false">
+            <div class="data half form-group baseline-align" ng-init="openDateEnd = false">
               <div  ng-show="editCtrl.differentDates">
                 <label><span translate>date_end </span></label>               
-                <div class="input-group" ng-model="outing.date_end" uib-datepicker-popup="dd MM yyyy" is-open="openDateEnd">
-                  <input type="text" class="form-control" value="{{outing.date_end | amDateFormat:'Do MMMM YYYY' }}"/>
+                <div class="input-group" ng-model="outing.date_end" datepicker-options="{maxDate : editCtrl.dateMaxEnd, minDate: editCtrl.dateMinEnd}" 
+                     uib-datepicker-popup="dd MM yyyy" is-open="openDateEnd" ng-change="editCtrl.dateMaxStart = outing.date_end">
+                  <input disabled type="text" class="form-control" value="{{outing.date_end | amDateFormat:'Do MMMM YYYY' }}"/>
                   <span class="input-group-btn">
                     <button type="button" class="btn btn-default" ng-click="openDateEnd = true"><span class="glyphicon glyphicon-calendar"></span></button>
                   </span>
                 </div>
-                <span class="glyphicon glyphicon-remove form-control-feedback"  ng-click="editCtrl.differentDates = false"></span>
+                <span class="glyphicon glyphicon-remove form-control-feedback"  ng-click="editCtrl.differentDates = false; outing.date_end = undefined; editCtrl.dateMaxStart = editCtrl.today;"></span>
               </div>
               <div ng-click="editCtrl.differentDates = true" ng-show="!editCtrl.differentDates" class="baseline-align">
                 <button class="btn orange-btn" type="button">several days?</button>
@@ -482,7 +484,7 @@ updating_doc = outing_id and outing_lang
                 <section class="associated-section">
                   <article class="associated-documents">
                     <h5 translate ng-show="outing.associations.users.length == 0">you can look up for users that were with you during the outing.</h5>
-                    <div class="list-item outing user-id-{{user.document_id}}" ng-repeat="user in outing.associations.users">
+                    <div class="list-item outings user-id-{{user.document_id}}" ng-repeat="user in outing.associations.users">
                       <a>
                         <div class="outing-author text-center">
                           <span class="icon-user"></span><br>
@@ -491,7 +493,7 @@ updating_doc = outing_id and outing_lang
                           <span class="list-item-title outing">{{user.username}}</span>
                         </div>
                       </a>
-                      <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(user.document_id, 'users')"></span>
+                      <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(user.document_id, 'users', $event)"></span>
                     </div>
                   </article>
                 </section>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -790,10 +790,11 @@ app-alerts {
   justify-content: center;
   
   app-alert {
-    width: 33%;
+    width: 40%;
     text-align: center;
   }
   .alert {
+    display: block !important;
     font-size: 1.2em;
     border: 1px solid #ccc !important;
   }

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -322,7 +322,7 @@
     left: -o-calc(~"100% + 5px");
     left: calc(~"100% + 5px");
     width: 14px;
-    height: 20px;
+    height: 0;
     z-index: 0 !important;
     pointer-events: all;
     


### PR DESCRIPTION
- inputs where the date appear are disabled and can be changed only with the calendar button.
- don't let selecting end_date before start_date
- don't let selecting start_date after end_date
- don't let selecting a date posterior to today
- minor fix for conditions_levels

Related to #404 (conditions_levels)
Related to #429
Related to #401 
Related to #406