### PR TITLE
Don't use latest version of zope.interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ dogpile.cache==0.6.1
 redis==2.10.5
 transifex-client==0.12.1
 python-slugify==1.2.0
+# Not using the latest version of 'zope.interface' because of:
+# https://github.com/Pylons/pyramid/issues/2758
+zope.interface==4.2.0
 
 # c2corg_common project
 # for development use a local checkout


### PR DESCRIPTION
The latest release of `zope.interface` which was released today is not usable with Pyramid (see https://github.com/Pylons/pyramid/issues/2758). We will go with the previous version for now.