### PR TITLE
Fix editing button ng-if expression

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -340,7 +340,7 @@
 ## Float buttons
 <%def name="show_float_buttons(outingUsers, doctype, doc_id, doc_lang, other_langs, missing_langs)">\
   <div class="float-buttons">
-      <div ng-if="::userCtrl.hasEditRights(${outingUsers if outingUsers is not None else '[]'})" class="float-button float-edit"
+      <div ng-if="::userCtrl.hasEditRights(${json.dumps(outingUsers) | n})" class="float-button float-edit"
            tooltip-placement="left" uib-tooltip="{{'Edit' | translate}}"
            protected-url-btn url="${request.route_url(doctype + '_edit', id=doc_id, lang=doc_lang)}">
         <span class="glyphicon glyphicon-edit"></span>


### PR DESCRIPTION
Fix editing button that do not display in routes because empty array evaluate to true.
https://github.com/c2corg/v6_ui/blob/7391fbf804e916fc55cdbb7eba51b3654bb49173/c2corg_ui/static/js/auth/authservice.js#L93

Note that IMHO all python variables passed to javacript part of HTML templates should be escaped with : 
```
${json.dumps(mavar) | n}
```
This pull request has been base on apha2 so it should ported in master after merge.