### PR TITLE
Cache pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 
 services:
 - docker
+- redis-server
 
 python:
 - 3.4

--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -1,11 +1,13 @@
 import requests
 from pyramid.config import Configurator
-from pyramid_mako import add_mako_renderer
-from c2corg_ui.lib.cacheversion import version_cache_buster, CACHE_PATH
 from pyramid.httpexceptions import (
     HTTPBadRequest, HTTPInternalServerError)
-from pyramid.view import view_config
 from pyramid.view import notfound_view_config
+from pyramid.view import view_config
+from pyramid_mako import add_mako_renderer
+
+from c2corg_ui.caching import configure_caches
+from c2corg_ui.caching.cacheversion import version_cache_buster, CACHE_PATH
 
 
 def main(global_config, **settings):
@@ -14,6 +16,9 @@ def main(global_config, **settings):
     """
     config = Configurator(settings=settings)
     add_mako_renderer(config, '.html')
+
+    # set up redis cache
+    configure_caches(settings)
 
     # configure connection pool for http requests
     max_connections = int(settings.get('http_request_connection_pool_size'))
@@ -27,7 +32,7 @@ def main(global_config, **settings):
     http_requests.session.mount('http://', adapter)
 
     # Register a tween to get back the cache buster path.
-    config.add_tween("c2corg_ui.lib.cacheversion.CachebusterTween")
+    config.add_tween("c2corg_ui.caching.cacheversion.CachebusterTween")
 
     _add_static_view(config, 'static', 'c2corg_ui:static')
     config.add_static_view('node_modules', settings.get('node_modules_path'),

--- a/c2corg_ui/caching/__init__.py
+++ b/c2corg_ui/caching/__init__.py
@@ -22,10 +22,12 @@ def create_region(name):
 
 cache_document_detail = create_region('detail')
 cache_document_archive = create_region('archive')
+cache_document_history = create_region('history')
 
 caches = [
     cache_document_detail,
-    cache_document_archive
+    cache_document_archive,
+    cache_document_history
 ]
 
 

--- a/c2corg_ui/caching/__init__.py
+++ b/c2corg_ui/caching/__init__.py
@@ -1,0 +1,70 @@
+import logging
+
+import time
+from dogpile.cache import make_region
+from redis.connection import BlockingConnectionPool
+
+log = logging.getLogger(__name__)
+
+# prefix for all cache keys
+KEY_PREFIX = 'c2corg_ui'
+
+# cache version (for production the current git revisions, for development
+# the git revision and a timestamp).
+CACHE_VERSION = None
+
+
+def create_region(name):
+    return make_region(
+        # prefix all keys (e.g. returns 'c2corg_ui_main:detail:3575-1-c796286')
+        key_mangler=lambda key: '{0}:{1}:{2}'.format(KEY_PREFIX, name, key)
+    )
+
+cache_document_detail = create_region('detail')
+cache_document_archive = create_region('archive')
+
+caches = [
+    cache_document_detail,
+    cache_document_archive
+]
+
+
+def configure_caches(settings):
+    global KEY_PREFIX
+    global CACHE_VERSION
+    KEY_PREFIX = settings['redis.cache_key_prefix']
+
+    # append a timestamp to the cache key when running in dev. mode
+    # (to make sure that the cache values are invalidated when the dev.
+    # server reloads when the code changes)
+    cache_version = settings['cache_version']
+    if settings['cache_version_timestamp'] == 'True':
+        cache_version = '{0}-{1}'.format(cache_version, int(time.time()))
+    CACHE_VERSION = cache_version
+
+    log.debug('Cache version {0}'.format(CACHE_VERSION))
+    log.debug('Cache Redis: {0}'.format(settings['redis.url']))
+
+    redis_pool = BlockingConnectionPool.from_url(
+        settings['redis.url'],
+        max_connections=int(settings['redis.cache_pool']),
+        timeout=3,  # 3 seconds (waiting for connection)
+        socket_timeout=3  # 3 seconds (timeout on open socket)
+    )
+
+    for cache in caches:
+        cache.configure(
+            'dogpile.cache.redis',
+            arguments={
+                'connection_pool': redis_pool,
+                'distributed_lock': True,
+                'lock_timeout': 5  # 5 seconds (dogpile lock)
+            },
+            replace_existing_backend=True
+        )
+
+
+class CachedPage(object):
+    def __init__(self, api_cache_key, page_html):
+        self.api_cache_key = api_cache_key
+        self.page_html = page_html

--- a/c2corg_ui/caching/__init__.py
+++ b/c2corg_ui/caching/__init__.py
@@ -24,12 +24,14 @@ cache_document_detail = create_region('detail')
 cache_document_archive = create_region('archive')
 cache_document_history = create_region('history')
 cache_document_diff = create_region('diff')
+cache_static_pages = create_region('pages')
 
 caches = [
     cache_document_detail,
     cache_document_archive,
     cache_document_history,
-    cache_document_diff
+    cache_document_diff,
+    cache_static_pages
 ]
 
 

--- a/c2corg_ui/caching/__init__.py
+++ b/c2corg_ui/caching/__init__.py
@@ -23,11 +23,13 @@ def create_region(name):
 cache_document_detail = create_region('detail')
 cache_document_archive = create_region('archive')
 cache_document_history = create_region('history')
+cache_document_diff = create_region('diff')
 
 caches = [
     cache_document_detail,
     cache_document_archive,
-    cache_document_history
+    cache_document_history,
+    cache_document_diff
 ]
 
 

--- a/c2corg_ui/caching/cacheversion.py
+++ b/c2corg_ui/caching/cacheversion.py
@@ -30,6 +30,10 @@ class CachebusterTween:
     @staticmethod
     def is_git_hash(str):
         # 592d5db = git rev-parse --short HEAD
+        if '-' in str:
+            # when in dev. mode, the cache key is appended
+            # with a timestamp, e.g. "592d5db-123456789"
+            str = str.split('-')[0]
         return len(str) == 7 and CachebusterTween.is_hexa(str)
 
     def __call__(self, request):

--- a/c2corg_ui/tests/views/__init__.py
+++ b/c2corg_ui/tests/views/__init__.py
@@ -1,4 +1,4 @@
-from c2corg_ui.tests import BaseTestCase, settings
+from c2corg_ui.tests import BaseTestCase, settings, read_file
 from pyramid import testing
 
 
@@ -49,3 +49,22 @@ class BaseTestUi(BaseTestCase):
         self.assertEqual(isinstance(total, int), True)
         self.assertEqual(isinstance(documents, list), True)
         self.assertEqual(isinstance(params, dict), True)
+
+
+def handle_mock_request(request, file, etag):
+    if request.headers.get('If-None-Match') == etag:
+        return {
+            'status_code': 304,
+            'headers': {
+                'ETag': etag
+            }
+        }
+    else:
+        return {
+            'status_code': 200,
+            'headers': {
+                'Content-Type': 'application/json; charset = UTF-8',
+                'ETag': etag
+            },
+            'content': read_file(file)
+        }

--- a/c2corg_ui/tests/views/__init__.py
+++ b/c2corg_ui/tests/views/__init__.py
@@ -36,7 +36,7 @@ class BaseTestUi(BaseTestCase):
 
     def _test_api_call(self):
         resp, content = self.view._call_api(self._prefix)
-        self.assertEqual(resp['status'], '200')
+        self.assertEqual(resp.status_code, 200)
         self.assertTrue('total' in content)
         self.assertTrue('documents' in content)
         total = content['total']

--- a/c2corg_ui/tests/views/data/outing.json
+++ b/c2corg_ui/tests/views/data/outing.json
@@ -1,0 +1,126 @@
+{
+	"elevation_max": 775,
+	"quality": "medium",
+	"public_transport": null,
+	"type": "o",
+	"participant_count": null,
+	"hut_status": null,
+	"length_total": 2600,
+	"height_diff_down": 140,
+	"date_start": "2016-03-20",
+	"partial_trip": true,
+	"areas": [{
+		"protected": false,
+		"locales": [{
+			"title": "Suisse",
+			"version": 1,
+			"lang": "fr"
+		}],
+		"version": 8,
+		"available_langs": null,
+		"document_id": 14067,
+		"type": "a",
+		"area_type": "country"
+	}, {
+		"protected": false,
+		"locales": [{
+			"title": "Vaud",
+			"version": 1,
+			"lang": "fr"
+		}],
+		"version": 1,
+		"available_langs": null,
+		"document_id": 14397,
+		"type": "a",
+		"area_type": "admin_limits"
+	}],
+	"protected": false,
+	"duration": null,
+	"date_end": "2016-03-20",
+	"available_langs": ["fr"],
+	"geometry": {
+		"geom_detail": null,
+		"version": 1,
+		"geom": "{\"coordinates\": [716464.6363154836, 5896270.4462415995], \"type\": \"Point\"}"
+	},
+	"height_diff_up": 140,
+	"elevation_access": 775,
+	"elevation_min": null,
+	"activities": ["hiking"],
+	"condition_rating": "good",
+	"locales": [{
+		"title": "Saut du Day",
+		"hut_comment": null,
+		"access_comment": null,
+		"description": "...",
+		"lang": "fr",
+		"timing": "11h-14h30",
+		"summary": null,
+		"conditions": "Sentiers un peu humides par endroits.",
+		"participants": "Andr\u00e9e",
+		"version": 3,
+		"conditions_levels": null,
+		"weather": "Beau, chaud et brumeux",
+		"route_description": "Petite boucle depuis les contrebas de Ballaigues, Saut du Day, Bloc erratique, Les Tassonni\u00e8res."
+	}],
+	"version": 1,
+	"document_id": 735574,
+	"associations": {
+		"users": [{
+			"username": "kakaka",
+			"name": "Sakapof-Kakaka",
+			"id": 501630
+		}, {
+			"username": "doudouchien",
+			"name": "Doudouchien",
+			"id": 426684
+		}],
+		"routes": [{
+			"protected": false,
+			"elevation_max": 817,
+			"locales": [{
+				"title": "Vallorbe >> Orbe",
+				"version": 1,
+				"title_prefix": "Saut du Day",
+				"lang": "fr"
+			}],
+			"version": 2,
+			"available_langs": null,
+			"document_id": 735553,
+			"type": "r",
+			"elevation_min": 441,
+			"activities": ["hiking"]
+		}],
+		"images": [{
+			"protected": false,
+			"locales": [{
+				"title": "Le bloc erratique",
+				"version": 1,
+				"lang": "fr"
+			}],
+			"version": 1,
+			"available_langs": null,
+			"document_id": 735595,
+			"author": null,
+			"type": "i",
+			"filename": "1458503704_493257965.jpg"
+		}, {
+			"protected": false,
+			"locales": [{
+				"title": "Saut du Day",
+				"version": 1,
+				"lang": "fr"
+			}],
+			"version": 2,
+			"available_langs": null,
+			"document_id": 735594,
+			"author": null,
+			"type": "i",
+			"filename": "1458503702_76085702.jpg"
+		}],
+		"waypoints": []
+	},
+	"frequentation": "some",
+	"access_condition": null,
+	"lift_status": null
+}

--- a/c2corg_ui/tests/views/data/outing_archive.json
+++ b/c2corg_ui/tests/views/data/outing_archive.json
@@ -1,0 +1,56 @@
+{
+	"document": {
+		"elevation_max": 775,
+		"locales": [{
+			"title": "Saut du Day",
+			"hut_comment": null,
+			"access_comment": null,
+			"description": "...",
+			"lang": "fr",
+			"timing": "11h-14h30",
+			"summary": null,
+			"conditions": "Sentiers un peu humides par endroits.",
+			"participants": "Andr\u00e9e",
+			"version": 2,
+			"conditions_levels": null,
+			"weather": "Beau, chaud et brumeux",
+			"route_description": "Petite boucle depuis les contrebas de Ballaigues, Saut du Day, Bloc erratique, Les Tassonni\u00e8res."
+		}],
+		"quality": "medium",
+		"public_transport": null,
+		"type": "o",
+		"participant_count": null,
+		"length_total": 2600,
+		"height_diff_down": 140,
+		"date_start": "2016-03-20",
+		"partial_trip": true,
+		"protected": false,
+		"duration": null,
+		"date_end": "2016-03-20",
+		"access_condition": null,
+		"geometry": {
+			"geom_detail": null,
+			"version": 1,
+			"geom": "{\"coordinates\": [716464.6363154836, 5896270.4462415995], \"type\": \"Point\"}"
+		},
+		"height_diff_up": 140,
+		"elevation_access": 775,
+		"elevation_min": null,
+		"activities": ["hiking"],
+		"condition_rating": "good",
+		"hut_status": null,
+		"version": 1,
+		"document_id": 735574,
+		"frequentation": "some",
+		"lift_status": null
+	},
+	"version": {
+		"user_id": 131,
+		"username": "ckiener",
+		"version_id": 1163060,
+		"comment": "Edit in fr",
+		"written_at": 1458509295
+	},
+	"previous_version_id": 1162915,
+	"next_version_id": 1163092
+}

--- a/c2corg_ui/tests/views/data/outing_archive.json
+++ b/c2corg_ui/tests/views/data/outing_archive.json
@@ -47,6 +47,7 @@
 	"version": {
 		"user_id": 131,
 		"username": "ckiener",
+		"name": "Chris",
 		"version_id": 1163060,
 		"comment": "Edit in fr",
 		"written_at": 1458509295

--- a/c2corg_ui/tests/views/data/route.json
+++ b/c2corg_ui/tests/views/data/route.json
@@ -1,0 +1,96 @@
+{
+	"elevation_max": 1570,
+	"height_diff_access": null,
+	"difficulties_height": null,
+	"main_waypoint_id": 722162,
+	"quality": "medium",
+	"type": "r",
+	"route_types": ["return_same_way"],
+	"protected": false,
+	"maps": [],
+	"height_diff_down": 700,
+	"hiking_rating": "T2",
+	"hiking_mtb_exposition": null,
+	"height_diff_difficulties": null,
+	"areas": [{
+		"protected": false,
+		"locales": [{
+			"title": "Estat espanyol",
+			"version": 3,
+			"lang": "ca"
+		}],
+		"version": 11,
+		"available_langs": null,
+		"document_id": 14267,
+		"type": "a",
+		"area_type": "country"
+	}],
+	"orientations": ["SE"],
+	"associations": {
+		"recent_outings": {
+			"total": 1,
+			"outings": [{
+				"protected": false,
+				"locales": [{
+					"title": "Comillini: des de Cadolla per la casa Encantada",
+					"version": 1,
+					"lang": "ca"
+				}],
+				"date_end": "2016-02-07",
+				"version": 1,
+				"available_langs": null,
+				"document_id": 736934,
+				"date_start": "2016-02-07",
+				"author": {
+					"user_id": 112603,
+					"username": "p\u00e8descau\u00e7",
+					"name": "Cesc Grau"
+				},
+				"type": "o",
+				"activities": ["hiking"]
+			}]
+		},
+		"routes": [],
+		"images": [],
+		"waypoints": [{
+			"elevation": 1275,
+			"protected": false,
+			"locales": [{
+				"title": "Corroncui",
+				"version": 1,
+				"lang": "ca"
+			}],
+			"version": 1,
+			"available_langs": null,
+			"document_id": 736903,
+			"waypoint_type": "access",
+			"type": "w"
+		}]
+	},
+	"available_langs": ["ca"],
+	"geometry": {
+		"geom_detail": null,
+		"version": 1,
+		"geom": "{\"coordinates\": [97634.23014221099, 5211573.605420916], \"type\": \"Point\"}"
+	},
+	"lift_access": null,
+	"height_diff_up": 700,
+	"elevation_min": 945,
+	"locales": [{
+		"title": "des de Cadolla per la casa Encantada",
+		"external_resources": null,
+		"remarks": null,
+		"version": 1,
+		"title_prefix": "Comillini",
+		"summary": null,
+		"description": "...",
+		"lang": "ca",
+		"route_history": null,
+		"gear": null
+	}],
+	"version": 1,
+	"route_length": null,
+	"document_id": 736901,
+	"durations": ["1"],
+	"activities": ["hiking"]
+}

--- a/c2corg_ui/tests/views/data/route_archive.json
+++ b/c2corg_ui/tests/views/data/route_archive.json
@@ -1,0 +1,50 @@
+{
+	"document": {
+		"elevation_max": 800,
+		"height_diff_access": null,
+		"difficulties_height": null,
+		"height_diff_down": 350,
+		"quality": "medium",
+		"type": "r",
+		"route_types": ["traverse"],
+		"protected": false,
+		"main_waypoint_id": null,
+		"hiking_mtb_exposition": null,
+		"height_diff_difficulties": null,
+		"orientations": null,
+		"hiking_rating": "T2",
+		"geometry": {
+			"geom_detail": null,
+			"version": 1,
+			"geom": "{\"coordinates\": [716464.6363154836, 5896270.4462415995], \"type\": \"Point\"}"
+		},
+		"lift_access": null,
+		"height_diff_up": null,
+		"elevation_min": 450,
+		"locales": [{
+			"title": "Vallorbe >> Orbe",
+			"external_resources": null,
+			"remarks": "* ...",
+			"version": 1,
+			"description": "...",
+			"summary": null,
+			"route_history": null,
+			"lang": "fr",
+			"gear": null
+		}],
+		"version": 1,
+		"route_length": 16300,
+		"document_id": 735553,
+		"durations": ["1"],
+		"activities": ["hiking"]
+	},
+	"version": {
+		"user_id": 131,
+		"username": "ckiener",
+		"version_id": 1162880,
+		"comment": "Edit in fr",
+		"written_at": 1458506363
+	},
+	"previous_version_id": null,
+	"next_version_id": 1162889
+}

--- a/c2corg_ui/tests/views/data/route_archive.json
+++ b/c2corg_ui/tests/views/data/route_archive.json
@@ -41,6 +41,7 @@
 	"version": {
 		"user_id": 131,
 		"username": "ckiener",
+		"name": "Chris",
 		"version_id": 1162880,
 		"comment": "Edit in fr",
 		"written_at": 1458506363

--- a/c2corg_ui/tests/views/data/route_history.json
+++ b/c2corg_ui/tests/views/data/route_history.json
@@ -1,0 +1,16 @@
+{
+	"title": "Vallorbe >> Orbe",
+	"versions": [{
+		"user_id": 131,
+		"username": "ckiener",
+		"version_id": 1162880,
+		"comment": "Edit in fr",
+		"written_at": 1458506363
+	}, {
+		"user_id": 131,
+		"username": "ckiener",
+		"version_id": 1162889,
+		"comment": "Edit in fr",
+		"written_at": 1458506554
+	}]
+}

--- a/c2corg_ui/tests/views/data/route_history.json
+++ b/c2corg_ui/tests/views/data/route_history.json
@@ -3,12 +3,14 @@
 	"versions": [{
 		"user_id": 131,
 		"username": "ckiener",
+		"name": "Chris",
 		"version_id": 1162880,
 		"comment": "Edit in fr",
 		"written_at": 1458506363
 	}, {
 		"user_id": 131,
 		"username": "ckiener",
+		"name": "Chris",
 		"version_id": 1162889,
 		"comment": "Edit in fr",
 		"written_at": 1458506554

--- a/c2corg_ui/tests/views/data/waypoint.json
+++ b/c2corg_ui/tests/views/data/waypoint.json
@@ -1,0 +1,45 @@
+{
+	"public_transportation_rating": "good",
+	"maps_info": null,
+	"elevation": 800,
+	"maps": [],
+	"elevation_min": null,
+	"parking_fee": null,
+	"lift_access": null,
+	"version": 3,
+	"locales": [{
+		"description": "...",
+		"summary": null,
+		"lang": "fr",
+		"title": "Vallorbe",
+		"access": "En train, [url=http://www.sbb.ch/fr/]horaires[/url]",
+		"access_period": null,
+		"version": 3
+	}],
+	"areas": [],
+	"geometry": {
+		"version": 3,
+		"geom": "{\"coordinates\": [709197.9968084743, 5895264.409731769], \"type\": \"Point\"}"
+	},
+	"quality": "medium",
+	"document_id": 117982,
+	"associations": {
+		"waypoints": [],
+		"waypoint_children": [],
+		"images": [],
+		"all_routes": {
+			"total": 0,
+			"routes": []
+		},
+		"recent_outings": {
+			"outings": [],
+			"total": 0
+		}
+	},
+	"snow_clearance_rating": "often",
+	"type": "w",
+	"available_langs": ["fr"],
+	"waypoint_type": "access",
+	"protected": false,
+	"public_transportation_types": ["train"]
+}

--- a/c2corg_ui/tests/views/data/waypoint_archive.json
+++ b/c2corg_ui/tests/views/data/waypoint_archive.json
@@ -33,6 +33,7 @@
 	"version": {
 		"comment": "Edit in fr",
 		"username": "ckiener",
+		"name": "Chris",
 		"version_id": 131565,
 		"user_id": 131,
 		"written_at": 1203164362

--- a/c2corg_ui/tests/views/data/waypoint_archive.json
+++ b/c2corg_ui/tests/views/data/waypoint_archive.json
@@ -1,0 +1,40 @@
+{
+	"previous_version_id": 131564,
+	"document": {
+		"public_transportation_rating": "good",
+		"maps_info": null,
+		"elevation": 800,
+		"locales": [{
+			"description": "...",
+			"summary": null,
+			"lang": "fr",
+			"title": "Vallorbe (gare CFF)",
+			"access": "En train, [url=http://www.sbb.ch/fr/]horaires[/url]",
+			"access_period": null,
+			"version": 2
+		}],
+		"elevation_min": null,
+		"parking_fee": null,
+		"geometry": {
+			"version": 2,
+			"geom": "{\"coordinates\": [709197.9968084743, 5895264.409731769], \"type\": \"Point\"}"
+		},
+		"version": 2,
+		"lift_access": null,
+		"type": "w",
+		"quality": "medium",
+		"document_id": 117982,
+		"snow_clearance_rating": "often",
+		"waypoint_type": "access",
+		"protected": false,
+		"public_transportation_types": null
+	},
+	"next_version_id": 292856,
+	"version": {
+		"comment": "Edit in fr",
+		"username": "ckiener",
+		"version_id": 131565,
+		"user_id": 131,
+		"written_at": 1203164362
+	}
+}

--- a/c2corg_ui/tests/views/data/waypoint_archive2.json
+++ b/c2corg_ui/tests/views/data/waypoint_archive2.json
@@ -1,0 +1,40 @@
+{
+	"document": {
+		"elevation": 800,
+		"parking_fee": null,
+		"quality": "medium",
+		"geometry": {
+			"version": 3,
+			"geom": "{\"coordinates\": [709197.9968084743, 5895264.409731769], \"type\": \"Point\"}"
+		},
+		"waypoint_type": "access",
+		"type": "w",
+		"public_transportation_rating": "good",
+		"maps_info": null,
+		"elevation_min": null,
+		"protected": false,
+		"lift_access": null,
+		"locales": [{
+			"title": "Vallorbe",
+			"description": "...",
+			"access_period": null,
+			"summary": null,
+			"version": 3,
+			"lang": "fr",
+			"access": "En train, [url=http://www.sbb.ch/fr/]horaires[/url]"
+		}],
+		"version": 3,
+		"document_id": 117982,
+		"public_transportation_types": ["train"],
+		"snow_clearance_rating": "often"
+	},
+	"version": {
+		"user_id": 122824,
+		"username": "xbrrr",
+		"version_id": 292856,
+		"comment": "Edit in fr",
+		"written_at": 1258305865
+	},
+	"previous_version_id": 131565,
+	"next_version_id": null
+}

--- a/c2corg_ui/tests/views/data/waypoint_archive2.json
+++ b/c2corg_ui/tests/views/data/waypoint_archive2.json
@@ -31,6 +31,7 @@
 	"version": {
 		"user_id": 122824,
 		"username": "xbrrr",
+		"name": "Xbrrr",
 		"version_id": 292856,
 		"comment": "Edit in fr",
 		"written_at": 1258305865

--- a/c2corg_ui/tests/views/test_outing.py
+++ b/c2corg_ui/tests/views/test_outing.py
@@ -1,8 +1,7 @@
 import os
 
-from httmock import HTTMock, all_requests
+from httmock import all_requests
 
-from c2corg_ui.caching import CACHE_VERSION
 from c2corg_ui.tests.views import BaseTestUi, handle_mock_request
 from c2corg_ui.views.route import Route
 
@@ -26,79 +25,16 @@ class TestOutingUi(BaseTestUi):
         self._test_get_documents()
 
     def test_detail(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(outing_detail_mock):
-            url = '/{0}/735574/fr'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735574-fr-1-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/735574/fr'.format(self._prefix)
+        self._test_page(url, outing_detail_mock, '735574-fr-1')
 
     def test_archive(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(outing_archive_mock):
-            url = '/{0}/735574/fr/1163060'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735574-fr-1-1163060-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/735574/fr/1163060'.format(self._prefix)
+        self._test_page(url, outing_archive_mock, '735574-fr-1-1163060')
 
     def test_history(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(outing_history_mock):
-            url = '/{0}/history/735553/fr'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735553-fr-1-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/history/735553/fr'.format(self._prefix)
+        self._test_page(url, outing_history_mock, '735553-fr-1')
 
 
 @all_requests

--- a/c2corg_ui/tests/views/test_outing.py
+++ b/c2corg_ui/tests/views/test_outing.py
@@ -9,10 +9,10 @@ from c2corg_ui.views.route import Route
 base_path = os.path.dirname(os.path.abspath(__file__))
 
 
-class TestRouteUi(BaseTestUi):
+class TestOutingUi(BaseTestUi):
 
     def setUp(self):  # noqa
-        self.set_prefix("routes")
+        self.set_prefix("outings")
         BaseTestUi.setUp(self)
         self.view = Route(request=self.request)
 
@@ -28,15 +28,15 @@ class TestRouteUi(BaseTestUi):
     def test_detail(self):
         """ An ETag header is set, using the ETag of the API response.
         """
-        with HTTMock(route_detail_mock):
-            url = '/{0}/736901/ca'.format(self._prefix)
+        with HTTMock(outing_detail_mock):
+            url = '/{0}/735574/fr'.format(self._prefix)
             resp = self.app.get(url, status=200)
 
             etag = resp.headers.get('ETag')
             self.assertIsNotNone(etag)
             self.assertEqual(
                 etag,
-                'W/"736901-ca-1-{0}"'.format(CACHE_VERSION))
+                'W/"735574-fr-1-{0}"'.format(CACHE_VERSION))
 
             # then request the page again with the etag
             headers = {
@@ -53,15 +53,15 @@ class TestRouteUi(BaseTestUi):
     def test_archive(self):
         """ An ETag header is set, using the ETag of the API response.
         """
-        with HTTMock(route_archive_mock):
-            url = '/{0}/735553/fr/1162880'.format(self._prefix)
+        with HTTMock(outing_archive_mock):
+            url = '/{0}/735574/fr/1163060'.format(self._prefix)
             resp = self.app.get(url, status=200)
 
             etag = resp.headers.get('ETag')
             self.assertIsNotNone(etag)
             self.assertEqual(
                 etag,
-                'W/"735553-fr-1-1162880-{0}"'.format(CACHE_VERSION))
+                'W/"735574-fr-1-1163060-{0}"'.format(CACHE_VERSION))
 
             # then request the page again with the etag
             headers = {
@@ -77,16 +77,16 @@ class TestRouteUi(BaseTestUi):
 
 
 @all_requests
-def route_detail_mock(url, request):
+def outing_detail_mock(url, request):
     return handle_mock_request(
         request,
-        os.path.join(base_path, 'data', 'route.json'),
-        'W/"736901-ca-1"')
+        os.path.join(base_path, 'data', 'outing.json'),
+        'W/"735574-fr-1"')
 
 
 @all_requests
-def route_archive_mock(url, request):
+def outing_archive_mock(url, request):
     return handle_mock_request(
         request,
-        os.path.join(base_path, 'data', 'route_archive.json'),
-        'W/"735553-fr-1-1162880"')
+        os.path.join(base_path, 'data', 'outing_archive.json'),
+        'W/"735574-fr-1-1163060"')

--- a/c2corg_ui/tests/views/test_outing.py
+++ b/c2corg_ui/tests/views/test_outing.py
@@ -75,6 +75,31 @@ class TestOutingUi(BaseTestUi):
             }
             self.app.get(url, status=200, headers=headers)
 
+    def test_history(self):
+        """ An ETag header is set, using the ETag of the API response.
+        """
+        with HTTMock(outing_history_mock):
+            url = '/{0}/history/735553/fr'.format(self._prefix)
+            resp = self.app.get(url, status=200)
+
+            etag = resp.headers.get('ETag')
+            self.assertIsNotNone(etag)
+            self.assertEqual(
+                etag,
+                'W/"735553-fr-1-{0}"'.format(CACHE_VERSION))
+
+            # then request the page again with the etag
+            headers = {
+                'If-None-Match': etag
+            }
+            self.app.get(url, status=304, headers=headers)
+
+            # if a wrong/outdated etag is provided, the full page is returned
+            headers = {
+                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
+            }
+            self.app.get(url, status=200, headers=headers)
+
 
 @all_requests
 def outing_detail_mock(url, request):
@@ -90,3 +115,11 @@ def outing_archive_mock(url, request):
         request,
         os.path.join(base_path, 'data', 'outing_archive.json'),
         'W/"735574-fr-1-1163060"')
+
+
+@all_requests
+def outing_history_mock(url, request):
+    return handle_mock_request(
+        request,
+        os.path.join(base_path, 'data', 'route_history.json'),
+        'W/"735553-fr-1"')

--- a/c2corg_ui/tests/views/test_route.py
+++ b/c2corg_ui/tests/views/test_route.py
@@ -1,8 +1,7 @@
 import os
 
-from httmock import HTTMock, all_requests
+from httmock import all_requests
 
-from c2corg_ui.caching import CACHE_VERSION
 from c2corg_ui.tests.views import BaseTestUi, handle_mock_request
 from c2corg_ui.views.route import Route
 
@@ -26,79 +25,16 @@ class TestRouteUi(BaseTestUi):
         self._test_get_documents()
 
     def test_detail(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(route_detail_mock):
-            url = '/{0}/736901/ca'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"736901-ca-1-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/736901/ca'.format(self._prefix)
+        self._test_page(url, route_detail_mock, '736901-ca-1')
 
     def test_archive(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(route_archive_mock):
-            url = '/{0}/735553/fr/1162880'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735553-fr-1-1162880-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/735553/fr/1162880'.format(self._prefix)
+        self._test_page(url, route_archive_mock, '735553-fr-1-1162880')
 
     def test_history(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(route_history_mock):
-            url = '/{0}/history/735553/fr'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735553-fr-1-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/history/735553/fr'.format(self._prefix)
+        self._test_page(url, route_history_mock, '735553-fr-1')
 
 
 @all_requests

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -101,6 +101,13 @@ class TestWaypointUi(BaseTestUi):
         url = '/{0}/history/735553/fr'.format(self._prefix)
         self._test_page(url, waypoint_history_mock, '735553-fr-1')
 
+    def test_diff(self):
+        url = '/{0}/diff/117982/fr/131565/292856'.format(self._prefix)
+        self._test_page(
+            url,
+            waypoint_diff_mock,
+            '117982-fr-1-131565-117982-fr-1-292856')
+
     def test_reprojection(self):
         # Testing lon/lat coordinates
         point = Point(6, 46)
@@ -151,3 +158,17 @@ def waypoint_history_mock(url, request):
         request,
         os.path.join(base_path, 'data', 'route_history.json'),
         'W/"735553-fr-1"')
+
+
+@all_requests
+def waypoint_diff_mock(url, request):
+    if '292856' in url.path:
+        return handle_mock_request(
+            request,
+            os.path.join(base_path, 'data', 'waypoint_archive2.json'),
+            'W/"117982-fr-1-292856"')
+    else:
+        return handle_mock_request(
+            request,
+            os.path.join(base_path, 'data', 'waypoint_archive.json'),
+            'W/"117982-fr-1-131565"')

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -93,55 +93,13 @@ class TestWaypointUi(BaseTestUi):
             self.assertEqual(cache_value, NO_VALUE)
             self.assertIsNone(response.headers.get('ETag'))
 
-    def test_archive_etag(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(waypoint_archive_mock):
-            url = '/{0}/117982/fr/131565'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"117982-fr-1-131565-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+    def test_archive(self):
+        url = '/{0}/117982/fr/131565'.format(self._prefix)
+        self._test_page(url, waypoint_archive_mock, '117982-fr-1-131565')
 
     def test_history(self):
-        """ An ETag header is set, using the ETag of the API response.
-        """
-        with HTTMock(waypoint_history_mock):
-            url = '/{0}/history/735553/fr'.format(self._prefix)
-            resp = self.app.get(url, status=200)
-
-            etag = resp.headers.get('ETag')
-            self.assertIsNotNone(etag)
-            self.assertEqual(
-                etag,
-                'W/"735553-fr-1-{0}"'.format(CACHE_VERSION))
-
-            # then request the page again with the etag
-            headers = {
-                'If-None-Match': etag
-            }
-            self.app.get(url, status=304, headers=headers)
-
-            # if a wrong/outdated etag is provided, the full page is returned
-            headers = {
-                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
-            }
-            self.app.get(url, status=200, headers=headers)
+        url = '/{0}/history/735553/fr'.format(self._prefix)
+        self._test_page(url, waypoint_history_mock, '735553-fr-1')
 
     def test_reprojection(self):
         # Testing lon/lat coordinates

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -1,6 +1,14 @@
-from c2corg_ui.tests.views import BaseTestUi
+import os
+
+from dogpile.cache.api import NO_VALUE
+from httmock import HTTMock, all_requests
+
+from c2corg_ui.caching import cache_document_detail, CachedPage, CACHE_VERSION
+from c2corg_ui.tests.views import BaseTestUi, handle_mock_request
 from c2corg_ui.views.waypoint import Waypoint
 from shapely.geometry import Point
+
+base_path = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestWaypointUi(BaseTestUi):
@@ -18,6 +26,97 @@ class TestWaypointUi(BaseTestUi):
 
     def test_get_documents(self):
         self._test_get_documents()
+
+    def test_detail_etag(self):
+        """ An ETag header is set, using the ETag of the API response.
+        """
+        with HTTMock(waypoint_detail_mock):
+            url = '/{0}/117982/fr'.format(self._prefix)
+            resp = self.app.get(url, status=200)
+
+            etag = resp.headers.get('ETag')
+            self.assertIsNotNone(etag)
+            self.assertEqual(
+                etag,
+                'W/"117982-fr-1-{0}"'.format(CACHE_VERSION))
+
+            # then request the page again with the etag
+            headers = {
+                'If-None-Match': etag
+            }
+            self.app.get(url, status=304, headers=headers)
+
+            # if a wrong/outdated etag is provided, the full page is returned
+            headers = {
+                'If-None-Match': 'W/"123456-xy-0-c796286-123456"'
+            }
+            self.app.get(url, status=200, headers=headers)
+
+    def test_detail_caching(self):
+        url = '/{0}/117982/fr'.format(self._prefix)
+        cache_key = self.view._get_cache_key(117982, 'fr')
+
+        with HTTMock(waypoint_detail_mock):
+            cache_document_detail.delete(cache_key)
+            cache_value = cache_document_detail.get(cache_key)
+            self.assertEqual(cache_value, NO_VALUE)
+
+            # check that the response is cached
+            self.app.get(url, status=200)
+
+            cache_value = cache_document_detail.get(cache_key)
+            self.assertNotEqual(cache_value, NO_VALUE)
+
+            # check that values are returned from the cache
+            fake_cache_value = CachedPage('117982-fr-1', 'fake page')
+            cache_document_detail.set(cache_key, fake_cache_value)
+
+            response = self.app.get(url, status=200)
+            self.assertEqual(response.text, 'fake page')
+
+        # simulate that the version of the document in the api has changed
+        with HTTMock(waypoint_detail_new_mock):
+            response = self.app.get(url, status=200)
+            self.assertNotEqual(response.text, 'fake page')
+
+    def test_detail_caching_debug(self):
+        """ Check that the cache is not used when using the debug flag.
+        """
+        url = '/{0}/117982/fr?debug'.format(self._prefix)
+        cache_key = self.view._get_cache_key(117982, 'fr')
+        cache_document_detail.delete(cache_key)
+
+        with HTTMock(waypoint_detail_mock):
+            response = self.app.get(url, status=200)
+
+            cache_value = cache_document_detail.get(cache_key)
+            self.assertEqual(cache_value, NO_VALUE)
+            self.assertIsNone(response.headers.get('ETag'))
+
+    def test_archive_etag(self):
+        """ An ETag header is set, using the ETag of the API response.
+        """
+        with HTTMock(waypoint_archive_mock):
+            url = '/{0}/117982/fr/131565'.format(self._prefix)
+            resp = self.app.get(url, status=200)
+
+            etag = resp.headers.get('ETag')
+            self.assertIsNotNone(etag)
+            self.assertEqual(
+                etag,
+                'W/"117982-fr-1-131565-{0}"'.format(CACHE_VERSION))
+
+            # then request the page again with the etag
+            headers = {
+                'If-None-Match': etag
+            }
+            self.app.get(url, status=304, headers=headers)
+
+            # if a wrong/outdated etag is provided, the full page is returned
+            headers = {
+                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
+            }
+            self.app.get(url, status=200, headers=headers)
 
     def test_reprojection(self):
         # Testing lon/lat coordinates
@@ -37,3 +136,27 @@ class TestWaypointUi(BaseTestUi):
         point6 = self.view._transform(point5, 'epsg:3857', 'epsg:21781')
         self.assertAlmostEqual(point6.x, point4.x, delta=1)
         self.assertAlmostEqual(point6.y, point4.y, delta=1)
+
+
+@all_requests
+def waypoint_detail_mock(url, request):
+    return handle_mock_request(
+        request,
+        os.path.join(base_path, 'data', 'waypoint.json'),
+        'W/"117982-fr-1"')
+
+
+@all_requests
+def waypoint_detail_new_mock(url, request):
+    return handle_mock_request(
+        request,
+        os.path.join(base_path, 'data', 'waypoint.json'),
+        'W/"117982-fr-2"')
+
+
+@all_requests
+def waypoint_archive_mock(url, request):
+    return handle_mock_request(
+        request,
+        os.path.join(base_path, 'data', 'waypoint_archive.json'),
+        'W/"117982-fr-1-131565"')

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -118,6 +118,31 @@ class TestWaypointUi(BaseTestUi):
             }
             self.app.get(url, status=200, headers=headers)
 
+    def test_history(self):
+        """ An ETag header is set, using the ETag of the API response.
+        """
+        with HTTMock(waypoint_history_mock):
+            url = '/{0}/history/735553/fr'.format(self._prefix)
+            resp = self.app.get(url, status=200)
+
+            etag = resp.headers.get('ETag')
+            self.assertIsNotNone(etag)
+            self.assertEqual(
+                etag,
+                'W/"735553-fr-1-{0}"'.format(CACHE_VERSION))
+
+            # then request the page again with the etag
+            headers = {
+                'If-None-Match': etag
+            }
+            self.app.get(url, status=304, headers=headers)
+
+            # if a wrong/outdated etag is provided, the full page is returned
+            headers = {
+                'If-None-Match': 'W/"123456-xy-0-1234-c796286-123456"'
+            }
+            self.app.get(url, status=200, headers=headers)
+
     def test_reprojection(self):
         # Testing lon/lat coordinates
         point = Point(6, 46)
@@ -160,3 +185,11 @@ def waypoint_archive_mock(url, request):
         request,
         os.path.join(base_path, 'data', 'waypoint_archive.json'),
         'W/"117982-fr-1-131565"')
+
+
+@all_requests
+def waypoint_history_mock(url, request):
+    return handle_mock_request(
+        request,
+        os.path.join(base_path, 'data', 'route_history.json'),
+        'W/"735553-fr-1"')

--- a/c2corg_ui/views/__init__.py
+++ b/c2corg_ui/views/__init__.py
@@ -1,0 +1,38 @@
+import logging
+
+from pyramid.httpexceptions import HTTPNotModified
+
+log = logging.getLogger(__name__)
+
+
+def etag_cache(request, etag_key):
+    """Use the HTTP Entity Tag cache for Browser side caching
+    If a "If-None-Match" header is found, and equivalent to ``key``,
+    then a ``304`` HTTP message will be returned with the ETag to tell
+    the browser that it should use its current cache of the page.
+    Otherwise, the ETag header will be added to the response headers.
+    Suggested use is within a view like so:
+    .. code-block:: python
+        def view(request):
+            etag_cache(request, key=1)
+            return render('/splash.mako')
+    .. note::
+        This works because etag_cache will raise an HTTPNotModified
+        exception if the ETag received matches the key provided.
+
+    Implementation adapted from:
+    https://github.com/Pylons/pylons/blob/799c310/pylons/controllers/util.py#L148  # noqa
+    """
+    # we are always using a weak ETag validator
+    etag = 'W/"%s"' % etag_key
+    etag_matcher = request.if_none_match
+
+    if str(etag_key) in etag_matcher:
+        headers = [
+            ('ETag', etag)
+        ]
+        log.debug("ETag match, returning 304 HTTP Not Modified Response")
+        raise HTTPNotModified(headers=headers)
+    else:
+        request.response.headers['ETag'] = etag
+        log.debug("ETag didn't match, returning response object")

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -146,17 +146,18 @@ class Document(object):
         url = '%s/%s' % (api_url, url)
         if log.isEnabledFor(logging.DEBUG):
             log.debug('API: %s %s', 'GET', url)
+        resp = None
         try:
             resp = http_requests.session.get(url, headers=headers)
-
-            if resp.status_code == 304:
-                # no content for 'not modified'
-                return resp, {}
-            else:
-                return resp, resp.json()
-        except Exception:
+        except:
             log.error('Request failed: {0}'.format(url), exc_info=1)
+            raise
+
+        if resp.status_code == 304:
+            # no content for 'not modified'
             return resp, {}
+        else:
+            return resp, resp.json()
 
     def _validate_id_lang(self):
         if 'id' not in self.request.matchdict:
@@ -367,6 +368,15 @@ class Document(object):
         return self._get_or_create(
             (id, lang, v1, v2), cache_document_diff, load_data, render_page,
             self._get_cache_key_diff, get_etag_key=self._get_etag_key_diff)
+
+    def _add(self, template):
+        return get_or_create_page(
+            '{0}-add'.format(self._API_ROUTE),
+            template,
+            self.template_input,
+            self.request,
+            self.debug
+        )
 
     def _get_geometry(self, data):
         return asShape(json.loads(data)) if data else None

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -1,4 +1,10 @@
+import re
+
+from dogpile.cache.api import NO_VALUE
+
 from c2corg_ui import http_requests
+from c2corg_ui.caching import cache_document_detail, CachedPage, \
+    cache_document_archive, CACHE_VERSION
 from c2corg_ui.diff.differ import diff_documents
 from shapely.geometry import asShape
 from shapely.ops import transform
@@ -12,13 +18,17 @@ from c2corg_common.attributes import default_langs
 from pyramid.httpexceptions import (
     HTTPBadRequest, HTTPNotFound, HTTPInternalServerError)
 
+from c2corg_ui.views import etag_cache
+
 log = logging.getLogger(__name__)
+
+IF_NONE_MATCH = re.compile('(?:W/)?(?:"([^"]*)",?\s*)')
 
 
 class Document(object):
 
-    # FIXME Is a "documents" route available/relevant in the API?
-    _API_ROUTE = 'documents'
+    # set in inheriting classes
+    _API_ROUTE = None
 
     # FIXME sync with API => use a CONSTANT in c2corg_common?
     _DEFAULT_FILTERS = {
@@ -28,14 +38,85 @@ class Document(object):
     def __init__(self, request):
         self.request = request
         self.settings = request.registry.settings
+        self.debug = 'debug' in self.request.params
         self.template_input = {
-            'debug': 'debug' in self.request.params,
+            'debug': self.debug,
             'api_url': self.settings['api_url'],
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
             'image_backend_url': self.settings['image_backend_url'],
             'image_url': self.settings['image_url']
         }
+
+    def _get_or_create_detail(self, id, lang, render_page):
+        """ Returns a detail page for a document
+
+         If the document page is currently in the cache, and the version in
+         the API and the code version has not changed, the page is served
+         from the cache. Otherwise the page is rendered and cached.
+
+         If the request includes an ETag and the provided ETag equals the
+         current version, "304 Not Modified" is returned.
+        """
+        def load_data(old_api_cache_key=None):
+            not_modified, api_cache_key, document_and_locale = \
+                self._get_document(id, lang, old_api_cache_key)
+            return not_modified, api_cache_key, document_and_locale
+
+        return self._get_or_create(
+            (id, lang), cache_document_detail, load_data, render_page,
+            self._get_cache_key)
+
+    def _get_or_create_archive(self, id, lang, version_id, render_page):
+        """ Returns an archived version of a document.
+         The response is cached and ETags are handled.
+        """
+        def load_data(old_api_cache_key=None):
+            not_modified, api_cache_key, document_locale_version = \
+                self._get_archived_document(
+                    id, lang, version_id, old_api_cache_key)
+            return not_modified, api_cache_key, document_locale_version
+
+        return self._get_or_create(
+            (id, lang, version_id), cache_document_archive, load_data,
+            render_page, self._get_cache_key_archive)
+
+    def _get_or_create(
+            self, request_data, cache, load_data, render_page, get_cache_key):
+        if self.debug:
+            # do not cache when in debug mode
+            _, _, loaded_data = load_data()
+            return self._get_response(render_page(*loaded_data))
+
+        cache_key = get_cache_key(*request_data)
+
+        # try to get a rendered page from the cache
+        cached_page = cache.get(cache_key, ignore_expiration=True)
+
+        old_api_cache_key = cached_page.api_cache_key \
+            if cached_page != NO_VALUE else None
+
+        # request the document from the api. if there was an entry in the
+        # cache, set the `If-None-Match` header with the last ETag. if the
+        # document version on the api has not changed, `not modified` will
+        # be returned.
+        not_modified, api_cache_key, loaded_data = load_data(old_api_cache_key)
+
+        ui_etag_key = self._get_etag_key(api_cache_key)
+        if not_modified:
+            # the cached page is still valid
+            log.debug('Serving from cache {0}'.format(cache_key))
+            etag_cache(self.request, ui_etag_key)
+            return self._get_response(cached_page.page_html)
+        else:
+            # there is a new version from the api, render the page
+            page_html = render_page(*loaded_data)
+
+            cache.set(cache_key, CachedPage(api_cache_key, page_html))
+
+            etag_cache(self.request, ui_etag_key)
+
+            return self._get_response(page_html)
 
     def _call_api(self, url, headers=None):
         settings = self.settings
@@ -51,7 +132,12 @@ class Document(object):
             log.debug('API: %s %s', 'GET', url)
         try:
             resp = http_requests.session.get(url, headers=headers)
-            return resp, resp.json()
+
+            if resp.status_code == 304:
+                # no content for 'not modified'
+                return resp, {}
+            else:
+                return resp, resp.json()
         except Exception:
             log.error('Request failed: {0}'.format(url), exc_info=1)
             return resp, {}
@@ -78,37 +164,64 @@ class Document(object):
         except Exception:
             raise HTTPBadRequest("Incorrect " + field)
 
-    def _get_document(self, id, lang):
+    def _get_document(self, id, lang, old_api_cache_key=None):
         url = '%s/%d?l=%s' % (self._API_ROUTE, id, lang)
-        resp, document = self._call_api(url)
-        if resp.status_code == 404:
-            raise HTTPNotFound()
-        elif resp.status_code != 200:
-            raise HTTPInternalServerError(
-                "An error occured while loading the document")
+        not_modified, api_cache_key, document = self._get_with_etag(
+            url, old_api_cache_key)
+
+        if not_modified:
+            return not_modified, api_cache_key, None
+
         # When requesting a lang that does not exist yet, the API sends
         # back an empty list as 'locales'
         if not document['locales']:
             raise HTTPNotFound('Requested lang does not exist')
+
         # We need to pass locale data to Mako as a dedicated object to make it
         # available to the parent templates:
         locale = document['locales'][0]
-        return document, locale
 
-    def _get_archived_document(self, id, lang, version_id):
+        return False, api_cache_key, (document, locale)
+
+    def _get_archived_document(
+            self, id, lang, version_id, old_api_cache_key=None):
         url = '%s/%d/%s/%d' % (self._API_ROUTE, id, lang, version_id)
-        resp, content = self._call_api(url)
-        if resp.status_code == 404:
-            raise HTTPNotFound()
-        elif resp.status_code != 200:
-            raise HTTPInternalServerError(
-                "An error occured while loading the document")
+        not_modified, api_cache_key, content = self._get_with_etag(
+            url, old_api_cache_key)
+
+        if not_modified:
+            return not_modified, api_cache_key, None
+
         document = content['document']
         version = content['version']
-        # We need to pass locale data to Mako as a dedicated object to make it
-        # available to the parent templates:
         locale = document['locales'][0]
-        return document, locale, version
+
+        return False, api_cache_key, (document, locale, version)
+
+    def _get_with_etag(self, url, old_api_cache_key=None):
+        headers = None
+        if old_api_cache_key:
+            headers = {'If-None-Match': 'W/"{0}"'.format(old_api_cache_key)}
+
+        resp, document = self._call_api(url, headers)
+
+        api_cache_key = None
+        if resp.headers.get('ETag'):
+            api_cache_key = self._get_api_cache_key_from_etag(
+                resp.headers.get('ETag'))
+
+        if resp.status_code in [200, 304] and not api_cache_key:
+            log.warn('no etag found for {0}'.format(url))
+
+        if resp.status_code == 404:
+            raise HTTPNotFound()
+        elif resp.status_code == 304:
+            return True, api_cache_key, None
+        elif resp.status_code != 200:
+            raise HTTPInternalServerError(
+                "An error occurred while loading the document")
+
+        return False, api_cache_key, document
 
     def _get_documents(self):
         params = []
@@ -199,3 +312,22 @@ class Document(object):
             return self.template_input
 
         raise HTTPNotFound()
+
+    def _get_cache_key(self, id, lang):
+        return '{0}-{1}-{2}'.format(id, lang, CACHE_VERSION)
+
+    def _get_cache_key_archive(self, id, lang, version_id):
+        return '{0}-{1}-{2}-{3}'.format(id, lang, version_id, CACHE_VERSION)
+
+    def _get_etag_key(self, api_cache_key):
+        return '{0}-{1}'.format(api_cache_key, CACHE_VERSION)
+
+    def _get_api_cache_key_from_etag(self, etag):
+        if_none_matches = IF_NONE_MATCH.findall(etag)
+
+        if if_none_matches:
+            return if_none_matches[0]
+
+    def _get_response(self, page_html):
+        self.request.response.text = page_html
+        return self.request.response

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -20,7 +20,7 @@ from c2corg_common.attributes import default_langs
 from pyramid.httpexceptions import (
     HTTPBadRequest, HTTPNotFound, HTTPInternalServerError)
 
-from c2corg_ui.views import etag_cache
+from c2corg_ui.views import etag_cache, get_response, get_or_create_page
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +49,18 @@ class Document(object):
             'image_backend_url': self.settings['image_backend_url'],
             'image_url': self.settings['image_url']
         }
+
+    def _index(self, template):
+        # FIXME no ETag is set, because the filters are set as query params,
+        # see https://github.com/c2corg/v6_ui/issues/554
+        return get_or_create_page(
+            self._API_ROUTE,
+            template,
+            self.template_input,
+            self.request,
+            self.debug,
+            no_etag=True
+        )
 
     def _get_or_create_detail(self, id, lang, render_page):
         """ Returns a detail page for a document
@@ -388,5 +400,4 @@ class Document(object):
             return if_none_matches[0]
 
     def _get_response(self, page_html):
-        self.request.response.text = page_html
-        return self.request.response
+        return get_response(self.request, page_html)

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -1,13 +1,16 @@
 from pyramid.view import view_config
 
+from c2corg_ui.views import get_or_create_page
+
 
 class Pages(object):
 
     def __init__(self, request):
         self.request = request
         self.settings = request.registry.settings
+        self.debug = 'debug' in self.request.params
         self.template_input = {
-            'debug': 'debug' in self.request.params,
+            'debug': self.debug,
             'api_url': self.settings['api_url'],
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
@@ -15,10 +18,23 @@ class Pages(object):
             'image_url': self.settings['image_url']
         }
 
-    @view_config(route_name='index', renderer='c2corg_ui:templates/index.html')
-    @view_config(route_name='auth', renderer='c2corg_ui:templates/auth.html')
-    @view_config(
-            route_name='account',
-            renderer='c2corg_ui:templates/account.html')
+    @view_config(route_name='index')
     def index(self):
-        return self.template_input
+        return self._get_page('index', 'c2corg_ui:templates/index.html')
+
+    @view_config(route_name='auth')
+    def auth(self):
+        return self._get_page('auth', 'c2corg_ui:templates/auth.html')
+
+    @view_config(route_name='account')
+    def account(self):
+        return self._get_page('account', 'c2corg_ui:templates/account.html')
+
+    def _get_page(self, page_key, template):
+        return get_or_create_page(
+            page_key,
+            template,
+            self.template_input,
+            self.request,
+            self.debug
+        )

--- a/c2corg_ui/views/outing.py
+++ b/c2corg_ui/views/outing.py
@@ -72,8 +72,7 @@ class Outing(Document):
     def history(self):
         return self._get_history()
 
-    @view_config(route_name='outings_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
+    @view_config(route_name='outings_diff')
     def diff(self):
         return self._diff()
 

--- a/c2corg_ui/views/outing.py
+++ b/c2corg_ui/views/outing.py
@@ -75,8 +75,14 @@ class Outing(Document):
     def diff(self):
         return self._diff()
 
-    @view_config(route_name='outings_add',
-                 renderer='c2corg_ui:templates/outing/edit.html')
+    @view_config(route_name='outings_add')
+    def add(self):
+        self.template_input.update({
+            'outing_lang': None,
+            'outing_id': None
+        })
+        return self._add('c2corg_ui:templates/outing/edit.html')
+
     @view_config(route_name='outings_edit',
                  renderer='c2corg_ui:templates/outing/edit.html')
     def edit(self):

--- a/c2corg_ui/views/outing.py
+++ b/c2corg_ui/views/outing.py
@@ -8,10 +8,9 @@ class Outing(Document):
 
     _API_ROUTE = 'outings'
 
-    @view_config(route_name='outings_index',
-                 renderer='c2corg_ui:templates/outing/index.html')
+    @view_config(route_name='outings_index')
     def index(self):
-        return self.template_input
+        return self._index('c2corg_ui:templates/outing/index.html')
 
     @view_config(route_name='outings_sitemap',
                  renderer='c2corg_ui:templates/outing/sitemap.html')

--- a/c2corg_ui/views/outing.py
+++ b/c2corg_ui/views/outing.py
@@ -68,6 +68,15 @@ class Outing(Document):
 
         return self._get_or_create_archive(id, lang, version_id, render_page)
 
+    @view_config(route_name='outings_history')
+    def history(self):
+        return self._get_history()
+
+    @view_config(route_name='outings_diff',
+                 renderer='c2corg_ui:templates/document/diff.html')
+    def diff(self):
+        return self._diff()
+
     @view_config(route_name='outings_add',
                  renderer='c2corg_ui:templates/outing/edit.html')
     @view_config(route_name='outings_edit',
@@ -79,13 +88,3 @@ class Outing(Document):
             'outing_id': id
         })
         return self.template_input
-
-    @view_config(route_name='outings_history',
-                 renderer='c2corg_ui:templates/document/history.html')
-    def history(self):
-        return self._get_history()
-
-    @view_config(route_name='outings_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
-    def diff(self):
-        return self._diff()

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -77,8 +77,16 @@ class Route(Document):
     def diff(self):
         return self._diff()
 
-    @view_config(route_name='routes_add',
-                 renderer='c2corg_ui:templates/route/edit.html')
+    @view_config(route_name='routes_add')
+    def add(self):
+        self.template_input.update({
+            'activities': activities,
+            'route_types': route_types,
+            'route_lang': None,
+            'route_id': None
+        })
+        return self._add('c2corg_ui:templates/route/edit.html')
+
     @view_config(route_name='routes_edit',
                  renderer='c2corg_ui:templates/route/edit.html')
     def edit(self):

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -9,10 +9,9 @@ class Route(Document):
 
     _API_ROUTE = 'routes'
 
-    @view_config(route_name='routes_index',
-                 renderer='c2corg_ui:templates/route/index.html')
+    @view_config(route_name='routes_index')
     def index(self):
-        return self.template_input
+        return self._index('c2corg_ui:templates/route/index.html')
 
     @view_config(route_name='routes_sitemap',
                  renderer='c2corg_ui:templates/route/sitemap.html')

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -70,6 +70,15 @@ class Route(Document):
 
         return self._get_or_create_archive(id, lang, version_id, render_page)
 
+    @view_config(route_name='routes_history')
+    def history(self):
+        return self._get_history()
+
+    @view_config(route_name='routes_diff',
+                 renderer='c2corg_ui:templates/document/diff.html')
+    def diff(self):
+        return self._diff()
+
     @view_config(route_name='routes_add',
                  renderer='c2corg_ui:templates/route/edit.html')
     @view_config(route_name='routes_edit',
@@ -83,13 +92,3 @@ class Route(Document):
             'route_id': id
         })
         return self.template_input
-
-    @view_config(route_name='routes_history',
-                 renderer='c2corg_ui:templates/document/history.html')
-    def history(self):
-        return self._get_history()
-
-    @view_config(route_name='routes_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
-    def diff(self):
-        return self._diff()

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -74,8 +74,7 @@ class Route(Document):
     def history(self):
         return self._get_history()
 
-    @view_config(route_name='routes_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
+    @view_config(route_name='routes_diff')
     def diff(self):
         return self._diff()
 

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -77,6 +77,15 @@ class Waypoint(Document):
 
         return self._get_or_create_archive(id, lang, version_id, render_page)
 
+    @view_config(route_name='waypoints_history')
+    def history(self):
+        return self._get_history()
+
+    @view_config(route_name='waypoints_diff',
+                 renderer='c2corg_ui:templates/document/diff.html')
+    def diff(self):
+        return self._diff()
+
     @view_config(route_name='waypoints_add',
                  renderer='c2corg_ui:templates/waypoint/edit.html')
     @view_config(route_name='waypoints_edit',
@@ -89,13 +98,3 @@ class Waypoint(Document):
             'waypoint_id': id
         })
         return self.template_input
-
-    @view_config(route_name='waypoints_history',
-                 renderer='c2corg_ui:templates/document/history.html')
-    def history(self):
-        return self._get_history()
-
-    @view_config(route_name='waypoints_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
-    def diff(self):
-        return self._diff()

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -84,8 +84,15 @@ class Waypoint(Document):
     def diff(self):
         return self._diff()
 
-    @view_config(route_name='waypoints_add',
-                 renderer='c2corg_ui:templates/waypoint/edit.html')
+    @view_config(route_name='waypoints_add')
+    def add(self):
+        self.template_input.update({
+            'waypoint_types': waypoint_types,
+            'waypoint_lang': None,
+            'waypoint_id': None
+        })
+        return self._add('c2corg_ui:templates/waypoint/edit.html')
+
     @view_config(route_name='waypoints_edit',
                  renderer='c2corg_ui:templates/waypoint/edit.html')
     def edit(self):

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -13,10 +13,9 @@ class Waypoint(Document):
 
     _API_ROUTE = 'waypoints'
 
-    @view_config(route_name='waypoints_index',
-                 renderer='c2corg_ui:templates/waypoint/index.html')
+    @view_config(route_name='waypoints_index')
     def index(self):
-        return self.template_input
+        return self._index('c2corg_ui:templates/waypoint/index.html')
 
     @view_config(route_name='waypoints_sitemap',
                  renderer='c2corg_ui:templates/waypoint/sitemap.html')

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -81,8 +81,7 @@ class Waypoint(Document):
     def history(self):
         return self._get_history()
 
-    @view_config(route_name='waypoints_diff',
-                 renderer='c2corg_ui:templates/document/diff.html')
+    @view_config(route_name='waypoints_diff')
     def diff(self):
         return self._diff()
 

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -1,7 +1,12 @@
+import logging
+
+from pyramid.renderers import render
 from pyramid.view import view_config
 
 from c2corg_ui.views.document import Document
 from c2corg_common.attributes import waypoint_types
+
+log = logging.getLogger(__name__)
 
 
 class Waypoint(Document):
@@ -27,28 +32,50 @@ class Waypoint(Document):
         })
         return self.template_input
 
-    @view_config(route_name='waypoints_view',
-                 renderer='c2corg_ui:templates/waypoint/view.html')
-    @view_config(route_name='waypoints_archive',
-                 renderer='c2corg_ui:templates/waypoint/view.html')
-    def view(self):
+    @view_config(route_name='waypoints_view')
+    def detail(self):
         id, lang = self._validate_id_lang()
-        if 'version' in self.request.matchdict:
-            version_id = int(self.request.matchdict['version'])
-            waypoint, locale, version = self._get_archived_document(
-                id, lang, version_id)
-        else:
-            waypoint, locale = self._get_document(id, lang)
-            version = None
-        self.template_input.update({
-            'lang': lang,
-            'waypoint': waypoint,
-            'locale': locale,
-            'geometry': self._get_geometry(waypoint['geometry']['geom']),
-            'transform': self._transform,
-            'version': version
-        })
-        return self.template_input
+
+        def render_page(waypoint, locale):
+            self.template_input.update({
+                'lang': lang,
+                'waypoint': waypoint,
+                'locale': locale,
+                'geometry': self._get_geometry(waypoint['geometry']['geom']),
+                'transform': self._transform,
+                'version': None
+            })
+
+            return render(
+                'c2corg_ui:templates/waypoint/view.html',
+                self.template_input,
+                self.request
+            )
+
+        return self._get_or_create_detail(id, lang, render_page)
+
+    @view_config(route_name='waypoints_archive')
+    def archive(self):
+        id, lang = self._validate_id_lang()
+        version_id = int(self.request.matchdict['version'])
+
+        def render_page(waypoint, locale, version):
+            self.template_input.update({
+                'lang': lang,
+                'waypoint': waypoint,
+                'locale': locale,
+                'geometry': self._get_geometry(waypoint['geometry']['geom']),
+                'transform': self._transform,
+                'version': version
+            })
+
+            return render(
+                'c2corg_ui:templates/waypoint/view.html',
+                self.template_input,
+                self.request
+            )
+
+        return self._get_or_create_archive(id, lang, version_id, render_page)
 
     @view_config(route_name='waypoints_add',
                  renderer='c2corg_ui:templates/waypoint/edit.html')

--- a/common.ini.in
+++ b/common.ini.in
@@ -9,6 +9,8 @@ image_url = {image_url}
 api_url_internal = {api_url_internal}
 api_url_host = {api_url_host}
 
+http_request_connection_pool_size = {http_request_connection_pool_size}
+
 ign_api_key = {ign_api_key}
 bing_api_key = {bing_api_key}
 

--- a/common.ini.in
+++ b/common.ini.in
@@ -11,6 +11,10 @@ api_url_host = {api_url_host}
 
 http_request_connection_pool_size = {http_request_connection_pool_size}
 
+redis.url = {redis_url}?db={redis_db}
+redis.cache_key_prefix = {redis_cache_key_prefix}
+redis.cache_pool = 20
+
 ign_api_key = {ign_api_key}
 bing_api_key = {bing_api_key}
 
@@ -18,6 +22,7 @@ pyramid.default_locale_name = fr
 
 cache_max_age = 3600
 cache_version = {version}
+cache_version_timestamp = False
 
 logging.level = {logging_level}
 

--- a/config/default
+++ b/config/default
@@ -4,7 +4,8 @@ export base_url = /
 export version = $(shell git rev-parse --short HEAD 2>/dev/null || echo "0")
 export debug_port = 6553
 
-export elasticsearch_host = ...
+# the size of the connection pool for http requests (to the API)
+export http_request_connection_pool_size = 200
 
 host = c2corgv6.demo-camptocamp.com
 url = http://$(host)

--- a/config/default
+++ b/config/default
@@ -1,7 +1,6 @@
 export instanceid = main
 export base_url = /
 
-export version = $(shell git rev-parse --short HEAD 2>/dev/null || echo "0")
 export debug_port = 6553
 
 # the size of the connection pool for http requests (to the API)
@@ -22,3 +21,11 @@ export bing_api_key = AudizIfCd3NAdt91ubJMGkMI-swfHxe1R-_U7KiLxCHqepDy70txQ-_-89
 
 export logging_level = WARNING
 export skip_captcha_validation = False
+
+
+# version used for the cache
+export version = $(shell git rev-parse --short HEAD 2>/dev/null || echo "0")
+
+export redis_url = redis://localhost:6379/
+export redis_db = 2
+export redis_cache_key_prefix = c2corg_ui_$(instanceid)

--- a/config/dev
+++ b/config/dev
@@ -7,3 +7,5 @@ include Makefile
 export ign_api_key = x216cgugvwkn0go20sm2mgar
 
 export bing_api_key = ApgmUK6zfKqlvU9kNDbXeLFL2KvhC0BF3Jy-nUbcnkFJK_Y7UgMCyRq1NTu_ptyj
+
+export redis_db = 3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ flake8==2.5.2
 pep8-naming==0.3.3
 nose==1.3.7
 WebTest==2.0.20
+httmock==1.2.5

--- a/development.ini.in
+++ b/development.ini.in
@@ -19,6 +19,10 @@ pyramid.includes =
 # '127.0.0.1' and '::1'.
 debugtoolbar.hosts = 0.0.0.0/0
 
+# in dev. mode, append the timestamp to the cache key, so that the cache is
+# invalidated when the debug server reloads
+cache_version_timestamp = True
+
 ###
 # wsgi server configuration
 ###

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ htmlmin==0.1.10
 bbcode==1.0.21
 Markdown==2.6.5
 gunicorn==19.6.0
+dogpile.cache==0.6.1
+redis==2.10.5
 
 # c2corg_common project
 # for development use a local checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyramid==1.7
 pyramid-debugtoolbar==2.4.2
 pyramid-mako==1.0.2
 waitress==0.8.10
-httplib2==0.9.2
+requests==2.1.0
 Shapely==1.5.13
 pyproj==1.9.5.1
 htmlmin==0.1.10

--- a/test.ini.in
+++ b/test.ini.in
@@ -1,2 +1,9 @@
 [app:main]
 use = config:common.ini
+
+pyramid.includes =
+    pyramid_closure
+    pyramid_mako
+
+redis.cache_key_prefix = {redis_cache_key_prefix}_tests
+cache_version_timestamp = True


### PR DESCRIPTION
This PR enables page caching. For example when requesting a document `routes/12345/fr`, the ui server side will check if there is an entry in the cache. If so, a request to the api is made with the previous ETag value (which is stored with the cached page). If the document on the api side has not changed, the cached page is returned. Otherwise the page is rendered, and the cached entry is updated.
An ETag is header is set, which is used by the browser cache (and also Varnish). The ETag header consists of the ETag from the api and the current Git revision (+ a timestamp when running the dev server).

Todo:
* [x] Set up caching/ETag for
  * [x] Detail page
  * [x] Archive page
  * [x] History page
  * [x] Diff page
  * [x] Index page
  * [x] Add/~~edit~~ page
  * [x] Index/auth/account page

Depends on https://github.com/c2corg/v6_api/pull/336
Related to https://github.com/c2corg/v6_ui/issues/456