### PR TITLE
longer timeout for map smart-scroll

### DIFF
--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -54,7 +54,7 @@ app.utils.setupSmartScroll = function(mouseWheelZoomInteraction) {
     }
     scrollTimer = setTimeout(function() {
       mouseWheelZoomInteraction.setActive(true);
-    }, 500);
+    }, 1000);
   });
 };
 


### PR DESCRIPTION
changed from 500ms to 1000ms.
2 seconds suggested by the client is way too long. 
related to #413