### PR TITLE
[WIP] get document-related comments from discourse

### DIFF
--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -110,7 +110,7 @@ appx.Document;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   geometry: Object,
  *   date_start: (string | Date),
  *   date_end: (string | Date),
@@ -149,7 +149,7 @@ appx.Outing;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   height_diff_up: number,
  *   height_diff_down: number,
  *   height_diff_access: number,
@@ -204,7 +204,7 @@ appx.Route;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   elevation: number,
  *   elevation_min: number,
  *   maps: Array.<Object>,
@@ -288,3 +288,11 @@ appx.AllRoutes;
  * }}
  */
 appx.mapApiKeys;
+
+/**
+ * @typedef {{
+ *   discourseUrl: string,
+ *   topicId: number
+ * }}
+ */
+appx.DiscourseEmbedded;

--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -450,4 +450,11 @@ app.Api.prototype.saveImages = function(files) {
 };
 
 
+/**
+ * @param {string} topic
+ */
+app.Api.prototype.getForumThread = function(topic) {
+  return this.getJson_('/forum/get-topic/' + topic);
+};
+
 app.module.service('appApi', app.Api);

--- a/c2corg_ui/static/js/auth/authservice.js
+++ b/c2corg_ui/static/js/auth/authservice.js
@@ -276,7 +276,8 @@ app.Authentication.prototype.needAuthorization = function(method, url) {
     return false;
   }
 
-  if (url.indexOf('/users/account') !== -1) {
+  if (url.indexOf('/users/account') !== -1 ||
+          url.indexOf('/forum/get-topic/') !== -1) {
     return true;
   }
 

--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -37,5 +37,6 @@ app.constants = {
     FORM_PROJ: 'EPSG:4326',
     DATA_PROJ: 'EPSG:3857'
   },
+  discourseURL: 'http://c2corgv6-discourse.demo-camptocamp.com/',
   imagesURL : 'http://s.camptocamp.org/uploads/images/'
 };

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -110,6 +110,12 @@ app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
    */
   this.scope_ = $scope;
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.createNewTopic = false;
+
 };
 
 
@@ -120,6 +126,16 @@ app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
 app.ViewDetailsController.prototype.openModal = function(selector) {
   var template = $(selector).clone();
   this.modal_.open({animation: true, size: 'lg', template: this.compile_(template)(this.scope_)});
+};
+
+
+/**
+ * @export
+ */
+app.ViewDetailsController.prototype.scrollToComments = function() {
+  $('html, body').animate({
+    scrollTop: $('#discourse-comments').offset().top
+  }, 1000);
 };
 
 
@@ -307,6 +323,35 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
  */
 app.ViewDetailsController.prototype.initSlickGallery_ = function() {
   $('.photos').slick({slidesToScroll: 3, dots: false});
+};
+
+
+/**
+ * @param {string} topic
+ * @export
+ */
+app.ViewDetailsController.prototype.getComments = function(topic) {
+  this.api_.getForumThread(topic).then(function(res) {
+    var thread = res['data']['thread'];
+    var id = thread['draft_key'].split('_')[1]; // topic ID
+    // create DiscourseEmbed script tag. From a discourse tutorial.
+    var s = document.createElement('script');
+    /**
+     * @export
+     * @type {appx.DiscourseEmbedded}
+     */
+    window.DiscourseEmbed = {
+      'discourseUrl': app.constants.discourseURL,
+      'topicId': id
+    };
+    s.src = app.constants.discourseURL + 'javascripts/embed.js';
+    document.getElementsByTagName('body')[0].appendChild(s);
+    console.log(thread);
+  }.bind(this)).catch(function(e) {
+    // no topic found
+    this.createNewTopic = true;
+
+  }.bind(this));
 };
 
 

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -22,6 +22,7 @@ closure_library_path = settings.get('closure_library_path')
     <meta name="apple-mobile-web-app-title" content="Camptocamp.org">
     <meta name="application-name" content="Camptocamp.org">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="X-Frame-Options" content="allow">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="msapplication-TileImage" content="${request.static_url('c2corg_ui:static/img/logo.svg')}">
     <meta name="msapplication-TileColor" content="#FF0000">

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -325,7 +325,8 @@
       <p class="float-button-text" translate>Favorites</p>
     </div>
     
-    <div class="float-button float-comments" tooltip-placement="left" uib-tooltip="{{'Comments' | translate}}">
+    <div class="float-button float-comments" tooltip-placement="left" uib-tooltip="{{'Comments' | translate}}" ng-if="!detailsCtrl.createNewTopic"
+         ng-click="detailsCtrl.scrollToComments()">
       <span class="glyphicon glyphicon-comment"></span>
       <p class="float-button-text" translate>Comments</p>
     </div>
@@ -570,5 +571,26 @@
 <%def name="get_image_gallery()">\
   <div class="view-details-photos col-xs-12 tab description" ng-show="detailsCtrl.documentService.document.associations.images.length > 0">
     <div class="photos" data-slick='{"variableWidth": true, "infinite": false, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
+  </div>
+</%def>
+
+
+<%def name="get_comments(id, lang)">\
+  <div class="view-details-associations comments col-xs-12 tab description">
+    <span class="lead">
+      <section>
+        <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#discourse-comments">
+          <span class="glyphicon glyphicon-comment"></span>
+          <span translate>Comments</span>
+          <span class="glyphicon glyphicon-menu-down"></span>
+        </h3>
+        <section id="discourse-comments" class="collapse in" ng-init="detailsCtrl.getComments('${id}-${lang}')">
+          <div ng-if="detailsCtrl.createNewTopic" class="add-outing">
+            <p class="text-center">No thread yet?</p>
+            <button protected-url-btn url="http://c2corgv6-discourse.demo-camptocamp.com/new-topic?title=${id}_${lang}&category=commentaires du topoguide/comments" class="btn gray-btn"  translate>Post the first comment</button>
+          </div>
+        </section>
+      </section>
+    </span>
   </div>
 </%def>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -8,7 +8,7 @@ from json import dumps
 <%namespace file="../helpers/common.html" import="show_title, show_fulldate"/>
 <%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow,
     get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_min_max,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_min_max,
     get_document_locale_text, show_attr, show_missing_langs_links, show_other_langs_links,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, delete_association_confirmation_modal"/>
@@ -151,6 +151,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     </span>
   </div>
   % endif
+  
+  ${get_comments(outing_id, lang)}
 
   ## OTHER BUTTON contents
   % if version:

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -5,7 +5,7 @@ from json import dumps
 %>
 
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
     get_document_locale_text, show_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title,
     show_areas, show_float_buttons, show_maps, get_route_activities,
@@ -180,6 +180,9 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     </div>
     % endif
   % endif
+
+  ${get_comments(route_id, lang)}
+
   
   ## OTHER BUTTON contents
   % if version:

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -10,7 +10,7 @@ from json import dumps
     get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
     get_waypoint_maps_info"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
     show_attr, show_missing_langs_links, show_other_langs_links, show_archive_data, 
     show_route_title, show_areas, show_maps, show_float_buttons,
     show_associated_waypoints, show_associated_routes, show_associated_outings,
@@ -193,7 +193,9 @@ geometry4326 = geometry
       </div>
     % endif
   % endif
-
+  
+  ${get_comments(waypoint_id, lang)}
+  
   ## OTHER BUTTON contents
   % if version:
     ${show_archive_data('waypoints', waypoint, locale, version)}

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -247,7 +247,6 @@
       margin-bottom: 5px;
     }
   }
-
   .view-details-informations {
     background-color: white;
     border: 1px solid #eee;
@@ -627,4 +626,10 @@ app-add-association {
     height: 110px;
     width: 100%;
   }
+}
+
+#discourse-comments {
+  padding-top: 20px;
+  .flex();
+  justify-content: center;
 }


### PR DESCRIPTION
So what I have achieved until now is the possibility to get a forum thread with its `document_id` and `lang` (`topic_slug` in JSON), for example getting :
http://c2corgv6-discourse.demo-camptocamp.com/t/262782-fr 
will redirect to :
http://c2corgv6-discourse.demo-camptocamp.com/t/262782-fr/108763 
with the last part being the topic ID.

If there is no data returned for the combination `document_id`-`lang`, the user is suggested to create a new thread. Some problems emerge:
- You cannot change the topic title, which is used to look for the contents and get the topic id. This is not viable - users cannot have some numbers as topic title !
- The first main comment created does not appear in the appended comments, although it is returned in the JSON. Only the responses for the main comment will appear.

We should be able to save the topic id for each document-view-page on create the thread so that I can directly get the thread without first getting `document_id`-`lang` and then the thread, if it exists. 
This operation takes a while imo.