### PR TITLE
Add slug to document URLs

### DIFF
--- a/build.json
+++ b/build.json
@@ -14,6 +14,7 @@
       "c2corg_ui/externs/angular-moment.js",
       "c2corg_ui/externs/vcrecaptcha.js",
       "c2corg_ui/externs/slick.js",
+      "c2corg_ui/externs/slug.js",
       "c2corg_ui/externs/photoswipe.js",
       "c2corg_ui/externs/moment.js",
       "c2corg_ui/externs/loadImage.js",

--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -42,40 +42,46 @@ def main(global_config, **settings):
 
     config.add_route('index', '/')
 
-    config.add_route('waypoints_view', '/waypoints/{id}/{lang}')
     config.add_route('waypoints_index', '/waypoints')
     config.add_route('waypoints_sitemap_default', '/waypoints/sitemap')
     config.add_route('waypoints_sitemap', '/waypoints/sitemap*filters')
     config.add_route('waypoints_add', '/waypoints/add')
-    config.add_route('waypoints_edit', '/waypoints/edit/{id}/{lang}')
-    config.add_route('waypoints_history', '/waypoints/history/{id}/{lang}')
+    config.add_route('waypoints_edit', '/waypoints/edit/{id:\d+}/{lang}')
+    config.add_route('waypoints_history', '/waypoints/history/{id:\d+}/{lang}')
     config.add_route('waypoints_archive',
-                     '/waypoints/{id}/{lang}/{version:\d+}')
+                     '/waypoints/{id:\d+}/{lang}/{version:\d+}')
+    config.add_route('waypoints_view', '/waypoints/{id:\d+}/{lang}/{slug}')
+    config.add_route('waypoints_view_id_lang', '/waypoints/{id:\d+}/{lang}')
+    config.add_route('waypoints_view_id', '/waypoints/{id:\d+}')
     config.add_route(
-        'waypoints_diff', '/waypoints/diff/{id}/{lang}/{v1}/{v2}')
+        'waypoints_diff', '/waypoints/diff/{id:\d+}/{lang}/{v1}/{v2}')
 
-    config.add_route('routes_view', '/routes/{id}/{lang}')
     config.add_route('routes_index', '/routes')
     config.add_route('routes_sitemap_default', '/routes/sitemap')
     config.add_route('routes_sitemap', '/routes/sitemap*filters')
     config.add_route('routes_add', '/routes/add')
-    config.add_route('routes_edit', '/routes/edit/{id}/{lang}')
-    config.add_route('routes_history', '/routes/history/{id}/{lang}')
-    config.add_route('routes_archive', '/routes/{id}/{lang}/{version:\d+}')
+    config.add_route('routes_edit', '/routes/edit/{id:\d+}/{lang}')
+    config.add_route('routes_history', '/routes/history/{id:\d+}/{lang}')
+    config.add_route('routes_archive', '/routes/{id:\d+}/{lang}/{version:\d+}')
+    config.add_route('routes_view', '/routes/{id:\d+}/{lang}/{slug}')
+    config.add_route('routes_view_id_lang', '/routes/{id:\d+}/{lang}')
+    config.add_route('routes_view_id', '/routes/{id:\d+}')
     config.add_route(
-        'routes_diff', '/routes/diff/{id}/{lang}/{v1}/{v2}')
+        'routes_diff', '/routes/diff/{id:\d+}/{lang}/{v1}/{v2}')
 
-    config.add_route('outings_view', '/outings/{id}/{lang}')
     config.add_route('outings_index', '/outings')
     config.add_route('outings_sitemap_default', '/outings/sitemap')
     config.add_route('outings_sitemap', '/outings/sitemap*filters')
     config.add_route('outings_add', '/outings/add')
-    config.add_route('outings_edit', '/outings/edit/{id}/{lang}')
-    config.add_route('outings_history', '/outings/history/{id}/{lang}')
+    config.add_route('outings_edit', '/outings/edit/{id:\d+}/{lang}')
+    config.add_route('outings_history', '/outings/history/{id:\d+}/{lang}')
     config.add_route('outings_archive',
-                     '/outings/{id}/{lang}/{version:\d+}')
+                     '/outings/{id:\d+}/{lang}/{version:\d+}')
+    config.add_route('outings_view', '/outings/{id:\d+}/{lang}/{slug}')
+    config.add_route('outings_view_id_lang', '/outings/{id:\d+}/{lang}')
+    config.add_route('outings_view_id', '/outings/{id:\d+}')
     config.add_route(
-        'outings_diff', '/outings/diff/{id}/{lang}/{v1}/{v2}')
+        'outings_diff', '/outings/diff/{id:\d+}/{lang}/{v1}/{v2}')
 
     config.add_route('auth', '/auth')
 

--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -47,7 +47,7 @@ appx.SimpleSearchDocumentResponse;
 /**
  * @typedef {{
  *   document_id: number,
- *   locales: Array.<appx.SimpleSearchDocumentLocale>,
+ *   locales: Array.<appx.DocumentLocale>,
  *   document_type: string,
  *   label: string,
  *   documentType: string
@@ -63,7 +63,7 @@ appx.SimpleSearchDocument;
  *   lang: string
  * }}
  */
-appx.SimpleSearchDocumentLocale;
+appx.DocumentLocale;
 
 
 /**

--- a/c2corg_ui/externs/slug.js
+++ b/c2corg_ui/externs/slug.js
@@ -1,0 +1,44 @@
+/**
+ * @type {Object}
+ */
+var slugx;
+
+/**
+ * @param {string} string
+ * @param {string|slugx.mode=} opts
+ * @constructor
+ */
+var slug = function(string, opts) {
+};
+
+/**
+ * @type {{
+ *   mode: string,
+ *   modes: Object.<string, slugx.mode>,
+ *   multicharmap: Object.<string, string>,
+ *   charmap: Object.<string, string>
+ * }}
+ */
+slug.defaults;
+
+/**
+ * @type {Object.<string, string>}
+ */
+slug.multicharmap;
+
+/**
+ * @type {Object.<string, string>}
+ */
+slug.charmap;
+
+/**
+ * @typedef {{
+ *   replacement: string,
+ *   symbols: boolean,
+ *   remove: ?string,
+ *   lower: boolean,
+ *   charmap: Object.<string, string>,
+ *   multicharmap: Object.<string, string>
+ * }}
+ */
+slugx.mode;

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -19,5 +19,6 @@ app.module = angular.module('app', [
   'ui.bootstrap',
   'angularMoment',
   'ngFileUpload',
+  'slug',
   'vcRecaptcha'
 ]);

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -3,6 +3,7 @@ goog.provide('app.cardDirective');
 
 goog.require('app');
 goog.require('app.utils');
+goog.require('app.Url');
 
 
 /**
@@ -40,18 +41,25 @@ app.module.directive('appCard', app.cardDirective);
 
 /**
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {app.Url} appUrl URL service.
  * @constructor
  * @struct
  * @export
  * @ngInject
  */
-app.CardController = function(gettextCatalog) {
+app.CardController = function(gettextCatalog, appUrl) {
 
   /**
    * @type {angularGettext.Catalog}
    * @private
    */
   this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {app.Url}
+   * @private
+   */
+  this.url_ = appUrl;
 
   /**
    * @type {string}
@@ -104,8 +112,8 @@ app.CardController.prototype.translate = function(str) {
 app.CardController.prototype.createURL = function() {
   var loc = window.location.pathname;
   if (loc.indexOf('edit') === -1 && loc.indexOf('add') === -1) {
-    return app.utils.buildDocumentUrl(this.type, this.doc['document_id'],
-      this.doc['locales'][0]['lang']);
+    return this.url_.buildDocumentUrl(
+      this.type, this.doc['document_id'], this.doc['locales'][0]);
   }
 };
 

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -5,6 +5,7 @@ goog.require('app');
 goog.require('app.Alerts');
 goog.require('app.Document');
 goog.require('app.Lang');
+goog.require('app.Url');
 goog.require('app.utils');
 goog.require('goog.asserts');
 goog.require('ol.format.GeoJSON');
@@ -55,13 +56,14 @@ app.module.directive('appDocumentEditing', app.documentEditingDirective);
  * @param {app.Api} appApi Api service.
  * @param {string} authUrl Base URL of the authentication page.
  * @param {app.Document} appDocument
+ * @param {app.Url} appUrl URL service.
  * @constructor
  * @ngInject
  * @export
  */
 app.DocumentEditingController = function($scope, $element, $attrs, appLang,
-        appAuthentication, ngeoLocation, appAlerts, appApi, authUrl, appDocument) {
-
+    appAuthentication, ngeoLocation, appAlerts, appApi, authUrl, appDocument,
+    appUrl) {
 
   /**
    * @type {app.Document}
@@ -153,6 +155,12 @@ app.DocumentEditingController = function($scope, $element, $attrs, appLang,
    * @private
    */
   this.api_ = appApi;
+
+  /**
+   * @type {app.Url}
+   * @private
+   */
+  this.url_ = appUrl;
 
   this.scope[this.modelName] = this.documentService.document;
 
@@ -295,8 +303,8 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
       'document': data
     };
     this.api_.updateDocument(this.module_, this.id_, data).then(function() {
-      window.location.href = app.utils.buildDocumentUrl(
-        this.module_, this.id_, this.lang_);
+      window.location.href = this.url_.buildDocumentUrl(
+        this.module_, this.id_, data['locales']['0']);
     }.bind(this)
     );
   } else {
@@ -305,8 +313,8 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
     data = this.prepareData(data);
     this.api_.createDocument(this.module_, data).then(function(response) {
       this.id_ = response['data']['document_id'];
-      window.location.href = app.utils.buildDocumentUrl(
-        this.module_, this.id_, this.lang_);
+      window.location.href = this.url_.buildDocumentUrl(
+        this.module_, this.id_, data['locales']['0']);
     }.bind(this));
   }
 };

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -3,6 +3,7 @@ goog.provide('app.mapDirective');
 
 goog.require('app');
 goog.require('app.utils');
+goog.require('app.Url');
 goog.require('ngeo.Debounce');
 goog.require('ngeo.Location');
 /** @suppress {extraRequire} */
@@ -63,13 +64,14 @@ app.module.directive('appMap', app.mapDirective);
  *    features to show on the map.
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {ngeo.Debounce} ngeoDebounce ngeo Debounce service.
+ * @param {app.Url} appUrl URL service.
  * @constructor
  * @struct
  * @export
  * @ngInject
  */
 app.MapController = function($scope, mapFeatureCollection, ngeoLocation,
-  ngeoDebounce) {
+  ngeoDebounce, appUrl) {
 
   /**
    * @type {number}
@@ -182,6 +184,12 @@ app.MapController = function($scope, mapFeatureCollection, ngeoLocation,
    * @private
    */
   this.ignoreExtentChange_ = false;
+
+  /**
+   * @type {app.Url}
+   * @private
+   */
+  this.url_ = appUrl;
 
   /**
    * @type {ol.Map}
@@ -659,13 +667,17 @@ app.MapController.prototype.handleMapFeatureClick_ = function(event) {
     return layer === this.getVectorLayer_();
   }, this);
   if (feature) {
-    var module = /** @type {string} */(feature.get('module'));
-    var id = feature.get('documentId').toString();
-    var lang = /** @type {string} */(feature.get('lang'));
-    var url = app.utils.buildDocumentUrl(module, id, lang);
-    if (url) {
-      window.location.href = url;
+    var module = feature.get('module');
+    var id = feature.get('documentId');
+    var locale = {
+      'lang': feature.get('lang'),
+      'title': feature.get('title')
+    };
+    if (module === 'routes' && feature.get('title_prefix')) {
+      locale['title_prefix'] = feature.get('title_prefix');
     }
+    window.location.href = this.url_.buildDocumentUrl(
+      module, id, /** @type {appx.DocumentLocale} */ (locale));
   }
 };
 

--- a/c2corg_ui/static/js/outingediting.js
+++ b/c2corg_ui/static/js/outingediting.js
@@ -18,6 +18,7 @@ goog.require('app.Lang');
  * @param {app.Api} appApi Api service.
  * @param {string} authUrl Base URL of the authentication page.
  * @param {app.Document} appDocument
+ * @param {app.Url} appUrl URL service.
  * @constructor
  * @extends {app.DocumentEditingController}
  * @ngInject
@@ -25,10 +26,10 @@ goog.require('app.Lang');
  */
 app.OutingEditingController = function($scope, $element, $attrs, appLang,
     appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
-    appDocument) {
+    appDocument, appUrl) {
 
   goog.base(this, $scope, $element, $attrs, appLang, appAuthentication,
-    ngeoLocation, appAlerts, appApi, authUrl, appDocument);
+    ngeoLocation, appAlerts, appApi, authUrl, appDocument, appUrl);
 
   /**
    * Start cannot be after today nor end_date.

--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -2,8 +2,8 @@ goog.provide('app.SimpleSearchController');
 goog.provide('app.simpleSearchDirective');
 
 goog.require('app');
-goog.require('app.utils');
 goog.require('app.Document');
+goog.require('app.Url');
 /** @suppress {extraRequire} */
 goog.require('ngeo.searchDirective');
 
@@ -97,10 +97,11 @@ app.module.directive('appSimpleSearch', app.simpleSearchDirective);
  * @param {angular.Attributes} $attrs Angular attributes.
  * @param {string} apiUrl Base URL of the API.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {app.Url} appUrl URL service.
  * @ngInject
  */
 app.SimpleSearchController = function(appDocument, $scope, $compile, $attrs, apiUrl,
-    gettextCatalog, $templateCache, appAuthentication) {
+    gettextCatalog, $templateCache, appAuthentication, appUrl) {
 
   /**
    * @type {app.Document}
@@ -157,6 +158,12 @@ app.SimpleSearchController = function(appDocument, $scope, $compile, $attrs, api
    * @private
    */
   this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {app.Url}
+   * @private
+   */
+  this.url_ = appUrl;
 
   /**
    * @type {TypeaheadOptions}
@@ -342,10 +349,8 @@ app.SimpleSearchController.select_ = function(event, doc, dataset) {
   if (this.selectHandler) {
     this.selectHandler({'doc': doc});
   } else {
-    var lang = doc.locales[0].lang;
-    var type = doc.documentType;
-    var url = app.utils.buildDocumentUrl(type, doc.document_id, lang);
-    window.location.href = url;
+    window.location.href = this.url_.buildDocumentUrl(
+      doc.documentType, doc.document_id, doc.locales[0]);
   }
 };
 

--- a/c2corg_ui/static/js/urlservice.js
+++ b/c2corg_ui/static/js/urlservice.js
@@ -11,6 +11,16 @@ goog.require('app');
  */
 app.Url = function(slug) {
 
+  slug.defaults.modes['custom'] = {
+    replacement: '-',
+    symbols: false,
+    remove: null,
+    lower: true,
+    charmap: angular.extend({'\'': ' '}, slug.defaults.charmap),
+    multicharmap: slug.defaults.multicharmap
+  };
+  slug.defaults.mode = 'custom';
+
   /**
    * @type {function(string):string}
    * @private

--- a/c2corg_ui/static/js/urlservice.js
+++ b/c2corg_ui/static/js/urlservice.js
@@ -1,0 +1,44 @@
+goog.provide('app.Url');
+
+goog.require('app');
+
+
+/**
+ * @param {function(string):string} slug angular-slug service.
+ * @constructor
+ * @ngInject
+ * @struct
+ */
+app.Url = function(slug) {
+
+  /**
+   * @type {function(string):string}
+   * @private
+   */
+  this.slug_ = slug;
+};
+
+
+/**
+ * @param {string} documentType The document type.
+ * @param {number} documentId The document id.
+ * @param {appx.DocumentLocale} locale Document locale data.
+ * @param {string=} lang Lang.
+ * @return {string} Url.
+ */
+app.Url.prototype.buildDocumentUrl = function(documentType, documentId, locale, lang) {
+  lang = lang || locale['lang'];
+  var title = '';
+  if (locale && documentType === 'routes' && locale['title_prefix']) {
+    title = locale['title_prefix'] + ' ';
+  }
+  title += locale['title'];
+  return '/{type}/{id}/{lang}/{slug}'
+    .replace('{type}', documentType)
+    .replace('{id}', String(documentId))
+    .replace('{lang}', lang)
+    .replace('{slug}', this.slug_(title));
+};
+
+
+app.module.service('appUrl', app.Url);

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -26,23 +26,6 @@ app.utils.getDoctype = function(type) {
 
 
 /**
- * @param {string} documentType The document type.
- * @param {string|number} documentId The document id.
- * @param {string} lang Lang.
- * @return {string} Url.
- */
-app.utils.buildDocumentUrl = function(documentType, documentId, lang) {
-  if (!documentType || !documentId || !lang) {
-    return '';
-  }
-  return '/{type}/{id}/{lang}'
-    .replace('{type}', documentType)
-    .replace('{id}', String(documentId))
-    .replace('{lang}', lang);
-};
-
-
-/**
  * @param {ol.interaction.MouseWheelZoom} mouseWheelZoomInteraction
  */
 app.utils.setupSmartScroll = function(mouseWheelZoomInteraction) {

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -101,6 +101,8 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/blueimp-load-image/js/load-image-exif-map.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/photoswipe/dist/photoswipe.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/photoswipe/dist/photoswipe-ui-default.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-slug/angular-slug.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/slug/slug.js' % node_modules_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>
     <script src="${request.static_url('c2corg_ui:static/js/main.js')}"></script>
 % else:
@@ -123,6 +125,8 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_url('%s/blueimp-load-image/js/load-image.all.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/photoswipe/dist/photoswipe.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/photoswipe/dist/photoswipe-ui-default.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-slug/angular-slug.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/slug/slug.js' % node_modules_path)}"></script>
     <script src="${request.static_url('c2corg_ui:static/build/build.js')}"></script>
 % endif
 

--- a/c2corg_ui/templates/document/diff.html
+++ b/c2corg_ui/templates/document/diff.html
@@ -10,7 +10,7 @@
   <h3 class="text-center" translate>Comparing documents</h3>
   <h2 class="text-center">${title}</h2><br>
   <p class="text-center">
-    <a href="${request.route_url(module + '_view', id=document_id, lang=lang)}">
+    <a href="${request.route_url(module + '_view_id_lang', id=document_id, lang=lang)}">
       <button class="btn orange-btn" translate>See the latest version</button>
     </a>
   </p>

--- a/c2corg_ui/templates/document/history.html
+++ b/c2corg_ui/templates/document/history.html
@@ -1,3 +1,6 @@
+<%!
+    from slugify import slugify
+%>
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/view.html" import="show_version_comment"/>
@@ -46,7 +49,7 @@
             % endif
             <%
                 if loop.first:
-                    version_url = request.route_url(module + '_view', id=document_id, lang=lang)
+                    version_url = request.route_url(module + '_view', id=document_id, lang=lang, slug=slugify(title))
                 else:
                     version_url = request.route_url(module + '_archive', id=document_id, lang=lang, version=v['version_id'])
             %>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -1,6 +1,7 @@
 <%!
     from c2corg_ui.templates.utils import get_attr
     from json import dumps, loads
+    from slugify import slugify
 %>
 
 <%def name="show_attr(obj, key, parse=True)">\
@@ -19,7 +20,7 @@
       <p><b translate>Changes</b>: <span x-translate>${show_version_comment(version)}</span></p>
     </div>
     <p class="text-center">
-        <a href="${request.route_url(module + '_view', id=document['document_id'], lang=locale['lang'])}">
+        <a href="${request.route_url(module + '_view_id_lang', id=document['document_id'], lang=locale['lang'])}">
           <button class="btn btn-default" translate>See the latest version</button>
         </a>
     </p>
@@ -33,7 +34,7 @@
       <ul>
       % for l in other_langs:
         <li>
-          <a href="${request.route_url(module + '_view', id=document['document_id'], lang=l)}" x-translate>${l}</a>
+          <a href="${request.route_url(module + '_view_id_lang', id=document['document_id'], lang=l)}" x-translate>${l}</a>
           <span class="glyphicon glyphicon-chevron-right"></span>
         </li>
       % endfor
@@ -111,12 +112,11 @@
       % for doc in documents:
         <%
             locale = doc['locales'][0]
+            title = locale['title_prefix'] + ' : ' if doctype == 'routes' and locale['title_prefix'] is not None else ''
+            title += locale['title']
         %>
-        ## TODO add slug to URL
         <li>
-          <a href="${request.route_url(doctype + '_view', id=doc['document_id'], lang=locale['lang'])}">
-            ${locale['title_prefix'] + ' : ' if doctype == 'routes' and locale['title_prefix'] is not None else ''}${locale['title']}
-          </a>
+          <a href="${request.route_url(doctype + '_view', id=doc['document_id'], lang=locale['lang'], slug=slugify(title))}">${title}</a>
         </li>
       % endfor
     </ul>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -604,7 +604,7 @@ updating_doc = outing_id and outing_lang
             <p class="float-button-text" translate>What is missing?</p>
           </button>
           <%
-          view_url = request.route_url('outings_view', id=outing_id, lang=outing_lang) if updating_doc else ''
+          view_url = request.route_url('outings_view_id_lang', id=outing_id, lang=outing_lang) if updating_doc else ''
           index_url = request.route_url('outings_index')
           %>
           <button type="button" class="btn btn-lg gray-btn float-button" ng-click="editCtrl.cancel('${view_url}', '${index_url}')"  tooltip-placement="left" uib-tooltip="{{'Cancel' | translate}}">

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -677,7 +677,7 @@ updating_doc = route_id and route_lang
             <span class="glyphicon glyphicon-ok"></span>
           </button>
           <%
-          view_url = request.route_url('routes_view', id=route_id, lang=route_lang) if updating_doc else ''
+          view_url = request.route_url('routes_view_id_lang', id=route_id, lang=route_lang) if updating_doc else ''
           index_url = request.route_url('routes_index')
           %>
           <button type="button" class="btn btn-lg gray-btn float-button" ng-click="editCtrl.cancel('${view_url}', '${index_url}')"  tooltip-placement="left" uib-tooltip="{{'Cancel' | translate}}">

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -792,7 +792,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             <span class="glyphicon glyphicon-ok"></span>
           </button>
           <%
-          view_url = request.route_url('waypoints_view', id=waypoint_id, lang=waypoint_lang) if updating_doc else ''
+          view_url = request.route_url('waypoints_view_id_lang', id=waypoint_id, lang=waypoint_lang) if updating_doc else ''
           index_url = request.route_url('waypoints_index')
           %>
           <button type="button" class="btn gray-btn btn-lg float-button" ng-click="editCtrl.cancel('${view_url}', '${index_url}')" tooltip-placement="left" uib-tooltip="{{'Cancel' | translate}}">

--- a/c2corg_ui/tests/views/__init__.py
+++ b/c2corg_ui/tests/views/__init__.py
@@ -26,15 +26,11 @@ class BaseTestUi(BaseTestCase):
         self.assertEqual(response.content_type, 'text/html')
 
         # ask for a non existing lang foo
-        route = '/%s/1/foo' % self._prefix
-        response = self.app.get(route, status=400)
-
-        # ask for a non integer document id foo
-        route = '/%s/foo/fr' % self._prefix
+        route = '/%s/1/foo/bar' % self._prefix
         response = self.app.get(route, status=400)
 
         # ask for a non existing document
-        route = '/%s/9999999999/fr' % self._prefix
+        route = '/%s/9999999999/fr/bar' % self._prefix
         response = self.app.get(route, status=404)
 
     def _test_api_call(self):

--- a/c2corg_ui/tests/views/test_outing.py
+++ b/c2corg_ui/tests/views/test_outing.py
@@ -25,7 +25,7 @@ class TestOutingUi(BaseTestUi):
         self._test_get_documents()
 
     def test_detail(self):
-        url = '/{0}/735574/fr'.format(self._prefix)
+        url = '/{0}/735574/fr/foo'.format(self._prefix)
         self._test_page(url, outing_detail_mock, '735574-fr-1')
 
     def test_archive(self):

--- a/c2corg_ui/tests/views/test_route.py
+++ b/c2corg_ui/tests/views/test_route.py
@@ -1,6 +1,6 @@
 import os
 
-from httmock import all_requests
+from httmock import HTTMock, all_requests
 
 from c2corg_ui.tests.views import BaseTestUi, handle_mock_request
 from c2corg_ui.views.route import Route
@@ -24,8 +24,17 @@ class TestRouteUi(BaseTestUi):
     def test_get_documents(self):
         self._test_get_documents()
 
+    def test_slug(self):
+        with HTTMock(route_detail_mock):
+            url = '/{0}/736901/ca'.format(self._prefix)
+            resp = self.app.get(url, status=301)
+
+            redir = resp.headers.get('Location')
+            self.assertEqual(
+                redir, 'http://localhost/routes/736901/ca/comillini-des-de-cadolla-per-la-casa-encantada')  # noqa
+
     def test_detail(self):
-        url = '/{0}/736901/ca'.format(self._prefix)
+        url = '/{0}/736901/ca/foo'.format(self._prefix)
         self._test_page(url, route_detail_mock, '736901-ca-1')
 
     def test_archive(self):

--- a/c2corg_ui/tests/views/test_waypoint.py
+++ b/c2corg_ui/tests/views/test_waypoint.py
@@ -27,11 +27,20 @@ class TestWaypointUi(BaseTestUi):
     def test_get_documents(self):
         self._test_get_documents()
 
+    def test_slug(self):
+        with HTTMock(waypoint_detail_mock):
+            url = '/{0}/117982/fr'.format(self._prefix)
+            resp = self.app.get(url, status=301)
+
+            redir = resp.headers.get('Location')
+            self.assertEqual(
+                redir, 'http://localhost/waypoints/117982/fr/vallorbe')
+
     def test_detail_etag(self):
         """ An ETag header is set, using the ETag of the API response.
         """
         with HTTMock(waypoint_detail_mock):
-            url = '/{0}/117982/fr'.format(self._prefix)
+            url = '/{0}/117982/fr/foo'.format(self._prefix)
             resp = self.app.get(url, status=200)
 
             etag = resp.headers.get('ETag')
@@ -53,7 +62,7 @@ class TestWaypointUi(BaseTestUi):
             self.app.get(url, status=200, headers=headers)
 
     def test_detail_caching(self):
-        url = '/{0}/117982/fr'.format(self._prefix)
+        url = '/{0}/117982/fr/foo'.format(self._prefix)
         cache_key = self.view._get_cache_key(117982, 'fr')
 
         with HTTMock(waypoint_detail_mock):
@@ -82,7 +91,7 @@ class TestWaypointUi(BaseTestUi):
     def test_detail_caching_debug(self):
         """ Check that the cache is not used when using the debug flag.
         """
-        url = '/{0}/117982/fr?debug'.format(self._prefix)
+        url = '/{0}/117982/fr/foo?debug'.format(self._prefix)
         cache_key = self.view._get_cache_key(117982, 'fr')
         cache_document_detail.delete(cache_key)
 

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -420,7 +420,8 @@ class Document(object):
 
         # TODO use a dedicated service that returns only title/title_prefix
         # TODO also support URLs with no lang (should redirect to "best" lang)
-        document, locale = self._get_document(id, lang)
+        not_modified, api_cache_key, data = self._get_document(id, lang)
+        (document, locale) = data
         title = ''
         if self._API_ROUTE == 'routes' and locale['title_prefix']:
             title += locale['title_prefix'] + ' '

--- a/c2corg_ui/views/outing.py
+++ b/c2corg_ui/views/outing.py
@@ -26,6 +26,11 @@ class Outing(Document):
         })
         return self.template_input
 
+    @view_config(route_name='outings_view_id')
+    @view_config(route_name='outings_view_id_lang')
+    def redirect_to_full_url(self):
+        self._redirect_to_full_url()
+
     @view_config(route_name='outings_view')
     def detail(self):
         id, lang = self._validate_id_lang()

--- a/c2corg_ui/views/route.py
+++ b/c2corg_ui/views/route.py
@@ -27,6 +27,11 @@ class Route(Document):
         })
         return self.template_input
 
+    @view_config(route_name='routes_view_id')
+    @view_config(route_name='routes_view_id_lang')
+    def redirect_to_full_url(self):
+        self._redirect_to_full_url()
+
     @view_config(route_name='routes_view',
                  renderer='c2corg_ui:templates/route/view.html')
     def detail(self):

--- a/c2corg_ui/views/waypoint.py
+++ b/c2corg_ui/views/waypoint.py
@@ -31,6 +31,11 @@ class Waypoint(Document):
         })
         return self.template_input
 
+    @view_config(route_name='waypoints_view_id')
+    @view_config(route_name='waypoints_view_id_lang')
+    def redirect_to_full_url(self):
+        self._redirect_to_full_url()
+
     @view_config(route_name='waypoints_view')
     def detail(self):
         id, lang = self._validate_id_lang()

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular-gettext": "2.3.4",
     "angular-gettext-tools": "2.2.3",
     "angular-messages": "1.5.8",
+    "angular-slug": "git://github.com/lucasconstantino/angular-slug#v0.0.4",
     "eslint": "2.13.1",
     "eslint-config-openlayers": "5.0.0",
     "jquery": "2.2.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gunicorn==19.6.0
 dogpile.cache==0.6.1
 redis==2.10.5
 transifex-client==0.12.1
+python-slugify==1.2.0
 
 # c2corg_common project
 # for development use a local checkout


### PR DESCRIPTION
Fixes https://github.com/c2corg/v6_ui/issues/109
Fixes https://github.com/c2corg/v6_ui/issues/204

Document URL can be of 3 forms:
* {type}/{id}
* {type}/{id}/{lang}
* {type}/{id}/{lang}/{slug}

The standard one is the third one. When loaded, the 2 others should redirect to it. If the lang is missing, the "best" lang should be found out by the API.

As for now the PR use the standard ``Document.get_document()`` function to get the lang and title of the document (in order to figure the slug out). This is not optimal since this triggers a full document retrieval. We need to create a special service for that in the API. See https://github.com/c2corg/v6_api/issues/364

The serve-side generated slugs uses https://github.com/un33k/python-slugify (there's also https://github.com/dimka665/awesome-slugify both seem quite equivalent).

We also need to slugify the document URLs in the cards (client-side). I have found those 2 angular libs:
* https://github.com/paulsmith/angular-slugify
* https://github.com/lucasconstantino/angular-slug

TODO
* [x] server-side slugs
* [x] client-side slugs
* [x] fix conflicts with the caching system
* [x] update tests