### PR TITLE
[WIP] Loading indicator for auth actions

### DIFF
--- a/c2corg_ui/templates/account.html
+++ b/c2corg_ui/templates/account.html
@@ -6,7 +6,7 @@
   <section>
     <div ng-controller="appAccountController as accountCtrl">
       <h1 translate>Change account parameters</h1>
-      <form name="accountForm" novalidate ng-submit="accountCtrl.save()">
+      <form name="accountForm" novalidate ng-submit="accountCtrl.save()" app-loading>
         <div id="account-currentpassword-group" class="form-group" ng-class="{ 'has-error': accountForm.currentpassword.$invalid }">
           <label translate>Current password</label>
           <input type="password" minlength="3" name="currentpassword" ng-model="account.currentpassword" class="form-control" required />

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -11,7 +11,7 @@ from pyramid.settings import asbool
     <div ng-show="authCtrl.uiStates.showLoginForm">
       <h1 translate>Login</h1>
 
-      <form name="loginForm" novalidate ng-submit="authCtrl.login()">
+      <form name="loginForm" novalidate ng-submit="authCtrl.login()" app-loading>
         <div id="login-username-group" class="form-group" ng-class="{ 'has-error': loginForm.username.$touched && loginForm.username.$invalid }">
           <label translate>Username</label>
           <input type="text" name="username" ng-model="login.username" class="form-control" required />
@@ -56,7 +56,7 @@ from pyramid.settings import asbool
     <div ng-show="authCtrl.uiStates.showRegisterForm">
       <h1 translate>Register</h1>
 
-      <form name="registerForm" novalidate ng-submit="authCtrl.register()">
+      <form name="registerForm" novalidate ng-submit="authCtrl.register()" app-loading>
         <div id="register-name-group" class="form-group" ng-class="{ 'has-error': registerForm.name.$touched && registerForm.name.$invalid }">
           <label translate>Fullname</label>
           <input type="text" name="name" ng-model="register.name" class="form-control" required />
@@ -118,7 +118,7 @@ from pyramid.settings import asbool
     <div ng-show="authCtrl.uiStates.showRequestChangePasswordForm">
       <h1 translate>Reset password</h1>
 
-      <form name="requestChangePasswordForm" novalidate ng-submit="authCtrl.requestPasswordChange()">
+      <form name="requestChangePasswordForm" novalidate ng-submit="authCtrl.requestPasswordChange()" app-loading>
         <div id="register-password-group" class="form-group" ng-class="{ 'has-error': requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid }">
           <label translate>Email</label>
           <input type="email" name="email" ng-model="requestChangePassword.email" class="form-control" required />

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -32,7 +32,7 @@ from pyramid.settings import asbool
           </label>
         </div>
         <p>
-          <button type="submit" class="btn blue-btn" ng-disabled="loginForm.$invalid" translate>Login</button>
+          <button type="submit" class="btn blue-btn" translate>Login</button>
           <button type="button" class="btn gray-btn" 
                   ng-click="authCtrl.uiStates.showRequestChangePasswordForm = true;
                                      authCtrl.uiStates.showRegisterForm = false;
@@ -51,7 +51,6 @@ from pyramid.settings import asbool
         </button>
       </p>
     </div>
-
 
     <div ng-show="authCtrl.uiStates.showRegisterForm">
       <h1 translate>Register</h1>
@@ -73,7 +72,7 @@ from pyramid.settings import asbool
         </div>
         <div id="register-forum_username-group" class="form-group" ng-class="{ 'has-error': registerForm.forum_username.$touched && registerForm.forum_username.$invalid }">
           <label translate>forum_user username</label>
-          <!-- http://stackoverflow.com/questions/1538512/how-can-i-invert-a-regular-expression-in-javascript: opposite test of /[^a-zA-Z0-9]/ -->
+          ## http://stackoverflow.com/questions/1538512/how-can-i-invert-a-regular-expression-in-javascript: opposite test of /[^a-zA-Z0-9]/
           <input type="text" name="forum_username" ng-minlength="3" maxlength="15" ng-pattern="/^(?!.*[^a-zA-Z0-9])/" ng-model="register.forum_username" class="form-control" required />
           <div class="help-block" ng-messages="registerForm.forum_username.$error" ng-if="registerForm.forum_username.$touched">
             <p ng-message="required" translate>This field is required.</p>
@@ -114,7 +113,6 @@ from pyramid.settings import asbool
       </p>
     </div>
 
-
     <div ng-show="authCtrl.uiStates.showRequestChangePasswordForm">
       <h1 translate>Reset password</h1>
 
@@ -146,7 +144,6 @@ from pyramid.settings import asbool
         </button>
       </p>
     </div>
-
 
     <div ng-show="authCtrl.uiStates.showChangePasswordForm">
       <h1 translate>Change password</h1>


### PR DESCRIPTION
As for now when authenticating/registering/resetting/changing the account data, there is nothing indicating something is going on in the background.

This PR adds the `app-loading` directive to the forms of those actions. It works well for login and account changing but causes an error with registering:

> Cannot set property 'lang' of undefined
>     at app.AuthController.register (auth.js:211)

and also for password resetting:

> Cannot read property 'email' of undefined
>     at app.AuthController.requestPasswordChange (auth.js:232)

No pb if I remove `app-loading` from the related forms... 
@ginold @gberaudo would you have an idea where it comes from.

Adding a loading indicator when logging out would also make sense but I cannot use the `app-loading` directive since the logout button directly calls a controller method. Perhaps we should add some code to this method as in the `app-loading` directive https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/loading.js#L25-L31 ? 
