### PR TITLE
Add missing title_prefix for routes on map + styling

### DIFF
--- a/c2corg_ui/static/js/advancedsearch.js
+++ b/c2corg_ui/static/js/advancedsearch.js
@@ -156,7 +156,6 @@ app.AdvancedSearchController.prototype.getFeatures_ = function() {
  * @private
  */
 app.AdvancedSearchController.prototype.createFeatureProperties_ = function(doc) {
-  // TODO choose the locale according to the UI lang and user prefs
   var locale = doc['locales'][0];
   var properties = {
     'module': this.doctype,
@@ -166,6 +165,8 @@ app.AdvancedSearchController.prototype.createFeatureProperties_ = function(doc) 
   };
   if (this.doctype === 'waypoints') {
     properties['type'] = doc['waypoint_type'];
+  } else if (this.doctype === 'routes') {
+    properties['title_prefix'] = locale['title_prefix'];
   }
   return properties;
 };

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -23,6 +23,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
 goog.require('ol.source.Vector');
+goog.require('ol.style.Fill');
 goog.require('ol.style.Icon');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
@@ -392,13 +393,24 @@ app.MapController.prototype.createPointStyle_ = function(feature,
 
     var text;
     if (highlight) { // on hover in list view
-      var title = /** @type {string} */(feature.get('title'));
+      var title = '';
+      if (type === 'routes' && feature.get('title_prefix')) {
+        title = feature.get('title_prefix') + ' : ';
+      }
+      title += feature.get('title');
 
       text = new ol.style.Text({
-        text: title,
+        text: app.utils.stringDivider(title, 30, '\n'),
         textAlign: 'left',
         offsetX: 20,
-        font: 'bold 14px Calibri,sans-serif',
+        font: '12px verdana,sans-serif',
+        stroke: new ol.style.Stroke({
+          color: 'white',
+          width: 3
+        }),
+        fill: new ol.style.Fill({
+          color: 'black'
+        }),
         textBaseline: 'middle'
       });
     }

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -170,3 +170,31 @@ app.utils.createImageSlide = function(file) {
                '<app-slide-info></app-slide-info>' +
              '</figure>';
 };
+
+/**
+ * http://openlayers.org/en/latest/examples/vector-labels.html
+ * http://stackoverflow.com/questions/14484787/wrap-text-in-javascript
+ * @param {string} str String to divide.
+ * @param {number} width Max string length before wrapping.
+ * @param {string} spaceReplacer
+ * @return {string}
+ */
+app.utils.stringDivider = function(str, width, spaceReplacer) {
+  if (str.length > width) {
+    var p = width;
+    while (p > 0 && (str[p] != ' ' && str[p] != '-')) {
+      p--;
+    }
+    if (p > 0) {
+      var left;
+      if (str.substring(p, p + 1) == '-') {
+        left = str.substring(0, p + 1);
+      } else {
+        left = str.substring(0, p);
+      }
+      var right = str.substring(p + 1);
+      return left + spaceReplacer + app.utils.stringDivider(right, width, spaceReplacer);
+    }
+  }
+  return str;
+};


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/441

Done:
* add missing title_prefix for route features displayed on the map
* change the styling of features labels on the map: black with white outline
* add a line feed for labels longer than 30 characters (but it's not perfect yet, the label of features on the right of the map may overflow the map...)