### PR TITLE
Enable ETag header for listing pages

### DIFF
--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -51,15 +51,12 @@ class Document(object):
         }
 
     def _index(self, template):
-        # FIXME no ETag is set, because the filters are set as query params,
-        # see https://github.com/c2corg/v6_ui/issues/554
         return get_or_create_page(
             self._API_ROUTE,
             template,
             self.template_input,
             self.request,
-            self.debug,
-            no_etag=True
+            self.debug
         )
 
     def _get_or_create_detail(self, id, lang, render_page):


### PR DESCRIPTION
Now that https://github.com/c2corg/v6_ui/issues/554 is fixed. This makes it possible that the page can be cached by the browser and Varnish.