### PR TITLE
route-view fixes

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -390,22 +390,22 @@
 
 <%def name="get_document_min_max(document, prop)">\
   % if document.get(prop + '_min') and document.get(prop + '_max') and (document.get(prop + '_max') is not None and document.get(prop + '_min') is not None):
-  <p><b x-translate class="value-title">${prop}</b>: <span class="value">min ${document[prop + '_min']} m / max ${document[prop + '_max']} m</span></p>
+  <p><b x-translate class="value-title">${prop} min / max </b>: <span class="value"> ${document[prop + '_min']}m / ${document[prop + '_max']}m</span></p>
   %  elif (document.get(prop + '_min') and document.get(prop + '_min') is not None) and not document.get(prop + '_max'):
-  <p><b x-translate class="value-title">${prop + '_min'}</b>: <span class="value">${document[prop + '_min']} m</span></p>
+  <p><b x-translate class="value-title">${prop + '_min'}</b>: <span class="value">${document[prop + '_min']}m</span></p>
   % elif document.get(prop + '_max') and document.get(prop + '_max') is not None:
-  <p><b x-translate class="value-title">${prop + '_max'}</b>: <span class="value">${document[prop + '_max']} m</span></p>
+  <p><b x-translate class="value-title">${prop + '_max'}</b>: <span class="value">${document[prop + '_max']}m</span></p>
   % endif
 </%def>
 
 
 <%def name="get_document_up_down(document, prop)">\
   % if document.get(prop + '_down') and document.get(prop + '_up') and (document.get(prop + '_up') is not None and document.get(prop + '_down') is not None):
-  <p><b x-translate class="value-title">${prop}</b>: <span class="value">-${document[prop + '_down']} m / +${document[prop + '_up']} m</span></p>
+  <p><b x-translate class="value-title">${prop}</b>: <span class="value">+${document[prop + '_up']}m / -${document[prop + '_down']}m</span></p>
   %  elif (document.get(prop + '_down') and document.get(prop + '_down') is not None) and not document.get(prop + '_up'):
-  <p><b x-translate class="value-title">${prop + '_down'}</b>: <span class="value">${document[prop + '_down']} m</span></p>
+  <p><b x-translate class="value-title">${prop + '_down'}</b>: <span class="value">${document[prop + '_down']}m</span></p>
   % elif document.get(prop + '_up') and document.get(prop + '_up') is not None:
-  <p><b x-translate class="value-title">${prop + '_up'}</b>: <span class="value">${document[prop + '_up']} m</span></p>
+  <p><b x-translate class="value-title">${prop + '_up'}</b>: <span class="value">${document[prop + '_up']}m</span></p>
   % endif
 </%def>
 
@@ -476,19 +476,6 @@
       <span uib-tooltip="{{mainCtrl.translate('global_rating')}}" class="value">${document['global_rating']}</span>&nbsp;
     % endif
 
-    ## [A0] (without bracket) is showed only if equipment_rating = P1 or P1+, and if aid_rating is empty.
-    % if document.get('rock_required_rating') or document.get('rock_free_rating'):
-      <div class="rating-block">
-      % if document.get('rock_required_rating'):
-        <span uib-tooltip="{{mainCtrl.translate('rock_free_rating')}}" class="value">${document.get('rock_free_rating')}</span>
-      % endif
-      ${'>' if document.get('rock_required_rating') and document.get('rock_free_rating') else ''}
-      % if document.get('rock_required_rating') and document.get('rock_free_rating'):
-        <span uib-tooltip="{{mainCtrl.translate('rock_required_rating')}}" class="value">${document['rock_required_rating']}${'A0' if (document.get('equipment_rating') == 'P1' or document.get('equipment_rating') == 'P1+') and not document.get('aid_rating') else ''}</span></p>
-      % endif
-      </div>
-    % endif
-
     % if route.get('aid_rating'):
       <span uib-tooltip="{{mainCtrl.translate('aid_rating')}}" class="value">${route['aid_rating']}</span>&nbsp;
     % endif
@@ -519,6 +506,21 @@
 
     % if route.get('exposition_rock_rating'):
      <span uib-tooltip="{{mainCtrl.translate('exposition_rock_rating')}}" class="value">${route['exposition_rock_rating']}</span>&nbsp;
+    % endif
+
+    ## [A0] (without bracket) is showed only if equipment_rating = P1 or P1+, and if aid_rating is empty.
+    % if document.get('rock_required_rating') or document.get('rock_free_rating'):
+      <div class="rating-block">
+      % if document.get('rock_free_rating'):
+        <span uib-tooltip="{{mainCtrl.translate('rock_free_rating')}}" class="value">${document.get('rock_free_rating')}</span>
+      % endif
+
+      ${'>' if document.get('rock_required_rating') and document.get('rock_free_rating') else ''}
+
+      % if document.get('rock_required_rating') and document.get('rock_free_rating'):
+        <span uib-tooltip="{{mainCtrl.translate('rock_required_rating')}}" class="value">${document['rock_required_rating']}${'A0' if (document.get('equipment_rating') == 'P1' or document.get('equipment_rating') == 'P1+') and not document.get('aid_rating') else ''}</span></p>
+      % endif
+      </div>
     % endif
 
   % endif

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -58,14 +58,13 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 </%block>
 
 <header class="view-details-title">
-  <h1>
-    ${locale['title']}<br>
-    <span class="outing-date" class="ng-cloak">${show_fulldate(outing['date_start'], outing['date_end'])}</span>
-    <label class="badge outing" onClick="window.location='${request.route_url('outings_index')}' ">
+  <h1 class="routes">
+    <div class="icons-header routes">${get_route_activities(outing, 'top')}</div>
+    <span class="title">${show_route_title(locale)}</span>
+    <label class="badge route" onClick="window.location='${request.route_url('outings_index')}' ">
       <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>outing</span>
     </label>
   </h1>
-  <div class="icons-header">${get_route_activities(outing, 'top')}</div>
 </header>
 
 <app-map class="view-details-map"></app-map>

--- a/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+++ b/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -4,22 +4,18 @@
 ## LOCATION
 <%def name="get_route_location(route)">\
   % if route.get('areas') or route.get('orientations'):
-    <div class="name-icon-value location" ng-click="detailsCtrl.openTab($event)">
+  <div class="name-icon-value location  ${'ng-hide' if route.get('areas') and not route.get('orientations') else ''} "
+       ng-click="detailsCtrl.openTab($event)">
       <h4><span translate>Location</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">
         <span class="glyphicon glyphicon-map-marker"></span>
         <p translate>Location</p>
       </div>
       <span class="detail-text accordion" id="detail-orientation">
-        ${show_areas(route)}
-        
+        <span class="areas">{show_areas(route)}</span>
+
         % if route.get('orientations'):
           ${show_orientations('detailsCtrl', 'detailsCtrl.documentService.document')}
-          <ul id="orientation-list">
-            % for orientation in route.get('orientations'):
-              <li>${orientation}</li>
-            % endfor
-          </ul>
         % endif
       </span>
     </div>
@@ -44,20 +40,25 @@
           % endfor
         </article>
       % endif
-    
+
       % if route.get('activities'):
         <article class="value activities">
           <span translate class="value-title">activities</span><br>
           % for type in route.get('activities') :
-          <span x-translate  class="green-text">${type}</span>${'' if loop.last else ', '}
+            <span x-translate  class="route-activity icon-${type}" uib-tooltip="{{mainCtrl.translate('${type}')}}" ></span>
           % endfor
         </article>
       % endif
 
       % if route.get('durations'):
-      <p><span translate class="value-title">durations</span>: <b class="value">${route['durations']}</b></p>
+        <article>
+          <span translate class="value-title">durations</span><br>
+          % for duration in route.get('durations') :
+          <span x-translate class="value">${duration}</span>${'' if loop.last else ', '}
+          % endfor
+        </article>
       % endif
-      
+
       % if route.get('rock_types'):
         <article>
           <span translate class="value-title">rock_types</span><br>
@@ -66,7 +67,7 @@
           % endfor
         </article>
       % endif
-      
+
       % if route.get('climbing_outdoor_type'):
         <p><span translate class="value-title">climbing_outdoor_type</span>: <b class="value">${route['climbing_outdoor_type']}</b></p>
       % endif
@@ -85,7 +86,7 @@
 </%def>
 
 
-## RATING  
+## RATING
 <%def name="get_route_rating(route)">\
 % if route.get('global_rating') or route.get('engagement_rating') or route.get('risk_rating') or route.get('exposition_rock_rating') \
   or route.get('rock_free_rating') or route.get('rock_required_rating') or route.get('hiking_rating') \
@@ -99,7 +100,7 @@
       <p translate>Rating</p>
     </div>
     <span class="detail-text accordion ratings">
-      
+
       ${get_global_rating(route)}
 
       ${get_hiking_mtb_rating(route)}
@@ -111,14 +112,14 @@
       % endif
 
         ${get_skitouring_rating(route)}
-      
+
     </span>
   </div>
   % endif
 </%def>
 
 
-## HEIGHTS  
+## HEIGHTS
 <%def name="get_route_heights(route)">\
   % if route.get('route_length') or route.get('mtb_height_diff_portages') or route.get('height_diff_difficulties') or route.get('difficulties_height') \
         or route.get('mtb_length_asphalt') or route.get('mtb_length_trail') or locale.get('slope') or route.get('elevation_max') or route.get('elevation_min') \
@@ -177,7 +178,7 @@
         <span class="glyphicon glyphicon-road"></span>
         <p translate>Access</p>
       </div>
-      
+
       <span class="detail-text accordion">
         % if route.get('lift_access'):
         <span x-translate class="value-title">lift_access</span> : <span translate class="value">yes</span><br>
@@ -204,7 +205,7 @@
       <p translate>Maps</p>
     </div>
     <span class="detail-text accordion">
-        ${show_maps(route)} 
+        ${show_maps(route)}
     </span>
   </div>
   % endif

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -46,7 +46,8 @@ other_langs, missing_langs = get_lang_lists(route, lang)
       {
         "type": "FeatureCollection",
         "properties": {},
-        "features": [{
+        "features": [
+        {
           "type": "Feature",
           "geometry": ${geometry | n},
           "properties": {
@@ -55,8 +56,24 @@ other_langs, missing_langs = get_lang_lists(route, lang)
             "documentId": ${route['document_id']},
             "module": "routes"
           }
-        }]
-      }
+        }
+        ## show associated waypoints on the map
+        ## missing geometry!
+          % if route.get('associations').get('waypoints'):
+          ,
+          % for wp in route.get('associations').get('waypoints'):
+            {
+              "type": "Feature",
+              "properties": {
+                "title": ${dumps(wp['locales'][0]['title']) | n},
+                "lang": ${dumps(wp['locales'][0]['lang']) | n},
+                "documentId": ${wp['document_id']},
+                "module": "waypoints"
+              }
+            }${'' if loop.last else ', '}
+          % endfor
+          % endif
+          ]}
     % else:
       null
     % endif
@@ -74,12 +91,13 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 </%block>
 
 <header class="view-details-title">
-  <h1>${show_route_title(locale)}
+  <h1 class="routes">
+    <div class="icons-header routes">${get_route_activities(route, 'top')}</div>
+    <span class="title">${show_route_title(locale)}</span>
     <label class="badge route" onClick="window.location='${request.route_url('routes_index')}' ">
       <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>route</span>
     </label>
   </h1>
-  <div class="icons-header">${get_route_activities(route, 'top')}</div>
 </header>
 
 <app-map class="view-details-map"></app-map>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -76,14 +76,13 @@ geometry4326 = geometry
 </%block>
 
 <header class="view-details-title">
-  <h1>${locale['title']}
+  <h1>
+    <span>${locale['title']}</span>
+    <span class="icon-${waypoint['waypoint_type']} waypoint-type" uib-tooltip="${waypoint['waypoint_type']}"></span>
     <label class="badge waypoint" onClick="window.location='${request.route_url('waypoints_index', _query={'wtyp': waypoint['waypoint_type']})}'">
       <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>waypoint</span>
     </label>
   </h1>
-  <div class="icons-header">
-    <span class="icon-${waypoint['waypoint_type']} waypoint-type" uib-tooltip="${waypoint['waypoint_type']}"></span>
-  </div>
 </header>
 
 <app-map class="view-details-map"></app-map>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -327,7 +327,7 @@ main {
   }
   @media @phone {
     border-width: 1px;
-    font-size: 1.3em;
+    font-size: 1.2em;
   }
   .waypoint-type {
     font-size: 2em;
@@ -596,6 +596,7 @@ app-simple-search {
   padding-left: 10px;
   margin-right: 10px;
   background: @C2C-orange;
+  width: 25%;
 
   .glyphicon {
     color: #F9F9F9;

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -583,7 +583,7 @@ input[type="radio"] {
 
 .circle-selected {
   transition: 0.3s ease-in-out;
-  fill: @C2C-orange;
+  fill: @bright-green;
 }
 
 .half-circle-selected {

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -25,6 +25,24 @@
     transition: 0.4s;
     line-height: 45px;
     font-size: 2.5em;
+    &.routes {
+      .flex();
+      align-items: center;
+      justify-content: center;
+      width: 99%;
+      .title {
+        max-width: 70%;
+        margin-right: 10px;
+      }
+      .icons-header {
+        font-size: 2em;
+        margin-right: 10px;
+        @media @phone {
+          margin-right: 5px;
+          width: 150px;
+        }
+      }
+    }
 
     @media @phone {
       font-size: 1.5em;
@@ -35,11 +53,20 @@
       font-size: 2em;
       line-height: 35px;
     }
+    .waypoint-type {
+      color: @C2C-orange;
+    }
     .badge {
       font-size: 0.5em;
-      margin-left: 10px;
+      margin-right: 10px;
+      width: 100px;
       padding-bottom: 6px;
+      margin-top: 5px;
       cursor: pointer;
+
+      @media @phone {
+        display: none;
+      }
 
       .glyphicon {
         color: white;
@@ -247,6 +274,10 @@
       padding-bottom: 10px;
       margin-bottom: 5px;
     }
+    #associated-outings {
+      max-height: 100%;
+      overflow-y: visible;
+    }
   }
 
   .view-details-informations {
@@ -273,6 +304,10 @@
         margin: 0;
         color: @bright-green;
       }
+    }
+    .route-activity {
+      font-size: 2.5em;
+      color: @bright-green;
     }
 
     #document-informations {
@@ -375,10 +410,12 @@
 
       &.location {
         .flex();
-        ul {
-          display: none;
-          @media @phone {
-            display: block;
+        @media @phone {
+          .flex() !important;
+        }
+        .areas {
+          @media (min-width: @phone-max) {
+            display: none;
           }
         }
       }
@@ -620,6 +657,6 @@ app-add-association {
 
   #orientation-svg{
     height: 110px;
-    width: 100%;
+    width: auto;
   }
 }


### PR DESCRIPTION
related to #433 for routes:
- replace activity name by icon
- move activity icon in header to the left
- inverse min/max and up/down values + join 'm' unit to the number
- selected orientation color (on svg)
- displaying situation (in info block) fix
- remove scrolling on mobile from associated outings
- reorder rock rating

- 1 wp fix: waypoint type icon to the left of the "waypoint" badge.

- started but not finished: show associated wps on the map
