### PR TITLE
Move the outing-specific editing to a dedicated controller

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -117,15 +117,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -381,7 +381,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -575,6 +575,12 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -584,6 +590,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -115,15 +115,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -373,7 +373,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -558,6 +558,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Benvingut/da a Camptocamp.org!"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -567,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -116,15 +116,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -559,6 +559,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Willkommen bei Camptocamp.org"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -568,6 +573,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -116,15 +116,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -559,6 +559,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Welcome to Camptocamp.org"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -568,6 +573,14 @@ msgstr "Yes"
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -116,15 +116,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -559,6 +559,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "¡Bienvenido/a a Camptocamp.org!"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -568,6 +573,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -115,15 +115,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -373,7 +373,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -558,6 +558,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Ongi etorri Camptocamp.org-era!"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -567,6 +572,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -113,15 +113,15 @@ msgstr "Comparaison des documents"
 msgid "Contact"
 msgstr "Contact"
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr "Créer une sortie"
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr "Créer un itinéraire"
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr "Créer un point de passage"
 
@@ -371,7 +371,7 @@ msgstr "Pas de description disponible"
 msgid "No maps associated"
 msgstr "Aucune carte associée"
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -560,6 +560,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Bienvenue sur Camptocamp.org"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -570,6 +575,14 @@ msgstr "Oui"
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
 msgstr "Vous consultez une ancienne version de ce document."
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
+msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html
 msgid "You can add geolocation info by typing in the input field."

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -116,15 +116,15 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new outing"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new route"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "Create a new waypoint"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "No maps associated"
 msgstr ""
 
-#: c2corg_ui/static/partials/suggestion_empty.html
+#: c2corg_ui/static/partials/suggestions/empty.html
 msgid "No results"
 msgstr ""
 
@@ -559,6 +559,11 @@ msgstr ""
 msgid "Welcome to Camptocamp.org"
 msgstr "Benvenuti a Camptocamp.org"
 
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "What is missing?"
+msgstr ""
+
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
@@ -568,6 +573,14 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "You are viewing an archived version of this document."
+msgstr ""
+
+#: c2corg_ui/templates/route/edit.html
+msgid "You can add associated routes and waypoints by searching in the field."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "You can add associated waypoints by searching in the field."
 msgstr ""
 
 #: c2corg_ui/static/partials/imageuploader.html

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -9,6 +9,7 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.AccountController');
+goog.require('app.OutingEditingController');
 goog.require('app.addAssociationDirective');
 goog.require('app.advancedSearchDirective');
 goog.require('app.alertsDirective');

--- a/c2corg_ui/static/js/outingediting.js
+++ b/c2corg_ui/static/js/outingediting.js
@@ -1,0 +1,178 @@
+goog.provide('app.OutingEditingController');
+
+goog.require('app');
+goog.require('app.DocumentEditingController');
+goog.require('app.Alerts');
+goog.require('app.Document');
+goog.require('app.utils');
+
+
+/**
+ * @param {angular.Scope} $scope Scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.Attributes} $attrs Attributes.
+ * @param {app.Authentication} appAuthentication
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {app.Alerts} appAlerts
+ * @param {app.Api} appApi Api service.
+ * @param {string} authUrl Base URL of the authentication page.
+ * @param {app.Document} appDocument
+ * @constructor
+ * @extends {app.DocumentEditingController}
+ * @ngInject
+ * @export
+ */
+app.OutingEditingController = function($scope, $element, $attrs,
+    appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
+    appDocument) {
+
+  goog.base(this, $scope, $element, $attrs, appAuthentication,
+    ngeoLocation, appAlerts, appApi, authUrl, appDocument);
+
+  /**
+   * Start cannot be after today nor end_date.
+   * @type {Date}
+   * @export
+   */
+  this.dateMaxStart = new Date();
+
+  /**
+   * @type {Date}
+   * @export
+   */
+  this.today = new Date();
+
+  /**
+   * The end date cannot be before start nor today.
+   * @type {Date}
+   * @export
+   */
+  this.dateMaxEnd = new Date();
+
+  /**
+   * The end date cannot be before start.
+   * @type {Date}
+   * @export
+   */
+  this.dateMinEnd;
+
+  /**
+   * @type {?boolean}
+   * @export
+   */
+  this.differentDates;
+
+  // allow association only for a new outing to existing route
+  if (ngeoLocation.hasParam('r')) {
+    var urlParam = {'routes': ngeoLocation.getParam('r')};
+    appApi.getDocumentByIdAndDoctype(urlParam['routes'], 'r').then(function(doc) {
+      this.documentService.pushToAssociations(doc.data['routes'].documents[0], 'routes', true);
+    }.bind(this));
+  }
+
+  if (this.auth.isAuthenticated()) {
+    this.scope[this.modelName]['associations']['users'].push({
+      'id' : this.auth.userData.id,
+      'document_id': this.auth.userData.id,
+      'username': this.auth.userData.username
+    });
+    this.formatOuting_(this.scope[this.modelName]);
+  }
+};
+goog.inherits(app.OutingEditingController, app.DocumentEditingController);
+
+
+/**
+ * @param {Object} response Response from the API server.
+ * @override
+ * @public
+ */
+app.OutingEditingController.prototype.successRead = function(response) {
+  goog.base(this, 'successRead', response);
+
+  var outing = this.scope[this.modelName];
+  // check if user has right to edit -> the user is one of the associated users
+  if (this.auth.hasEditRights(outing['associations']['users'])) {
+    outing = this.formatOuting_(outing);
+    this.differentDates = app.utils.areDifferentDates(outing['date_start'], outing['date_end']);
+    if (!this.differentDates) {
+      outing['date_end'] = undefined;
+    }
+  } else {
+    this.alerts.addError('You have no rights to edit this document.');
+    setTimeout(function() { // redirect to the details-view page
+      window.location = window.location.href.replace('/edit', '');
+    }, 3000);
+  }
+};
+
+
+/**
+ * @param {appx.Document} data Document attributes.
+ * @return {appx.Document}
+ * @override
+ * @public
+ */
+app.OutingEditingController.prototype.prepareData = function(data) {
+  // adapt the Object for what's expected on the API side + format the outing
+  this.formatOuting_(/** @type appx.Outing */ (data));
+  return data;
+};
+
+
+/**
+ * @param {Object} outing
+ * better edit-form checking before saving
+ * @private
+ */
+app.DocumentEditingController.prototype.formatOuting_ = function(outing) {
+  if (this.submit) {
+    // transform condition_levels to a string
+    if (typeof outing.locales[0]['conditions_levels'] !== 'string') {
+      outing.locales[0]['conditions_levels'] = JSON.stringify(outing['locales'][0]['conditions_levels']);
+    }
+    // if no date end -> make it the same as date start
+    if (!outing.date_end && outing.date_start instanceof Date) {
+      outing.date_start.setHours(outing.date_start.getHours() + 2);
+      outing.date_end = outing.date_start;
+    }
+
+    var associations = outing.associations;
+    for (var i = 0; i < associations['users'].length; i++) {
+      associations['users'][i]['id'] = associations['users'][i]['document_id'] || associations['users'][i]['id'];
+      delete associations['users'][i]['document_id'];
+    }
+  }
+  // convert existing date from string to a date object
+  if (outing.date_end && typeof outing.date_end === 'string') {
+    outing.date_end = app.utils.formatDate(outing.date_end);
+    this.dateMaxStart = outing.date_end;
+  }
+
+  if (outing.date_start && typeof outing.date_start === 'string') {
+    outing.date_start = app.utils.formatDate(outing.date_start);
+    this.dateMinEnd = outing.date_start;
+  }
+
+  var conditions = outing.locales[0]['conditions_levels'];
+  // conditions_levels -> to Object, snow_height -> to INT
+  if (conditions && typeof conditions === 'string') {
+    conditions = JSON.parse(conditions);
+    this.scope[this.modelName]['locales'][0]['conditions_levels'] = conditions;
+  } else {
+    if (!this.submit) {
+      // init empty conditions_levels for ng-repeat
+      outing['locales'][0]['conditions_levels'] = [{
+        'level_snow_height_soft': '',
+        'level_snow_height_total': '',
+        'level_comment': '',
+        'level_place': ''
+      }];
+    }
+  }
+  this.submit = false;
+  return outing;
+};
+
+
+app.module.controller('appOutingEditingController', app.OutingEditingController);

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -126,11 +126,13 @@ app.utils.formatDate = function(date) {
  * @export
  * @param {Date} date1
  * @param {Date} date2
+ * @return {?boolean}
  */
 app.utils.areDifferentDates = function(date1, date2) {
   if (date1 !== null && date2 !== null) {
     return date1.toDateString() !== date2.toDateString();
   }
+  return null;
 };
 
 

--- a/c2corg_ui/static/partials/alert.html
+++ b/c2corg_ui/static/partials/alert.html
@@ -3,7 +3,7 @@
     <span aria-hidden="true">&times;</span>
     <span class="sr-only">Close</span>
   </button>
-  <h4 translate ng-show="alertCtrl.title">{{alertCtrl.title}}</h4>
+  <h4 x-translate ng-show="alertCtrl.title">{{alertCtrl.title}}</h4>
   <div ng-bind-html="alertCtrl.msg | appTrustAsHtml" class="alert-text" translate></div>
 </div>
 

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -21,6 +21,7 @@ updating_doc = outing_id and outing_lang
       class="text-center"></h1>
   
   <form app-loading app-document-editing="outings" app-document-editing-model="outing"
+    app-document-editing-controller-name="appOutingEditingController"
   % if updating_doc:
     app-document-editing-id="${outing_id}" app-document-editing-lang="${outing_lang}"
   % endif 

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -21,6 +21,7 @@ updating_doc = route_id and route_lang
   <h1 ng-cloak ng-init="id=${route_id if route_id else 0}" ng-bind="id ? ('Editing a route' | translate) : ('Creating a route' | translate)" class="text-center"></h1>
   
   <form app-loading app-document-editing="routes" app-document-editing-model="route"
+    app-document-editing-controller-name="appDocumentEditingController"
   % if updating_doc:
     app-document-editing-id="${route_id}" app-document-editing-lang="${route_lang}"
   % endif 

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -26,10 +26,11 @@
   </h1>
 
   <form app-loading app-document-editing="waypoints" app-document-editing-model="waypoint"
-        % if updating_doc:
-        app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
-        % endif
-        class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    app-document-editing-controller-name="appDocumentEditingController"
+  % if updating_doc:
+    app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
+  % endif
+    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
     
     ## It won't work with ng-init
     <span class="ng-hide">


### PR DESCRIPTION
Fixes #246 

This PR introduces the possibility to select an inherited controller when using the ``appDocumentEditingDirective``. This way, code specific to outings may be moved to an ``AppOutingEditingController`` controller.

See explanations at http://stackoverflow.com/a/23647720

For class inheritance with Closure, see also
* http://stackoverflow.com/questions/11122608/why-is-goog-basethis-necessary-in-addition-to-goog-inherits
* http://bolinfest.com/javascript/inheritance.php
* http://bolinfest.com/essays/googbase.html

~~The PR is almost ready even though I have to fix some error that occurs when editing an outing (but the editing seems to work anyway, intensive testing is still to be done).~~
