### PR TITLE
Recenter map when searching using a doc id

### DIFF
--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -321,7 +321,10 @@ app.MapController.DEFAULT_POINT_ZOOM = 12;
  */
 app.MapController.prototype.recenterOnExtent_ = function(extent, options) {
   var mapSize = this.map.getSize();
-  if (mapSize) {
+  if (!mapSize || !ol.extent.getWidth(extent) || !ol.extent.getHeight(extent)) {
+    this.view_.setCenter(ol.extent.getCenter(extent));
+    this.view_.setZoom(this.zoom || app.MapController.DEFAULT_POINT_ZOOM);
+  } else {
     options = options || {};
     this.view_.fit(extent, mapSize, options);
   }
@@ -488,17 +491,9 @@ app.MapController.prototype.showFeatures_ = function(features, recenter) {
 
   source.addFeatures(features);
   if (recenter) {
-    if (features.length == 1 &&
-        features[0].getGeometry() instanceof ol.geom.Point) {
-      var point = /** @type {ol.geom.Point} */ (features[0].getGeometry());
-      this.view_.setCenter(point.getCoordinates());
-      this.view_.setZoom(this.zoom || app.MapController.DEFAULT_POINT_ZOOM);
-    } else {
-      this.recenterOnExtent_(
-        vectorLayer.getSource().getExtent(), {
-          padding: [10, 10, 10, 10]
-        });
-    }
+    this.recenterOnExtent_(source.getExtent(), {
+      padding: [10, 10, 10, 10]
+    });
   }
 };
 

--- a/c2corg_ui/static/js/search/pagination.js
+++ b/c2corg_ui/static/js/search/pagination.js
@@ -74,10 +74,11 @@ app.PaginationController = function($scope, ngeoLocation) {
  * @param {Object} event
  * @param {Array.<ol.Feature>} features Search results features.
  * @param {number} total Total number of results.
+ * @param {boolean} recenter
  * @private
  */
 app.PaginationController.prototype.handleSearchChange_ = function(event,
-    features, total) {
+    features, total, recenter) {
   this.total = total;
   this.offset = this.location_.getParamAsInt('offset') || 0;
 };

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -222,3 +222,18 @@ app.utils.getTemplate = function(path, $templateCache) {
   }
   return tpl;
 };
+
+
+/**
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @return {boolean}
+ */
+app.utils.detectDocumentIdFilter = function(ngeoLocation) {
+  var associatedDocTypes = ['w', 'r'];
+  for (var i = 0, n = associatedDocTypes.length; i < n; i++) {
+    if (ngeoLocation.hasParam(associatedDocTypes[i])) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -223,9 +223,8 @@ main {
 
 #pagination {
   position: absolute;
-  right: 0;
+  right: 20px;
   padding: 0;
-  margin-top: 5px;
 
   @media (max-width: @screen-sm-min) {
     position: relative;


### PR DESCRIPTION
When searching using a document id (eg. ``/routes?w=37355``), the initial map extent should not be taken into account unless explicitely provided via a ``bbox`` parameter and the map should be recentered on the search results.

Map extent changes resulting from zooming/panning are then taken into account as filter as usual. Ditto if the initial page URL contains a ``bbox`` param => the map extent is taken into account as filter as usual and no recentering on results is performed.

Fixes https://github.com/c2corg/v6_ui/issues/471