### PR TITLE
Clean up externs files

### DIFF
--- a/build.json
+++ b/build.json
@@ -16,6 +16,10 @@
       "c2corg_ui/externs/slick.js",
       "c2corg_ui/externs/photoswipe.js",
       "c2corg_ui/externs/loadImage.js",
+      "c2corg_ui/externs/ui-bootstrap.js",
+      "c2corg_ui/externs/angular-1.5.js",
+      "c2corg_ui/externs/angular-1.5-q_templated.js",
+      "c2corg_ui/externs/angular-1.5-http-promise_templated.js",
       "node_modules/openlayers/externs/bingmaps.js",
       "node_modules/openlayers/externs/closure-compiler.js",
       "node_modules/openlayers/externs/esrijson.js",
@@ -27,10 +31,7 @@
       "node_modules/ngeo/externs/angular-gettext.js",
       "node_modules/ngeo/externs/closure-compiler.js",
       "node_modules/ngeo/externs/twbootstrap.js",
-      "node_modules/ngeo/externs/typeahead.js",
-      "c2corg_ui/externs/angular-1.5.js",
-      "c2corg_ui/externs/angular-1.5-q_templated.js",
-      "c2corg_ui/externs/angular-1.5-http-promise_templated.js"
+      "node_modules/ngeo/externs/typeahead.js"
     ],
     "define": [
       "goog.array.ASSUME_NATIVE_FUNCTIONS=true",

--- a/c2corg_ui/externs/angular-moment.js
+++ b/c2corg_ui/externs/angular-moment.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Externs for bootstrap-slider
+ * @fileoverview Externs for angular-moment
  *
  * @externs
  */

--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -69,16 +69,6 @@ appx.AlertMessage;
 
 /**
  * @typedef {{
- *  min: number,
- *  max: number,
- *  value: Array.<number>
- * }}
- */
-appx.BootstrapSliderValues;
-
-
-/**
- * @typedef {{
  *   email: string
  * }}
  */

--- a/c2corg_ui/externs/bootstrap-slider.js
+++ b/c2corg_ui/externs/bootstrap-slider.js
@@ -6,14 +6,17 @@
 
 
 /**
- * @constructor
+ * @typedef {{
+ *  min: number,
+ *  max: number,
+ *  value: Array.<number>
+ * }}
  */
-function Slider(arg1, arg2) {};
+var bootstrapSliderParameters;
 
 
 /**
- * @param {appx.BootstrapSliderValues} arg
+ * @param {bootstrapSliderParameters} arg
  * @return {!jQuery}
  */
 $.prototype.slider = function(arg) {};
-

--- a/c2corg_ui/externs/loadImage.js
+++ b/c2corg_ui/externs/loadImage.js
@@ -6,22 +6,38 @@
 
 
 /**
+ * @const
+ */
+var loadImage = {};
+
+
+/**
+ * @param {File|Blob} file
+ * @param {function(loadImageMetaData)} callback
+ * @param {Object=} opt_options
+ */
+loadImage.parseMetaData = function(file, callback, opt_options) {};
+
+
+/**
  * @constructor
  */
-function loadImage(file, callback, options) {};
+var loadImageMetaData = function() {};
 
 
 /**
- * @param {Object} file
- * @param {Object} callback
- * @param {Object} options
+ * @type {loadImageExif}
  */
-window.prototype.loadImage = function(file, callback, options) {};
+loadImageMetaData.prototype.exif;
 
 
 /**
- * @param {Object} file
- * @param {Object} callback
- * @param {Object} options
+ * @constructor
  */
-window.prototype.loadImage.parseMetaData = function(file, callback, options) {};
+var loadImageExif = function() {};
+
+
+/**
+ * @return Object
+ */
+loadImageExif.prototype.getAll = function() {};

--- a/c2corg_ui/externs/ui-bootstrap.js
+++ b/c2corg_ui/externs/ui-bootstrap.js
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for ui-bootstrap.
+ *
+ * API Reference: http://angular-ui.github.io/bootstrap/
+ *
+ * @externs
+ */
+
+
+/**
+ * Suppresses the compiler warning when multiple externs files declare the
+ * ui namespace.
+ * @suppress {duplicate}
+ * @noalias
+ */
+var ui = {};
+
+
+/**
+ * @const
+ */
+ui.bootstrap = {};
+
+/******************************************************************************
+ * $transition Service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {function(!angular.JQLite, !(string|Object|Function),
+ *     Object=):!angular.$q.Promise
+ *     }
+ */
+ui.bootstrap.$transition;
+
+
+/**
+ * Augment the ui.bootstrap.$transition type definition by reopening the type
+ * via an artificial ui.bootstrap.$transition instance.
+ *
+ * This allows us to define methods on function objects which is something
+ * that can't be expressed via typical type annotations.
+ *
+ * @type {ui.bootstrap.$transition}
+ */
+ui.bootstrap.$transition_;
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.$transition_.animationEndEventName;
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.$transition_.transitionEndEventName;
+
+/******************************************************************************
+ * $modal service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   close: function(*=),
+ *   dismiss: function(*=),
+ *   opened: !angular.$q.Promise,
+ *   result: !angular.$q.Promise
+ * }}
+ */
+ui.bootstrap.modalInstance;
+
+
+/**
+ * @param {*=} opt_result
+ */
+ui.bootstrap.modalInstance.close = function(opt_result) {};
+
+
+/**
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.modalInstance.dismiss = function(opt_reason) {};
+
+
+/**
+ * @type {!angular.$q.Promise}
+ */
+ui.bootstrap.modalInstance.opened;
+
+
+/**
+ * @type {!angular.$q.Promise}
+ */
+ui.bootstrap.modalInstance.result;
+
+
+/**
+ * @typedef {{
+ *   open: function(!Object)
+ * }}
+ */
+ui.bootstrap.$modal;
+
+
+/**
+ * @param {!Object} modalOptions
+ * @return {!ui.bootstrap.modalInstance}
+ */
+ui.bootstrap.$modal.open = function(modalOptions) {};
+
+/******************************************************************************
+ * $modalStack service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   open: function(!Object, !Object),
+ *   close: function(!Object, *=),
+ *   dismiss: function(!Object, *=),
+ *   dismissAll: function(*=),
+ *   getTop: function()
+ * }}
+ */
+ui.bootstrap.$modalStack;
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {!Object} modal
+ */
+ui.bootstrap.$modalStack.open = function(modalInstance, modal) {};
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {*=} opt_result
+ */
+ui.bootstrap.$modalStack.close = function(modalInstance, opt_result) {};
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.$modalStack.dismiss = function(modalInstance, opt_reason) {};
+
+
+/**
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.$modalStack.dismissAll = function(opt_reason) {};
+
+
+/**
+ * @return {!ui.bootstrap.modalInstance}
+ */
+ui.bootstrap.$modalStack.getTop = function() {};
+
+
+
+/******************************************************************************
+ * $position service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   position: function(!angular.JQLite),
+ *   offset: function(!angular.JQLite),
+ *   positionElements: function(!angular.JQLite, !angular.JQLite, string,
+ *     (boolean|undefined))
+ *   }}
+ */
+ui.bootstrap.$position;
+
+
+/**
+ * @param {!angular.JQLite} element
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.position = function(element) {};
+
+
+/**
+ * @param {!angular.JQLite} element
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.offset = function(element) {};
+
+
+/**
+ * @param {!angular.JQLite} hostEl
+ * @param {!angular.JQLite} targetEl
+ * @param {string} positionStr
+ * @param {boolean=} opt_appendToBody
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.positionElements = function(hostEl, targetEl,
+    positionStr, opt_appendToBody) {};
+
+
+/******************************************************************************
+ * Tooltip
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   compile: (function(!angular.JQLite=, !angular.Attributes=)|undefined),
+ *   restrict: (string|undefined)
+ *   }}
+ */
+ui.bootstrap.Tooltip;
+
+
+/**
+ * @param {!angular.JQLite=} opt_element
+ * @param {!angular.Attributes=} opt_attrs
+ */
+ui.bootstrap.Tooltip.compile = function(opt_element, opt_attrs) {};
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.Tooltip.restrict;
+
+/******************************************************************************
+ * $tooltip service
+ *****************************************************************************/
+
+
+/**
+ * @param {string} type
+ * @param {string} prefix
+ * @param {string} defaultTriggerShow
+ * @return {!ui.bootstrap.Tooltip}
+ */
+ui.bootstrap.$tooltip = function(type, prefix, defaultTriggerShow) {};
+
+/******************************************************************************
+ * $tooltipProvider service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   options: function(!Object.<string,(boolean|number|string)>=),
+ *   setTriggers: function(!Object.<string,string>)
+ *   }}
+ */
+ui.bootstrap.$tooltipProvider;
+
+
+/**
+ * @param {!Object.<string,(boolean|number|string)>=} opt_options
+ */
+ui.bootstrap.$tooltipProvider.options = function(opt_options) {};
+
+
+/**
+ * @param {!Object.<string, string>} triggers
+ */
+ui.bootstrap.$tooltipProvider.setTriggers = function(triggers) {};

--- a/c2corg_ui/static/js/deleteassociation.js
+++ b/c2corg_ui/static/js/deleteassociation.js
@@ -41,7 +41,7 @@ app.module.directive('appDeleteAssociation', app.deleteAssociationDirective);
  * @param {angular.Scope} $rootScope
  * @param {!angular.Scope} $scope Scope.
  * @param {angular.$compile} $compile Angular compile service.
- * @param {Object} $uibModal modal from angular bootstrap
+ * @param {ui.bootstrap.$modal} $uibModal modal from angular bootstrap
  * @param {app.Api} appApi The API service
  * @param {app.Document} appDocument service
  * @ngInject
@@ -63,7 +63,7 @@ app.DeleteAssociationController = function($rootScope, $scope, $compile,
   this.scope_ = $scope;
 
   /**
-   * @type {Object} angular bootstrap modal
+   * @type {ui.bootstrap.$modal} angular bootstrap modal
    * @private
    */
   this.modal_ = $uibModal;
@@ -107,6 +107,7 @@ app.DeleteAssociationController = function($rootScope, $scope, $compile,
 
 
 /**
+ * @return {ui.bootstrap.modalInstance}
  * @private
  */
 app.DeleteAssociationController.prototype.openModal_ = function() {

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -183,7 +183,6 @@ app.ImageUploaderModalController.prototype.close = function() {
 app.ImageUploaderController.prototype.upload_ = function() {
   this.areAllUploaded = false;
   var file;
-  var promise;
 
   var interval = setInterval(function() {
     this.scope_.$apply();
@@ -204,8 +203,8 @@ app.ImageUploaderController.prototype.upload_ = function() {
       });
 
       this.getImageMetadata_(file);
-      promise = this.uploading[i] = this.api_.uploadImage(file);
-      this.promises.push(promise);
+      this.uploading[i] = this.api_.uploadImage(file);
+      this.promises.push(this.uploading[i]);
 
       this.uploading[i].then(function(resp) {
         console.log('100% uploaded! ' + file['metadata']['title'] + ' ' + i);
@@ -300,13 +299,13 @@ app.ImageUploaderController.prototype.deleteImage = function(index) {
 
 
 /**
- * @property {Object} file image
+ * @property {File} file image
  * @suppress {missingProperties}
  * @private
  */
 app.ImageUploaderController.prototype.getImageMetadata_ = function(file) {
   window.loadImage.parseMetaData(file, function(data) {
-    var exif = data['exif'];
+    var exif = data.exif;
     if (exif) {
       angular.extend(file['metadata'], exif.getAll());
       return;


### PR DESCRIPTION
Currently there are several places where external libraries are used without providing an externs file (e.g. [here](https://github.com/c2corg/v6_ui/blob/1a7fafe/c2corg_ui/static/js/deleteassociation.js#L114) or [here](https://github.com/c2corg/v6_ui/blob/32f052b04b7246cffd5577ea8cbfdf1c4237e1da/c2corg_ui/static/js/imageuploader.js#L311)).

When calling a method of an external library or when referencing a property using the *dot-syntax* (e.g. `foo.bar()` or `foo.bar`), the Closure Compiler will rename these methods or properties if no externs file is provided. It is only by chance that the methods are not renamed in the two cases linked above (there are methods in other externs that by accident have the same names).

So, when using an external library, you can either use the *string-syntax* (e.g. `foo['bar']()`, see also [Inconsistent Property Names](https://developers.google.com/closure/compiler/docs/api-tutorial3#propnames)) or use a basic externs file. Before writing your own externs file, do a quick search if no-one wrote one before (for example there was already one for angular-bootstrap-ui). And if you have to write your own, you only need to include the methods that you are actually using.