### PR TITLE
Move geolocation button near the geonames service in maps

### DIFF
--- a/c2corg_ui/static/partials/map/map.html
+++ b/c2corg_ui/static/partials/map/map.html
@@ -1,6 +1,6 @@
 <div class="map" ngeo-map="::mapCtrl.map">
   <app-baselayer-selector app-baselayer-selector-map="::mapCtrl.map"></app-baselayer-selector>
-  <div ng-show="::mapCtrl.showRecenterTools">
+  <div class="map-recenter-tools" ng-show="::mapCtrl.showRecenterTools">
     <app-geolocation app-geolocation-map="::mapCtrl.map"></app-geolocation>
     <app-map-search app-map-search-map="::mapCtrl.map"></app-map-search>
   </div>

--- a/less/map.less
+++ b/less/map.less
@@ -21,18 +21,14 @@ app-baselayer-selector {
   z-index: 2;
 }
 
-app-geolocation {
-  position: absolute;
-  bottom: 10px;
-  left: 100px;
-  z-index: 2;
-}
-
-app-map-search {
+.map-recenter-tools {
   position: absolute;
   top: 50px;
   left: 50px;
   z-index: 2;
+}
+
+app-map-search {
   background-color: white;
 
   .tt-menu {


### PR DESCRIPTION
As for now the geolocation button was in the left bottom corner of maps (next to the baselayer selector) whereas the geonames recentering input was at the top of the map.
This PR groups both recentering tools in the top left corner.