### PR TITLE
Fix templatecache issue in debug mode

### DIFF
--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -15,7 +15,8 @@ goog.require('app.utils');
  */
 app.cardDirective = function($compile, $templateCache) {
   var template = function(doctype) {
-    return $templateCache.get('/static/partials/cards/' + doctype + '.html');
+    var path = '/static/partials/cards/' + doctype + '.html';
+    return app.utils.getTemplate(path, $templateCache);
   };
 
   return {

--- a/c2corg_ui/static/js/search/suggestion.js
+++ b/c2corg_ui/static/js/search/suggestion.js
@@ -1,5 +1,8 @@
 goog.provide('app.suggestionDirective');
 
+goog.require('app.utils');
+
+
 /**
  * @param {angular.$compile} $compile Angular compile service.
  * @param {angular.$sce} $sce Angular Strict Contextual Escaping service.
@@ -9,7 +12,8 @@ goog.provide('app.suggestionDirective');
  */
 app.suggestionDirective = function($compile, $sce, $templateCache) {
   var template = function(doctype) {
-    return $templateCache.get('/static/partials/suggestions/' + doctype + '.html');
+    var path = '/static/partials/suggestions/' + doctype + '.html';
+    return app.utils.getTemplate(path, $templateCache);
   };
 
   return {
@@ -18,7 +22,9 @@ app.suggestionDirective = function($compile, $sce, $templateCache) {
     link: function(scope, element) {
       scope.highlight = function(text, search) {
         if (search) { // i = case insensitive
-          return $sce.trustAsHtml(text.replace(new RegExp(search, 'ig'), '<span class="tt-highlight">$&</span>'));
+          return $sce.trustAsHtml(text.replace(
+            new RegExp(search, 'ig'),
+            '<span class="tt-highlight">$&</span>'));
         }
         return $sce.trustAsHtml(text);
       };

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -176,6 +176,7 @@ app.utils.createImageSlide = function(file, imageUrl) {
              '</figure>';
 };
 
+
 /**
  * http://openlayers.org/en/latest/examples/vector-labels.html
  * http://stackoverflow.com/questions/14484787/wrap-text-in-javascript
@@ -202,4 +203,22 @@ app.utils.stringDivider = function(str, width, spaceReplacer) {
     }
   }
   return str;
+};
+
+
+/**
+ * @param {string} path Path of the partial.
+ * @param {angular.$templateCache} $templateCache service
+ * @return {string}
+ */
+app.utils.getTemplate = function(path, $templateCache) {
+  var tpl = $templateCache.get(path);
+  if (goog.DEBUG && !tpl) {
+    var req = new XMLHttpRequest();
+    req.open('GET', path, false /* synchronous */);
+    req.send(null);
+    tpl = req.status === 200 ? req.responseText : 'Partial not found';
+    $templateCache.put(path, tpl);
+  }
+  return tpl;
 };


### PR DESCRIPTION
With the precious help of @sbrunner

A synchronous request is made in debug mode to get the partial in the link function. The browser complains synchronous requests are evil:
> Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.

but it's only in debug mode. Prod mode stays (almost) the same.

Fixes #369 

Fixes both the cards and the simple search (suggestions) in debug mode.