### PR TITLE
Remove debug param stripping in advanced search

### DIFF
--- a/c2corg_ui/static/js/search/advancedsearch.js
+++ b/c2corg_ui/static/js/search/advancedsearch.js
@@ -135,7 +135,6 @@ app.AdvancedSearchController.prototype.getResults_ = function() {
   var url = this.location_.getUriString();
   var qstr = goog.uri.utils.getFragment(url) || '';
   qstr += '&pl=' + this.gettextCatalog_.currentLanguage;
-  qstr = qstr.replace('debug', ''); // FIXME better handling of special params?
   this.api_.listDocuments(this.doctype, qstr).then(
     this.successList_.bind(this)
   );


### PR DESCRIPTION
Since the advanced search params are passed in the URL using ``#`` instead of ``?``, ``?debug`` in the advanced search URLs is no longer automatically propagated to the API request (by the way would it really be a problem?).

As a result this PR removes the ``debug`` removal.