### PR TITLE
Fix i18n duplicates

### DIFF
--- a/c2corg_ui/locale/c2corg_ui-client.pot
+++ b/c2corg_ui/locale/c2corg_ui-client.pot
@@ -95,6 +95,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -109,6 +113,8 @@ msgid "Comment about the changes"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -147,6 +153,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -221,6 +231,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html
 #: c2corg_ui/templates/auth.html
 msgid "Email"
@@ -232,7 +246,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -285,6 +299,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -510,6 +528,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -524,10 +546,6 @@ msgstr ""
 msgid "This field is required."
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
@@ -540,6 +558,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -625,6 +647,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -693,10 +719,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
@@ -730,9 +752,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -746,11 +765,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -829,14 +843,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -872,7 +878,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -880,7 +885,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -891,7 +895,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -902,11 +905,6 @@ msgstr ""
 #: c2corg_ui/templates/helpers/view.html
 #: c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-#: c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -932,10 +930,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -944,7 +938,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -992,10 +985,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
@@ -1019,7 +1008,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -1028,6 +1016,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1184,10 +1173,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
@@ -1212,10 +1197,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1256,7 +1237,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1449,8 +1429,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1551,18 +1539,14 @@ msgid "or try the following pages:"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/outing/edit.html
-#: c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
+#: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1627,9 +1611,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
 #: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
 #: c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
@@ -1648,10 +1629,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1679,13 +1656,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1699,16 +1673,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html
@@ -1758,7 +1727,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/route/filters.html
@@ -1807,10 +1775,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1901,11 +1865,8 @@ msgid "snowshoeing"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
-msgid "soft snow"
-msgstr ""
-
 #: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
+msgid "soft snow"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1930,10 +1891,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -2059,8 +2016,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/ca/LC_MESSAGES/c2corg_ui-client.po
@@ -94,6 +94,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -106,7 +110,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -145,6 +150,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -219,6 +228,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -229,7 +242,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -281,6 +294,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -495,6 +512,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -505,10 +526,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
@@ -522,6 +539,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -604,6 +625,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -670,10 +695,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -704,9 +725,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -720,11 +738,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -803,14 +816,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -845,7 +850,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -853,7 +857,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -864,7 +867,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -874,10 +876,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -902,10 +900,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -914,7 +908,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -961,10 +954,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -986,7 +975,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -995,6 +983,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1143,10 +1132,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1169,10 +1154,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1209,7 +1190,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1394,8 +1374,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1489,17 +1477,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1563,11 +1547,7 @@ msgid "pass"
 msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1585,10 +1565,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1616,13 +1592,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1636,16 +1609,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1690,7 +1658,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1735,10 +1702,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1825,12 +1788,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1853,10 +1812,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1979,8 +1934,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/de/LC_MESSAGES/c2corg_ui-client.po
@@ -95,6 +95,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -107,7 +111,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -146,6 +151,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -220,6 +229,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -230,7 +243,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -282,6 +295,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -496,6 +513,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -506,10 +527,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
@@ -523,6 +540,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -605,6 +626,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -671,10 +696,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -705,9 +726,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -721,11 +739,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -804,14 +817,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -846,7 +851,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -854,7 +858,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -865,7 +868,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -875,10 +877,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -903,10 +901,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -915,7 +909,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -962,10 +955,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -987,7 +976,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -996,6 +984,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1144,10 +1133,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1170,10 +1155,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1210,7 +1191,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1395,8 +1375,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1490,17 +1478,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1564,11 +1548,7 @@ msgid "pass"
 msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1586,10 +1566,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1617,13 +1593,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1637,16 +1610,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1691,7 +1659,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1736,10 +1703,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1826,12 +1789,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1854,10 +1813,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1980,8 +1935,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/en/LC_MESSAGES/c2corg_ui-client.po
@@ -95,6 +95,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -107,7 +111,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr "Comment about the changes"
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -146,6 +151,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -220,6 +229,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -230,7 +243,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -282,6 +295,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -496,6 +513,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -508,10 +529,6 @@ msgstr ""
 msgid "This field is required."
 msgstr "This field is required."
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
-msgstr ""
-
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be a number."
@@ -523,6 +540,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -605,6 +626,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -671,10 +696,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -705,9 +726,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -721,11 +739,6 @@ msgstr ""
 msgid "base_camp"
 msgstr "base_camp"
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr "bergschrund"
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -804,14 +817,6 @@ msgstr "cave"
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr "cliff"
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr "climbing indoor"
@@ -846,7 +851,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -854,7 +858,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -865,7 +868,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -875,10 +877,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -903,10 +901,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr "confluence"
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -915,7 +909,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -962,10 +955,6 @@ msgstr ""
 msgid "description"
 msgstr "Description"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -987,7 +976,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -996,6 +984,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1144,10 +1133,6 @@ msgstr "geometry"
 msgid "gite"
 msgstr "gite"
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr "glacier"
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1170,10 +1155,6 @@ msgstr "green"
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1210,7 +1191,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr "Height difference up"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1395,8 +1375,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1490,17 +1478,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1564,11 +1548,7 @@ msgid "pass"
 msgstr "pass"
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1587,10 +1567,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
-msgstr "pit"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "previous difference"
@@ -1617,13 +1593,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1637,16 +1610,11 @@ msgstr ""
 msgid "raid"
 msgstr "raid"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1691,7 +1659,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1736,10 +1703,6 @@ msgstr "Route types"
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1826,12 +1789,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr "snowshoeing"
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1854,10 +1813,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1981,25 +1936,3 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
 msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
-msgstr ""
-
-#~ msgid "Add a route"
-#~ msgstr "Add a route"
-
-#~ msgid "Add a waypoint"
-#~ msgstr "Add a waypoint"
-
-#~ msgid "Next"
-#~ msgstr "Next"
-
-#~ msgid "Previous"
-#~ msgstr "Previous"
-
-#~ msgid "moutain_biking"
-#~ msgstr "moutain biking"
-
-#~ msgid "Longitude"
-#~ msgstr "Longitude"

--- a/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/es/LC_MESSAGES/c2corg_ui-client.po
@@ -95,6 +95,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -107,7 +111,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -146,6 +151,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -220,6 +229,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -230,7 +243,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -282,6 +295,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -496,6 +513,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -506,10 +527,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
@@ -523,6 +540,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -605,6 +626,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -671,10 +696,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -705,9 +726,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -721,11 +739,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -804,14 +817,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -846,7 +851,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -854,7 +858,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -865,7 +868,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -875,10 +877,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -903,10 +901,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -915,7 +909,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -962,10 +955,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -987,7 +976,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -996,6 +984,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1144,10 +1133,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1170,10 +1155,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1210,7 +1191,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1395,8 +1375,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1490,17 +1478,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1564,11 +1548,7 @@ msgid "pass"
 msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1586,10 +1566,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1617,13 +1593,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1637,16 +1610,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1691,7 +1659,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1736,10 +1703,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1826,12 +1789,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1854,10 +1813,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1980,8 +1935,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/eu/LC_MESSAGES/c2corg_ui-client.po
@@ -94,6 +94,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -106,7 +110,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -145,6 +150,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -219,6 +228,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -229,7 +242,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -281,6 +294,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -495,6 +512,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -505,10 +526,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
@@ -522,6 +539,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -604,6 +625,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -670,10 +695,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -704,9 +725,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -720,11 +738,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -803,14 +816,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -845,7 +850,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -853,7 +857,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -864,7 +867,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -874,10 +876,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -902,10 +900,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -914,7 +908,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -961,10 +954,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -986,7 +975,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -995,6 +983,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1143,10 +1132,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1169,10 +1154,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1209,7 +1190,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1394,8 +1374,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1489,17 +1477,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1563,11 +1547,7 @@ msgid "pass"
 msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1585,10 +1565,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1616,13 +1592,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1636,16 +1609,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1690,7 +1658,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1735,10 +1702,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1825,12 +1788,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1853,10 +1812,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1979,8 +1934,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/fr/LC_MESSAGES/c2corg_ui-client.po
@@ -92,6 +92,10 @@ msgstr "Modifier le mot de passe"
 msgid "Changes"
 msgstr "Modifications"
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr "Veuillez indiquer un ou plusieurs itinéraires empruntés lors de votre sortie"
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -104,7 +108,8 @@ msgstr "Supprimer les filtres"
 msgid "Comment about the changes"
 msgstr "Courte description des changements"
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr "Commentaires"
 
@@ -144,6 +149,10 @@ msgstr "Création d'un itinéraire"
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
 msgstr "Création d'un point de passage"
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
+msgstr ""
 
 #: c2corg_ui/templates/account.html
 msgid "Current password"
@@ -217,6 +226,10 @@ msgstr "Edition d'un itinéraire"
 msgid "Editing a waypoint"
 msgstr "Edition d'un point de passage"
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr "Adresse email"
@@ -227,7 +240,7 @@ msgid "Equipment"
 msgstr "Équipement"
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr "Une erreur est apparue pendant le téléchargement de l'image :"
 
 #: c2corg_ui/templates/i18n.html
@@ -280,6 +293,10 @@ msgstr "Général"
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
 msgstr "Retourner à la page précédente"
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
+msgstr "Déjà inscrit(e) ?"
 
 #: c2corg_ui/templates/helpers/view.html
 msgid "History"
@@ -495,6 +512,10 @@ msgstr "Vitesse d'obturation"
 msgid "Style"
 msgstr "Style"
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr "Itinéraires empruntés"
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr "La page que vous demandez n'existe pas ou est cassée."
@@ -506,10 +527,6 @@ msgstr "La page que vous demandez n'existe pas ou est cassée."
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
 msgstr "Ce champ est obligatoire."
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
-msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
 #: c2corg_ui/templates/waypoint/edit.html
@@ -523,6 +540,10 @@ msgstr "Ce champ doit être compris entre -180° et 180°."
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
 msgstr "Ce champ doit être compris entre -90° and 90°.."
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
+msgstr ""
 
 #: c2corg_ui/templates/auth.html
 msgid "This fielt must be at least 3 characters."
@@ -606,6 +627,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr "Vous n'avez pas les droits pour éditer ce document."
@@ -672,10 +697,6 @@ msgstr "ajouter des images"
 msgid "add row"
 msgstr "ajouter une ligne"
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr "Limites administratives"
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -706,9 +727,6 @@ msgid "aug"
 msgstr "août"
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr "Signe d'avalanche"
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -722,11 +740,6 @@ msgstr "Avalanches observées"
 msgid "base_camp"
 msgstr "camp de base"
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr "rimaye"
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -805,15 +818,6 @@ msgstr "grotte"
 msgid "children_proof"
 msgstr "Adapté aux enfants ?"
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-"Veuillez indiquer un ou plusieurs itinéraires empruntés lors de votre sortie."
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr "falaise"
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr "SAE"
@@ -848,7 +852,6 @@ msgstr "Types de site d'escalade"
 msgid "climbing_rating_max"
 msgstr "Cotation maximale en escalade"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -856,7 +859,6 @@ msgstr "Cotation maximale en escalade"
 msgid "climbing_rating_median"
 msgstr "Cotation moyenne en escalade"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -867,7 +869,6 @@ msgstr "Cotation minimale en escalade"
 msgid "climbing_ratings"
 msgstr "Cotations en escalade"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -878,10 +879,6 @@ msgstr "Styles de grimpe"
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
 msgstr "Commentaire"
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
-msgstr "Commentaires"
 
 #: c2corg_ui/templates/outing/edit.html
 msgid "condition_levels"
@@ -905,10 +902,6 @@ msgstr "Conditions"
 msgid "configuration"
 msgstr "Configuration"
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr "confluent"
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr "Contact"
@@ -917,7 +910,6 @@ msgstr "Contact"
 msgid "content license"
 msgstr "Licences des contenus"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr "Pays"
@@ -964,10 +956,6 @@ msgstr "décembre"
 msgid "description"
 msgstr "Description"
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr "Descriptions"
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -989,7 +977,6 @@ msgstr "Qualité du document"
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr "Durée"
 
@@ -998,6 +985,7 @@ msgstr "Durée"
 msgid "duration_difficulties"
 msgstr "Durée des difficultés"
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1146,10 +1134,6 @@ msgstr "Géométrie"
 msgid "gite"
 msgstr "gite"
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr "glacier"
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1173,10 +1157,6 @@ msgstr "vert"
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
 msgstr "natures du sol"
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
-msgstr "Déjà inscrit(e) ?"
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
@@ -1212,7 +1192,6 @@ msgstr "Dénivelé négatif"
 msgid "height_diff_up"
 msgstr "Dénivelé positif"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1397,9 +1376,17 @@ msgstr "mars"
 msgid "matress_unstaffed"
 msgstr "matelas hors gardiennage"
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
 msgstr "mai"
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
+msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "misc"
@@ -1492,17 +1479,13 @@ msgstr "Période d'ouverture"
 msgid "or try the following pages:"
 msgstr "ou essayez les pages suivantes"
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr "orientation"
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr "orientations"
 
@@ -1566,11 +1549,7 @@ msgid "pass"
 msgstr "col"
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr "Commentaire personnel"
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr "Commentaires personnels"
 
@@ -1589,10 +1568,6 @@ msgstr "Téléphone"
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
 msgstr "téléphone gardien/gérant"
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
-msgstr "gouffre"
 
 #: c2corg_ui/templates/document/diff.html
 msgid "previous difference"
@@ -1619,13 +1594,10 @@ msgid "public_transport"
 msgstr "Transports publics"
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1639,17 +1611,12 @@ msgstr "Transports en commun"
 msgid "raid"
 msgstr "raid"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
 msgstr "pluie"
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
-msgstr "massif"
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
 msgid "ratings"
@@ -1693,7 +1660,6 @@ msgstr "Cotation escalade libre"
 msgid "rock_required_rating"
 msgstr "Cotation obligée"
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1739,10 +1705,6 @@ msgstr "Type d'itinéraire"
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
 msgstr "Quantité des itinéraires"
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
-msgstr "Itinéraires empruntés"
 
 #: c2corg_ui/templates/i18n.html
 msgid "see more results"
@@ -1828,12 +1790,8 @@ msgstr "Cotation raquette"
 msgid "snowshoeing"
 msgstr "Raquette"
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1857,10 +1815,6 @@ msgstr "Cartes Swisstopo"
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
 msgstr "Conditions d'utilisation"
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
-msgstr "Temps"
 
 #: c2corg_ui/templates/outing/edit.html
 msgid "timing"
@@ -1983,31 +1937,3 @@ msgstr "Indiquez ici un résumé"
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
 msgstr "oui"
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
-msgstr ""
-
-#~ msgid "GPS Track"
-#~ msgstr "Tracé GPS"
-
-#~ msgid "No"
-#~ msgstr "Non"
-
-#~ msgid "apply and search"
-#~ msgstr "lancer la recherche"
-
-#~ msgid "close and cancel"
-#~ msgstr "Fermer et annuler"
-
-#~ msgid "height_diff"
-#~ msgstr "Dénivelé"
-
-#~ msgid "more filters"
-#~ msgstr "Plus de filtres"
-
-#~ msgid "lift access"
-#~ msgstr "Accès en remontées mécaniques"
-
-#~ msgid "Cable car"
-#~ msgstr "Remontées mécaniques"

--- a/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
+++ b/c2corg_ui/locale/it/LC_MESSAGES/c2corg_ui-client.po
@@ -95,6 +95,10 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Choose at least one route taken during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -107,7 +111,8 @@ msgstr ""
 msgid "Comment about the changes"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
+#: c2corg_ui/templates/route/edit.html
 msgid "Comments"
 msgstr ""
 
@@ -146,6 +151,10 @@ msgstr ""
 
 #: c2corg_ui/templates/i18n.html
 msgid "Creating a waypoint"
+msgstr ""
+
+#: c2corg_ui/templates/i18n.html
+msgid "Creating an outing"
 msgstr ""
 
 #: c2corg_ui/templates/account.html
@@ -220,6 +229,10 @@ msgstr ""
 msgid "Editing a waypoint"
 msgstr ""
 
+#: c2corg_ui/templates/i18n.html
+msgid "Editing an outing"
+msgstr ""
+
 #: c2corg_ui/templates/account.html c2corg_ui/templates/auth.html
 msgid "Email"
 msgstr ""
@@ -230,7 +243,7 @@ msgid "Equipment"
 msgstr ""
 
 #: c2corg_ui/static/js/imageuploader.js
-msgid "Error while uploading the image :"
+msgid "Error while uploading the image:"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -282,6 +295,10 @@ msgstr ""
 
 #: c2corg_ui/templates/404.html
 msgid "Go to the previous page"
+msgstr ""
+
+#: c2corg_ui/templates/auth.html
+msgid "Have an account?"
 msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html
@@ -496,6 +513,10 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "Taken routes"
+msgstr ""
+
 #: c2corg_ui/templates/404.html
 msgid "The page you are looking for does not exist or is broken."
 msgstr ""
@@ -506,10 +527,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field is required."
-msgstr ""
-
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "This field must be  than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
@@ -523,6 +540,10 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "This field must be between -90° and 90°."
+msgstr ""
+
+#: c2corg_ui/templates/waypoint/edit.html
+msgid "This field must be lower than 9999 m."
 msgstr ""
 
 #: c2corg_ui/templates/auth.html
@@ -605,6 +626,10 @@ msgstr ""
 msgid "You can add geolocation info by typing in the input field."
 msgstr ""
 
+#: c2corg_ui/templates/outing/edit.html
+msgid "You can look up for users that were with you during the outing."
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "You have no rights to edit this document."
 msgstr ""
@@ -671,10 +696,6 @@ msgstr ""
 msgid "add row"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "admin_limits"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "aid_rating"
@@ -705,9 +726,6 @@ msgid "aug"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
-msgid "avalanche_sign"
-msgstr ""
-
 #: c2corg_ui/templates/outing/filters.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
 msgid "avalanche_signs"
@@ -721,11 +739,6 @@ msgstr ""
 msgid "base_camp"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "bergschrund"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -804,14 +817,6 @@ msgstr ""
 msgid "children_proof"
 msgstr ""
 
-#: c2corg_ui/templates/outing/edit.html
-msgid "choose at least one route taken during the outing."
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "cliff"
-msgstr ""
-
 #: c2corg_ui/templates/i18n.html
 msgid "climbing_indoor"
 msgstr ""
@@ -846,7 +851,6 @@ msgstr ""
 msgid "climbing_rating_max"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -854,7 +858,6 @@ msgstr ""
 msgid "climbing_rating_median"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -865,7 +868,6 @@ msgstr ""
 msgid "climbing_ratings"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
@@ -875,10 +877,6 @@ msgstr ""
 
 #: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-msgid "comments"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -903,10 +901,6 @@ msgstr ""
 msgid "configuration"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "confluence"
-msgstr ""
-
 #: c2corg_ui/templates/sidemenu.html
 msgid "contact"
 msgstr ""
@@ -915,7 +909,6 @@ msgstr ""
 msgid "content license"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 msgid "country"
 msgstr ""
@@ -962,10 +955,6 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: c2corg_ui/templates/waypoint/edit.html
-msgid "descriptions"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -987,7 +976,6 @@ msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/outing/helpers/detailed_outings_attributes.html
-#: c2corg_ui/templates/route/create_edit_summary.html
 msgid "duration"
 msgstr ""
 
@@ -996,6 +984,7 @@ msgstr ""
 msgid "duration_difficulties"
 msgstr ""
 
+#: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
 msgid "durations"
@@ -1144,10 +1133,6 @@ msgstr ""
 msgid "gite"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
-msgid "glacier"
-msgstr ""
-
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 msgid "glacier_gear"
@@ -1170,10 +1155,6 @@ msgstr ""
 
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "ground_types"
-msgstr ""
-
-#: c2corg_ui/templates/auth.html
-msgid "have an account ?"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1210,7 +1191,6 @@ msgstr ""
 msgid "height_diff_up"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 msgid "height_max"
@@ -1395,8 +1375,16 @@ msgstr ""
 msgid "matress_unstaffed"
 msgstr ""
 
+#: c2corg_ui/templates/helpers/view.html
+msgid "max"
+msgstr ""
+
 #: c2corg_ui/templates/i18n.html
 msgid "may"
+msgstr ""
+
+#: c2corg_ui/templates/helpers/view.html
+msgid "min"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1490,17 +1478,13 @@ msgstr ""
 msgid "or try the following pages:"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/i18n.html
-#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/route/edit.html
-#: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "orientation"
-msgstr ""
-
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 #: c2corg_ui/templates/route/create_edit_summary.html
-#: c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
+#: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "orientations"
 msgstr ""
 
@@ -1564,11 +1548,7 @@ msgid "pass"
 msgstr ""
 
 #: c2corg_ui/templates/outing/create_edit_summary.html
-#: c2corg_ui/templates/outing/edit.html
-msgid "personal comment"
-msgstr ""
-
-#: c2corg_ui/templates/outing/view.html
+#: c2corg_ui/templates/outing/edit.html c2corg_ui/templates/outing/view.html
 msgid "personal comments"
 msgstr ""
 
@@ -1586,10 +1566,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "phone_custodian"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "pit"
 msgstr ""
 
 #: c2corg_ui/templates/document/diff.html
@@ -1617,13 +1593,10 @@ msgid "public_transport"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
-#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
-msgid "public_transportation_rating"
-msgstr ""
-
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
-msgid "public_transportation_ratings"
+#: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+msgid "public_transportation_rating"
 msgstr ""
 
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -1637,16 +1610,11 @@ msgstr ""
 msgid "raid"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/waypoint/create_edit_summary.html
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "rain_proof"
-msgstr ""
-
-#: c2corg_ui/templates/i18n.html
-msgid "range"
 msgstr ""
 
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/waypoint/edit.html
@@ -1691,7 +1659,6 @@ msgstr ""
 msgid "rock_required_rating"
 msgstr ""
 
-#: c2corg_ui/templates/i18n.html
 #: c2corg_ui/templates/route/create_edit_summary.html
 #: c2corg_ui/templates/route/edit.html c2corg_ui/templates/route/filters.html
 #: c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -1736,10 +1703,6 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/filters.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "routes_quantity"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "routes_taken"
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html
@@ -1826,12 +1789,8 @@ msgstr ""
 msgid "snowshoeing"
 msgstr ""
 
-#: c2corg_ui/templates/helpers/view.html
+#: c2corg_ui/templates/helpers/view.html c2corg_ui/templates/outing/edit.html
 msgid "soft snow"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "soft snow ("
 msgstr ""
 
 #: c2corg_ui/templates/i18n.html c2corg_ui/templates/outing/edit.html
@@ -1854,10 +1813,6 @@ msgstr ""
 
 #: c2corg_ui/templates/sidemenu.html
 msgid "terms of use"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "time"
 msgstr ""
 
 #: c2corg_ui/templates/outing/edit.html
@@ -1980,8 +1935,4 @@ msgstr ""
 #: c2corg_ui/templates/waypoint/edit.html
 #: c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
 msgid "yes"
-msgstr ""
-
-#: c2corg_ui/templates/outing/edit.html
-msgid "you can look up for users that were with you during the outing."
 msgstr ""

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -239,10 +239,10 @@ app.ImageUploaderController.prototype.uploadFile_ = function(file) {
   }.bind(this), function(resp) {
     if (resp.status == -1) {
       if (!file['manuallyAborted']) {
-        this.alerts_.addError(this.alerts_.gettext('Error while uploading the image : ') + 'Timeout');
+        this.alerts_.addError(this.alerts_.gettext('Error while uploading the image:') + ' Timeout');
       }
     } else {
-      this.alerts_.addError(this.alerts_.gettext('Error while uploading the image : ') + resp.statusText);
+      this.alerts_.addError(this.alerts_.gettext('Error while uploading the image:') + ' ' + resp.statusText);
     }
     this.deleteImage(this.files.indexOf(file));
   }.bind(this));

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -109,7 +109,7 @@ from pyramid.settings import asbool
                 ng-click="authCtrl.uiStates.showLoginForm = true;
                                    authCtrl.uiStates.showRegisterForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
-                                   authCtrl.uiStates.showRequestChangePasswordForm = false;" translate>have an account ?
+                                   authCtrl.uiStates.showRequestChangePasswordForm = false;" translate>Have an account?
         </button>
       </p>
     </div>
@@ -135,7 +135,7 @@ from pyramid.settings import asbool
                 ng-click="authCtrl.uiStates.showLoginForm = true;
                                    authCtrl.uiStates.showRegisterForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
-                                   authCtrl.uiStates.showRequestChangePasswordForm = false;" translate>have an account ?
+                                   authCtrl.uiStates.showRequestChangePasswordForm = false;" translate>Have an account?
         </button>
         
         <button type="button" class="btn orange-btn" 

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -270,7 +270,7 @@
                   <tr>
                     <th class="location"><span translate>location</span> |
                       <span translate>altitude</span> |
-                      <span translate>orientation</span>
+                      <span translate>orientations</span>
                     </th>
                     <th class="soft-snow" translate>soft snow</th>
                     <th class="total-snow" translate>total snow</th>

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -28,13 +28,8 @@
 <span translate>lake</span>
 <span translate>bisse</span>
 <span translate>waterfall</span>
-<span translate>cliff</span>
 <span translate>cave</span>
-<span translate>pit</span>
 <span translate>locality</span>
-<span translate>confluence</span>
-<span translate>glacier</span>
-<span translate>bergschrund</span>
 <span translate>waterpoint</span>
 <span translate>climbing_outdoor</span>
 <span translate>climbing_indoor</span>
@@ -88,24 +83,20 @@
 <span translate>Editing a route</span>
 <span translate>Creating a waypoint</span>
 <span translate>Editing a waypoint</span> 
+<span translate>Creating an outing</span>
+<span translate>Editing an outing</span>
 
 ## home
 <span translate>Home</span>
 
 ## waypoint attributes
-<span translate>rain_proof</span>
 <span translate>very_safe</span>
 <span translate>exposed</span>
-<span translate>rock_types</span>
-<span translate>best_periods</span>
-<span translate>climbing_styles</span>
-<span translate>orientation</span>
-<span translate>height_max</span>
-<span translate>climbing_rating_min</span>
-<span translate>climbing_rating_median</span>
-<span translate>admin_limits</span>
-<span translate>country</span>
-<span translate>range</span>
+<span translate>bus</span>
+<span translate>train</span>
+<span translate>service_on_demand</span>
+<span translate>cable_car</span>
+<span translate>boat</span>
 
 ## months
 <span translate>jan</span>
@@ -120,12 +111,6 @@
 <span translate>nov</span>
 <span translate>oct</span>
 <span translate>dec</span>
-
-<span translate>bus</span>
-<span translate>train</span>
-<span translate>service_on_demand</span>
-<span translate>cable_car</span>
-<span translate>boat</span>
 
 <span translate>see more results</span>
 

--- a/c2corg_ui/templates/outing/create_edit_summary.html
+++ b/c2corg_ui/templates/outing/create_edit_summary.html
@@ -30,7 +30,7 @@
 ## DESCRIPTION
 <figure class="summary-description">
   <h3>text</h3>
-  <label translate>personal comment</label>
+  <label translate>personal comments</label>
   <textarea class="form-control">{{outing.locales[0].description}}</textarea>
   
   <label translate>conditions</label>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -1,5 +1,5 @@
 <%!
-from c2corg_common.attributes import default_langs, activities, condition_ratings, awesomeness, quality_types, hut_status, lift_status, frequentation_types, avalanche_signs,  route_duration_types, access_conditions, glacier_ratings
+from c2corg_common.attributes import default_langs, activities, condition_ratings, awesomeness, quality_types, hut_status, lift_status, frequentation_types, avalanche_signs, route_duration_types, access_conditions, glacier_ratings
 %>
 
 <%inherit file="../base.html"/>
@@ -75,14 +75,14 @@ updating_doc = outing_id and outing_lang
 
             ## ROUTE TAKEN
             <div class=" full" class="form-group">
-              <label><span translate>routes_taken</span> *</label>
+              <label><span translate>Taken routes</span> *</label>
               <app-simple-search parent-id="outing.document_id"
                 app-select="editCtrl.documentService.pushToAssociations(doc, 'routes', true)" dataset="r"></app-simple-search>
             </div>
 
             <section class="section associations">
               <div class="route-associations">
-                <h5 translate ng-show="outing.associations.routes.length == 0">choose at least one route taken during the outing.</h5>
+                <h5 translate ng-show="outing.associations.routes.length == 0">Choose at least one route taken during the outing.</h5>
                 ${show_editing_associated_routes('outing')}
               </div>
             </section>
@@ -270,8 +270,8 @@ updating_doc = outing_id and outing_lang
               <table class="table table-striped conditions-levels" ng-if="outing.locales[0].conditions_levels[0]">
                 <thead>
                   <tr>
-                    <th class="location"><span translate>location</span> / <span translate>altitude</span> / <span translate>orientation</span></th>
-                    <th class="soft-snow"><span translate>soft snow (</span>cm)</th>
+                    <th class="location"><span translate>location</span> / <span translate>altitude</span> / <span translate>orientations</span></th>
+                    <th class="soft-snow"><span translate>soft snow</span> (cm)</th>
                     <th class="total-snow"><span translate>total snow</span> (cm)</th>
                     <th class="comment" translate>comment</th>
                     <th class="delete"></th>
@@ -369,19 +369,19 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## AVALANCHE SIGNS
-            <div class="form-group half" ng-class="{'has-success': outing.avalanche_sign}"
+            <div class="form-group half" ng-class="{'has-success': outing.avalanche_signs}"
                   ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1">
-              <label translate>avalanche_sign</label>
+              <label translate>avalanche_signs</label>
               <div class="input-group">
-                <select class="form-control" ng-model="outing.avalanche_sign" ng-options="rat as rat for rat in ${avalanche_signs}"><option value=""></option></select>
+                <select class="form-control" ng-model="outing.avalanche_signs" ng-options="rat as rat for rat in ${avalanche_signs}"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon glyphicon-alert"></span></span>
               </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.avalanche_sign"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.avalanche_signs"></span>
             </div>
 
             ## AVALANCHES
             <div class="form-group  full"  ng-if="(outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1
-                      || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1) && (outing.avalanche_sign != 'no' && outing.avalanche_sign != null) ">
+                      || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1) && (outing.avalanche_signs != 'no' && outing.avalanche_signs != null) ">
               <label translate>avalanches_info</label>
               <textarea class="form-control" ng-model="outing.locales[0]['avalanches']"></textarea>
             </div>
@@ -475,7 +475,7 @@ updating_doc = outing_id and outing_lang
 
       <div class="step step-3">
         <section class="section">
-          <h2 class="heading show-phone"><span translate>comments</span></h2>
+          <h2 class="heading show-phone"><span translate>Comments</span></h2>
           <div class="content collapse in">
 
             ## TITLE
@@ -504,7 +504,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## ASSOCIATED PARTICIPANTS
-            ## todo: better to show all users in one row, will have to convert users in controller.
+            ## TODO better to show all users in one row, will have to convert users in controller.
             <div id="participants-group" class="form-group  full" ng-class="{'has-success': outing.locales[0]['participants']}">
               <app-simple-search parent-id="outing.document_id"
                 app-select="editCtrl.documentService.pushToAssociations(doc)" dataset="u"></app-simple-search>
@@ -513,7 +513,7 @@ updating_doc = outing_id and outing_lang
 
                 <section class="associated-section">
                   <article class="associated-documents">
-                    <h5 translate ng-show="outing.associations.users.length == 0">you can look up for users that were with you during the outing.</h5>
+                    <h5 translate ng-show="outing.associations.users.length == 0">You can look up for users that were with you during the outing.</h5>
                     <div class="list-item outings user-id-{{user.document_id}}" ng-repeat="user in outing.associations.users">
                       <a>
                         <div class="outing-author text-center">
@@ -551,8 +551,8 @@ updating_doc = outing_id and outing_lang
 
             ## COMMENT
             <div class=" full form-group">
-              <label translate>personal comment</label>
-              <textarea class="form-control description" placeholder="{{mainCtrl.translate('write your comment')}}" ng-model="outing.locales[0]['description']"></textarea>
+              <label translate>personal comments</label>
+              <textarea class="form-control description" placeholder="{{mainCtrl.translate('write your comments')}}" ng-model="outing.locales[0]['description']"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/route/create_edit_summary.html
+++ b/c2corg_ui/templates/route/create_edit_summary.html
@@ -13,9 +13,9 @@
     <input disabled class="form-control" value="{{mainCtrl.translate(route.locales[0].lang)}}">
   </article>
 
-  <article ng-if="route.duration">
-    <label translate>duration</label>
-    <input disabled class="form-control" value="route.duration">
+  <article ng-if="route.durations">
+    <label translate>durations</label>
+    <input disabled class="form-control" value="route.durations">
   </article>
 
   <article ng-if="route.activities.length > 0">
@@ -25,10 +25,10 @@
     </ul>
   </article>
 
-  <article ng-if="route.orientation.length > 0">
+  <article ng-if="route.orientations.length > 0">
     <label translate>orientations</label><br>
     <ul class="types">
-      <li ng-repeat="type in route['orientation']" x-translate>{{type}}</li>
+      <li ng-repeat="type in route['orientations']" x-translate>{{type}}</li>
     </ul>
   </article>
 

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -37,7 +37,7 @@ updating_doc = route_id and route_lang
       <ul class="progress-bar-edit">
         <li class="nav-step-1" ng-click="progressBarCtrl.step(1, 'route',  'backwards')" ng-class="{'nav-step-selected': progressBarCtrl.currentStep == 1 }"><span class="nav-text"><span translate>route</span> & <span translate>associations</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-2" ng-click="progressBarCtrl.step(2, 'route', progressBarCtrl.previousStep >= 2 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>figures</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
-        <li class="nav-step-3" ng-click="progressBarCtrl.step(3, 'route', progressBarCtrl.previousStep >= 3 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>comments</span></span></span><span class="bullet-container"><span class="bullet"></span></span></li>
+        <li class="nav-step-3" ng-click="progressBarCtrl.step(3, 'route', progressBarCtrl.previousStep >= 3 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>Comments</span></span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-4" ng-click="progressBarCtrl.step(4, 'route',  'forwards')"><span translate class="nav-text">review</span><span class="bullet-container"><span class="bullet"></span></span></li>
       </ul>
 
@@ -144,7 +144,7 @@ updating_doc = route_id and route_lang
 
             ## ORIENTATION
             <div class="form-group data half">
-              <label><span translate>orientation</span></label>
+              <label><span translate>orientations</span></label>
               ${show_orientations('editCtrl', 'route')}
             </div>
 
@@ -596,7 +596,7 @@ updating_doc = route_id and route_lang
 
       <div class="step step-3">
         <section class="section">
-          <h2 class="heading show-phone" translate>comments</h2>
+          <h2 class="heading show-phone" translate>Comments</h2>
           <div class="content" id="title-edit">
 
             ## SUMMARY

--- a/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
+++ b/c2corg_ui/templates/route/helpers/detailed_route_attributes.html
@@ -91,7 +91,7 @@
 % if route.get('global_rating') or route.get('engagement_rating') or route.get('risk_rating') or route.get('exposition_rock_rating') \
   or route.get('rock_free_rating') or route.get('rock_required_rating') or route.get('hiking_rating') \
   or route.get('hiking_mtb_exposition') or route.get('ice_rating') or route.get('mixed_rating') or route.get('snowshoe_rating')  \
-  or route.get('mtb_down_rating') or route.get('mtb_up_rating') or route.get('via_ferrata_rating') or route.get('equipment_ratings') \
+  or route.get('mtb_down_rating') or route.get('mtb_up_rating') or route.get('via_ferrata_rating') or route.get('equipment_rating') \
   or route.get('ski_rating') or route.get('labande_ski_rating') or route.get('labande_global_rating') or route.get('ski_exposition') :
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Rating</span><span class="glyphicon glyphicon-menu-right"></span></h4>

--- a/c2corg_ui/templates/waypoint/create_edit_summary.html
+++ b/c2corg_ui/templates/waypoint/create_edit_summary.html
@@ -14,7 +14,7 @@
     <p class="text-danger" translate ng-if="!waypoint.locales[0].lang">This field is required.</p>
   </p>
   <p ng-if="waypoint.waypoint_type == 'paragliding_takeoff' || waypoint.waypoint_type == 'paragliding_landing' || waypoint.waypoint_type == 'climbing_outdoor'">
-    <label translate>orientation</label>{{waypoint.orientation}}</p>
+    <label translate>orientations</label>{{waypoint.orientations}}</p>
   <p ng-if="waypoint.areas[0].locales[0].title"><label translate>country</label>{{waypoint.areas[0].locales[0].title}}</p>
   <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>children_proof</label>{{waypoint.children_proof}}</p>
   <p ng-if="waypoint.waypoint_type == 'climbing_outdoor'"><label translate>rain_proof</label>{{waypoint.rain_proof}}</p>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -51,7 +51,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
           <span class="nav-text"><span translate>figures</span></span><span class="bullet-container"><span class="bullet"></span></span>
         </li>
         <li class="nav-step-{{progressBarCtrl.maxSteps -1}}" ng-click="progressBarCtrl.step((progressBarCtrl.maxSteps == 4 ? 3 : 2), 'waypoint',  progressBarCtrl.previousStep >= ((progressBarCtrl.maxSteps == 4) ? 3 : 2) ? 'backwards' : 'forwards')" >
-          <span class="nav-text"><span ng-if="type != 'climbing_indoor' "><span translate>associations</span> & </span><span translate>descriptions</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
+          <span class="nav-text"><span ng-if="type != 'climbing_indoor' "><span translate>associations</span> & </span><span translate>description</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
         </li>
         <li class="nav-step-{{progressBarCtrl.maxSteps}}" ng-click="progressBarCtrl.step(progressBarCtrl.maxSteps, 'forwards')"><span translate class="nav-text">review</span>
           <span class="bullet-container"><span class="bullet"></span></span>
@@ -133,7 +133,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && editForm.elevation.$touched"></span>
               <div class="help-block" ng-messages="editForm.elevation.$error">
                 <p ng-message="required" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="max" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be  than 9999 m.</p>
+                <p ng-message="max" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be lower than 9999 m.</p>
                 <p ng-message="number" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
               </div>
             </div>
@@ -149,7 +149,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$invalid && editForm.elevation_min.$touched"></span>
               <div class="help-block" ng-messages="editForm.elevation_min.$error">
                 <p ng-message="required" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="max" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be  than 9999 m.</p>
+                <p ng-message="max" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be lower than 9999 m.</p>
                 <p ng-message="number" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
               </div>
             </div>
@@ -579,7 +579,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## PUBLIC TRANSPORT RATINGS
             <div class="form-group data half" ng-if="type == 'access' " ng-class="{'has-success': waypoint.public_transportation_rating}">
-              <label translate>public_transportation_ratings</label>
+              <label translate>public_transportation_rating</label>
               <div class="input-group">
                 <select class="form-control" ng-options="rat as mainCtrl.translate(rat) for rat in ${public_transportation_ratings}" ng-model="waypoint.public_transportation_rating"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
@@ -715,7 +715,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
         </section>
 
         <section class="section">
-          <h2 class="heading show-phone" translate>descriptions</h2>
+          <h2 class="heading show-phone" translate>description</h2>
           <div class="content">
 
             ## SUMMARY

--- a/c2corg_ui/templates/waypoint/filters.html
+++ b/c2corg_ui/templates/waypoint/filters.html
@@ -145,7 +145,7 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
         </div>
 
         <div class="filter col-xs-12 col-sm-6">
-          <label translate>public_transportation_ratings</label><br>
+          <label translate>public_transportation_rating</label><br>
           ${add_multiselect('tp', public_transportation_ratings)}
         </div>
 

--- a/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+++ b/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -36,7 +36,7 @@
 
     % if waypoint.get('orientations'):
       <p>
-        <span translate>orientation</span>:
+        <span translate>orientations</span>:
        ${', '.join(waypoint['orientations'])}
       </p>
     % endif
@@ -384,10 +384,10 @@
 <%def name="get_waypoint_orientation(waypoint)">\
   % if waypoint.get('orientations') :
     <div class="name-icon-value orientation" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>orientation</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <h4><span translate>orientations</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">
         <span class="glyphicon glyphicon-move"></span>
-        <p translate>orientation</p>
+        <p translate>orientations</p>
       </div>
       <span class="detail-text accordion" id="detail-orientation">
         ${show_orientations('detailsCtrl', 'detailsCtrl.documentService.document')}


### PR DESCRIPTION
Fixes #392 

I have noticed typos (missing or extra "s") for some attributes. For instance ``avalanche_sign`` instead of ``avalanche_signs``. Or ``orientation`` instead of ``orientations``. Please note that some attributes are almost homonyms, for instance ``duration`` for outings vs ``durations`` for routes.
I have then made changes in the editing forms. @ginold could you please double check/test that my changes are OK?