### PR TITLE
disable deleting the last associated wp

### DIFF
--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -304,7 +304,7 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
     };
     this.api_.updateDocument(this.module_, this.id_, data).then(function() {
       window.location.href = this.url_.buildDocumentUrl(
-        this.module_, this.id_, data['locales']['0']);
+        this.module_, this.id_, this.documentService.document['locales'][0]);
     }.bind(this)
     );
   } else {
@@ -314,7 +314,7 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
     this.api_.createDocument(this.module_, data).then(function(response) {
       this.id_ = response['data']['document_id'];
       window.location.href = this.url_.buildDocumentUrl(
-        this.module_, this.id_, data['locales']['0']);
+        this.module_, this.id_, data['locales'][0]);
     }.bind(this));
   }
 };

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -180,7 +180,11 @@
            <app-card app-card-doc="doc"></app-card>
         % if showDelete:
         <app-delete-association child-doctype="${type}" parent-id="${document['document_id']}" child-id="doc.document_id"
-                                ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+                                ng-if="userCtrl.auth.isAuthenticated()
+                                % if document['doctype'] == 'routes':
+                                    && ${associations}.length > 1
+                                % endif
+                                "></app-delete-association>
         % endif
       </div>
     </div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1104,7 +1104,7 @@ ul {
       color: red;
       font-size: 1.3em;
       right: 10px;
-      top: 80%;
+          top: calc(~"100% - 25px");
       @media @phone {
         font-size: 1em;
         top: 78%;

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -270,7 +270,7 @@
       }
       &.route-associations {
         width: 100%;
-        padding: 1%;
+        padding: 2%;
       }
       .associated-documents {
         padding-bottom: 10px;


### PR DESCRIPTION
related to #511
 
when creating a route with associated waypoints, one of them NEEDS to be the main waypoint, therefore you will not be able to save a route with associated waypoint where none of them is the main one. 

- when associating the 1st wp to route, it will appear automatically as the main wp
- when deleting the main wp, while you still have some other wps, the first one will become the main wp

Like this, when you are on a view page, you will always find some associated waypoints where least one is the main one -> this one cannot be deleted and thus you will not be able to delete all the associated waypoints.