### PR TITLE
Show document-related comments from discourse

### DIFF
--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -116,6 +116,7 @@ class NotFound():
           'bing_api_key': self.settings['bing_api_key'],
           'image_backend_url': self.settings['image_backend_url'],
           'image_url': self.settings['image_url'],
+          'discourse_url': self.settings['discourse_url'],
           'error_msg': self.context.detail if self.context.detail else ''
         }
 

--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -119,7 +119,7 @@ appx.Document;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   geometry: Object,
  *   date_start: (string | Date),
  *   date_end: (string | Date),
@@ -157,7 +157,7 @@ appx.Outing;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   height_diff_up: number,
  *   height_diff_down: number,
  *   height_diff_access: number,
@@ -212,7 +212,7 @@ appx.Route;
  *   type : string,
  *   quality: string,
  *   document_id: number,
- *   
+ *
  *   elevation: number,
  *   elevation_min: number,
  *   maps: Array.<Object>,
@@ -296,3 +296,11 @@ appx.AllRoutes;
  * }}
  */
 appx.mapApiKeys;
+
+/**
+ * @typedef {{
+ *   discourseUrl: string,
+ *   topicId: number
+ * }}
+ */
+appx.DiscourseEmbedded;

--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -461,4 +461,18 @@ app.Api.prototype.createImages = function(files, document) {
 };
 
 
+/**
+ * @param {number} document_id
+ * @param {string} lang
+ */
+app.Api.prototype.createTopic = function(document_id, lang) {
+  var promise = this.postJson_('/forum/topics', {
+    'document_id': document_id,
+    'lang': lang
+  });
+  promise.catch(this.errorSaveDocument_.bind(this));
+  return promise;
+};
+
+
 app.module.service('appApi', app.Api);

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -124,6 +124,16 @@ app.ViewDetailsController.prototype.openModal = function(selector) {
 
 
 /**
+ * @export
+ */
+app.ViewDetailsController.prototype.scrollToComments = function() {
+  $('html, body').animate({
+    scrollTop: $('#discourse-comments').offset().top
+  }, 1000);
+};
+
+
+/**
  * @param {Event} tab the clicked tab
  * @export
  */
@@ -303,6 +313,48 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
  */
 app.ViewDetailsController.prototype.initSlickGallery_ = function() {
   $('.photos').slick({slidesToScroll: 3, dots: false});
+};
+
+
+/**
+ * @export
+ */
+app.ViewDetailsController.prototype.getComments = function() {
+  var topic_id = this.documentService.document['topic_id'];
+  if (topic_id === null) {
+    return;
+  }
+
+  // create DiscourseEmbed script tag. From a discourse tutorial.
+  // https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963
+  var s = document.createElement('script');
+  /**
+   * @export
+   * @type {appx.DiscourseEmbedded}
+   */
+  window.DiscourseEmbed = {
+    'discourseUrl': this.discourseUrl_,
+    'topicId': topic_id
+  };
+  s.src = this.discourseUrl_ + 'javascripts/embed.js';
+  document.getElementsByTagName('body')[0].appendChild(s);
+};
+
+
+/**
+ * @export
+ */
+app.ViewDetailsController.prototype.createTopic = function() {
+  var document = this.documentService.document;
+  var document_id = document.document_id;
+  var lang = document.lang;
+  this.api_.createTopic(document_id, lang).then(function(resp) {
+    var topic_id = resp['data']['topic_id'];
+    this.documentService.document.topic_id = topic_id;
+    this.getComments();
+    var url = this.discourseUrl_ + 't/' + document_id + '_' + lang + '/' + topic_id;
+    window.open(url);
+  }.bind(this));
 };
 
 

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -57,13 +57,14 @@ app.module.directive('appViewDetails', app.viewDetailsDirective);
  * @param {app.Api} appApi Api service.
  * @param {app.Document} appDocument service
  * @param {appx.Document} documentData Data set as module value in the HTML.
- * @param {String} imageUrl URL to the image backend.
+ * @param {string} imageUrl URL to the image backend.
+ * @param {string} discourseUrl URL to discourse.
  * @constructor
  * @export
  * @ngInject
  */
 app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
-    appDocument, documentData, imageUrl) {
+    appDocument, documentData, imageUrl, discourseUrl) {
 
   /**
    * @type {app.Document}
@@ -91,10 +92,17 @@ app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
   this.api_ = appApi;
 
   /**
-   * @type {String}
+   * @type {string}
    * @private
    */
   this.imageUrl_ = imageUrl;
+
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.discourseUrl_ = discourseUrl;
 
   /**
    * @type {!angular.Scope}

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -22,6 +22,7 @@ closure_library_path = settings.get('closure_library_path')
     <meta name="apple-mobile-web-app-title" content="Camptocamp.org">
     <meta name="application-name" content="Camptocamp.org">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="X-Frame-Options" content="allow">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="msapplication-TileImage" content="${request.static_url('c2corg_ui:static/img/logo.svg')}">
     <meta name="msapplication-TileColor" content="#FF0000">

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -145,6 +145,7 @@ closure_library_path = settings.get('closure_library_path')
          module.constant('apiUrl', '${api_url}');
          module.constant('imageBackendUrl', '${image_backend_url}');
          module.constant('imageUrl', '${image_url}');
+         module.constant('discourseUrl', '${discourse_url}');
          module.constant('authUrl', '${request.route_url('auth')}');
          module.constant('langs', ['${"','".join(default_langs) |n}']);
          module.constant('mapApiKeys', {

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -417,7 +417,8 @@
       <p class="float-button-text" translate>Favorites</p>
     </div>
 
-    <div class="float-button float-comments" tooltip-placement="left" uib-tooltip="{{'Comments' | translate}}">
+    <div class="float-button float-comments" tooltip-placement="left" uib-tooltip="{{'Comments' | translate}}"
+         ng-click="detailsCtrl.scrollToComments()">
       <span class="glyphicon glyphicon-comment"></span>
       <p class="float-button-text" translate>Comments</p>
     </div>
@@ -663,5 +664,29 @@
 <%def name="get_image_gallery()">\
   <div class="view-details-photos col-xs-12 tab description" ng-show="detailsCtrl.documentService.document.associations.images.length > 0">
     <div class="photos" data-slick='{"variableWidth": true, "infinite": false, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
+  </div>
+</%def>
+
+
+<%def name="get_comments()">\
+  <div class="view-details-comments col-xs-12 comments">
+    <h3 class="heading comments"
+        data-toggle="collapse" data-target="#discourse-comments"
+        ng-click="mainCtrl.animateHeaderIcon($event)">
+      <span class="glyphicon glyphicon-comment"></span>
+      <span translate>Comments</span>
+      <span class="glyphicon glyphicon-menu-down"></span>
+    </h3>
+    <section id="discourse-comments" class="collapse in" ng-init="detailsCtrl.getComments()">
+      <div ng-if="detailsCtrl.documentService.document.topic_id == null" class="no-thread">
+        <p class="text-center">No thread yet?</p>
+        <p class="text-center"
+            ng-if="!userCtrl.auth.isAuthenticated()">Log in to post the first comment</p>
+        <button class="btn gray-btn"
+            ng-if="userCtrl.auth.isAuthenticated()"
+            ng-click="detailsCtrl.createTopic()"
+            translate>Post the first comment</button>
+      </div>
+    </section>
   </div>
 </%def>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -8,7 +8,7 @@ from json import dumps
 <%namespace file="../helpers/common.html" import="show_title, show_fulldate"/>
 <%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow,
     get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_min_max,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_min_max,
     get_document_locale_text, show_attr, show_missing_langs_links, show_other_langs_links,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, delete_association_confirmation_modal,
@@ -57,7 +57,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   module.value('documentData', {
     "document_id": ${outing.get('document_id')},
     "lang": "${lang}",
-    "type": "o"
+    "type": "o",
+    "topic_id": ${dumps(locale.get('topic_id'))}
     % if not version:
        , "associations": ${dumps(outing.get('associations')) | n}
     % endif
@@ -158,6 +159,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
       </section>
     </span>
   </div>
+
+  ${get_comments()}
 
   ## OTHER BUTTON contents
     ${show_other_langs_links('outings', outing, other_langs)}

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -5,7 +5,7 @@ from json import dumps
 %>
 
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
     get_document_locale_text, show_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title,
     show_areas, show_float_buttons, show_maps, get_route_activities,
@@ -70,6 +70,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     "document_id": ${route.get('document_id')},
     "lang": "${lang}",
     "type": "r",
+    "topic_id": ${dumps(locale.get('topic_id'))},
     % if route.get('orientations'):
       "orientations": [${'"' + '","'.join(route['orientations']) + '"' if len(route['orientations']) else '' | n}],
     % endif
@@ -183,6 +184,8 @@ other_langs, missing_langs = get_lang_lists(route, lang)
         </span>
       </div>
     % endif
+
+  ${get_comments()}
 
   ## OTHER BUTTON contents
     ${show_other_langs_links('routes', route, other_langs)}

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -10,7 +10,7 @@ from json import dumps
     get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
     get_waypoint_maps_info"/>
-<%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
     show_attr, show_missing_langs_links, show_other_langs_links, show_archive_data,
     show_route_title, show_areas, show_maps, show_float_buttons,
     show_associated_waypoints, show_associated_routes, show_associated_outings,
@@ -74,6 +74,7 @@ geometry4326 = geometry
     "document_id": ${waypoint.get('document_id')},
     "lang": "${lang}",
     "type": "w",
+    "topic_id": ${dumps(locale.get('topic_id'))},
     % if waypoint.get('orientations'):
       "orientations": [${'"' + '","'.join(waypoint['orientations']) + '"' if len(waypoint['orientations']) else '' | n}],
     % endif
@@ -192,6 +193,8 @@ geometry4326 = geometry
       </div>
     % endif
   % endif
+
+  ${get_comments()}
 
   ## OTHER BUTTON contents
   % if not version:

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -47,7 +47,8 @@ class Document(object):
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
             'image_backend_url': self.settings['image_backend_url'],
-            'image_url': self.settings['image_url']
+            'image_url': self.settings['image_url'],
+            'discourse_url': self.settings['discourse_url']
         }
 
     def _index(self, template):

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -15,7 +15,8 @@ class Pages(object):
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
             'image_backend_url': self.settings['image_backend_url'],
-            'image_url': self.settings['image_url']
+            'image_url': self.settings['image_url'],
+            'discourse_url': self.settings['discourse_url']
         }
 
     @view_config(route_name='index')

--- a/common.ini.in
+++ b/common.ini.in
@@ -8,6 +8,7 @@ image_backend_url = {image_backend_url}
 image_url = {image_url}
 api_url_internal = {api_url_internal}
 api_url_host = {api_url_host}
+discourse_url = {discourse_url}
 
 http_request_connection_pool_size = {http_request_connection_pool_size}
 

--- a/config/default
+++ b/config/default
@@ -14,6 +14,7 @@ export image_backend_url = http://c2corgv6-demo.gis.internal:8480
 export image_url = http://c2corgv6-demo.gis.internal:8480/active/
 export api_url_internal =
 export api_url_host =
+export discourse_url = http://c2corgv6-discourse.demo-camptocamp.com/
 
 # Valid for http://c2corgv6.demo-camptocamp.com
 export ign_api_key = 9qxhimhvm24i40p8j86n7de3

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -172,7 +172,8 @@
       }
     }
   }
-  .view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos {
+  .view-details-description, .view-details-other,  .view-details-info, .view-details-associations, .view-details-photos,
+  .view-details-comments {
     padding-left: 0;
     padding-right: 0;
     background: white;
@@ -488,6 +489,25 @@
         text-align: center;
         vertical-align: middle;
         padding: 1%;
+      }
+    }
+  }
+  .view-details-comments {
+    @media @big {
+      width: 100%;
+    }
+
+    #discourse-comments {
+      text-align: center;
+
+      .no-thread {
+        display: inline-block;
+        background: #CACACA;
+        margin: 10px;
+        padding: .5%;
+        color: white;
+        border-radius: 5px;
+        font-variant: small-caps;
       }
     }
   }


### PR DESCRIPTION
Superseed #458 

Add a comments section in the document (waypoint, outing and route) detail view with embeded comments from discourse.

For performance and technical problems, discourse topics ids are stored on guidebook side in documents_topics table.

If the topic do not exists, the comments section contains a button to create the first post (<=> topic/thread) in discourse. This button is only accessible to authenticated users, unauthenticated users get a "log in to create the first post" message.

For now the topic first post (<=> topic/thread description) only contains a link to the current document. Note that the first post is always created by the discourse system user and do not appears in the guidebook comments section, but only on the discourse side.