### PR TITLE
outing-view fixes #433

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -170,13 +170,14 @@
       <span x-translate>Associated ${type}</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <div class="associated-documents collapse in" id="associated-waypoints">
-      <div class="list-item"
+      <div class="list-item waypoints"
         % if document['doctype'] == 'routes':
           ng-class="{'main-waypoint': doc.document_id === ${document['main_waypoint_id']}, 'new-item': doc['new']}"
+          ng-style="doc.document_id === ${document['main_waypoint_id']} && {'order': -1}"
         % else:
           ng-class="{'new-item': doc['new']}"
         % endif
-          ng-repeat="doc in ${associations}">
+          ng-repeat="doc in ${associations} | orderBy: 'waypoint_type'">
         <app-card app-card-doc="doc"></app-card>
         % if showDelete:
           <app-delete-association child-doctype="${type}" parent-id="${document['document_id']}" child-id="doc.document_id"
@@ -269,12 +270,11 @@
                   <tr>
                     <th class="location"><span translate>location</span> |
                       <span translate>altitude</span> |
-                      <span translate>orientation</span> |
-                      <span translate>time</span>
+                      <span translate>orientation</span>
                     </th>
                     <th class="soft-snow" translate>soft snow</th>
                     <th class="total-snow" translate>total snow</th>
-                    <th class="comment text-center" translate>comment</th>
+                    <th class="comment" translate>comment</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -315,11 +315,18 @@
 
   % else :
     % if text in locale and locale[text]:
+    <%
+      open_tab =  text == 'route_description' or text == 'hut_comment'
+    %>
       <div class="view-details-info col-xs-12">
-        <h3 class="heading closed show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#${text}">
+        <h3 class="heading
+            ${'closed' if not open_tab else ''}
+            show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#${text}">
           <span x-translate>${text}</span><span class="glyphicon glyphicon-menu-right"></span>
         </h3>
-        <section class="collapse" id="${text}" aria-expanded="trues">
+        <section
+          class="${'collapse in' if open_tab else 'collapse'}"
+          id="${text}" aria-expanded="trues">
           <div class="lead">
             ${show_attr(locale, text)}
           </div>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -122,10 +122,10 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   <div class="description ">
     ${get_document_locale_text(locale, 'route_description')}
-    ${get_document_locale_text(locale, 'avalanches')}
     ${get_document_locale_text(locale, 'hut_comment')}
-    ${get_document_locale_text(locale, 'access')}
     ${get_document_locale_text(locale, 'access_comment')}
+    ${get_document_locale_text(locale, 'avalanches')}
+    ${get_document_locale_text(locale, 'access')}
     ${get_document_locale_text(locale, 'timing')}
     ${get_document_locale_text(locale, 'weather')}
   </div>

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -24,6 +24,7 @@
     text-align: center;
     transition: 0.4s;
     line-height: 45px;
+    font-size: 2.5em;
 
     @media @phone {
       font-size: 1.5em;
@@ -223,17 +224,17 @@
       font-size: 1.1em;
     }
     .list-item {
-      display: block;
-      max-width : 48%;
-      margin: 10px .5% 0% .5%;
-
-      @media @phone {
-        max-width: 100%;
+      &.waypoints {
+        @media @big {
+          width: 24%;
+        }
+        @media @desktop {
+          width: 32%;
+        }
+        @media @tablet {
+          width: 49%;
+        }
       }
-      @media @big {
-        width: 32%;
-      }
-
       .list-item-title {
         font-size: 0.9em;
       }


### PR DESCRIPTION
- smaller title font size
- route_description & hut_comment are open by default
- associated waypoints are ordered by type
- 4 columns for associated wps on big screen

related to #433 outings.