### PR TITLE
Ignore Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.pyc
 *.egg-info
 *.po~
+Dockerfile


### PR DESCRIPTION
A Dockerfile seems to be generated by some recent change and appears when making a ``git status``. Should it be ignored?