### PR TITLE
Fix document title badges

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -1,6 +1,8 @@
 <%!
     from c2corg_ui.templates.utils import get_attr
     from json import dumps, loads
+    from shapely.geometry import asShape
+    from math import floor
     from slugify import slugify
 %>
 
@@ -674,7 +676,6 @@
   </div>
 </%def>
 
-
 <%def name="get_comments()">\
   <div class="view-details-comments col-xs-12 comments">
     <h3 class="heading comments"
@@ -696,4 +697,22 @@
       </div>
     </section>
   </div>
+</%def>
+
+<%def name="show_badge(document, type)">\
+  <%
+      fragments = []
+      if document.get('geometry') and document.get('geometry').get('geom'):
+          geojson = loads(document.get('geometry').get('geom'))
+          geom = asShape(geojson)
+          buffer = geom.buffer(10000)
+          bounds = map(floor, buffer.bounds)
+          fragments.append(('bbox', ','.join(map(str, bounds))))
+      if type == 'waypoint':
+          fragments.append(('wtyp', document['waypoint_type']))
+  %>
+  <label class="badge ${type}">
+    <a href="${request.route_url(type + 's_index')}#${'&'.join(['='.join(fragment) for fragment in fragments])}"><span
+       class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>${type}</span></a>
+  </label>
 </%def>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -7,10 +7,11 @@ from json import dumps
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
 
-<%namespace file="helpers/detailed_images_attributes.html" import="get_image_general, get_image_camera_settings"/>
+<%namespace file="helpers/detailed_images_attributes.html"
+    import="get_image_general, get_image_camera_settings"/>
 
 <%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery,
-    show_attr, show_missing_langs_links, show_other_langs_links,
+    show_attr, show_missing_langs_links, show_other_langs_links, show_badge,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, delete_association_confirmation_modal"/>
 
@@ -60,9 +61,7 @@ other_langs, missing_langs = get_lang_lists(image, lang)
   <h1 class="routes">
     <div class="icons-header">${get_route_activities(image, 'top')}</div>
     <span class="title">${show_route_title(locale)}</span><br>
-    <label class="badge" onClick="window.location='${request.route_url('images_index')}' ">
-      <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>image</span>
-    </label>
+    ${show_badge(image, 'image')}
   </h1>
 </header>
 

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -8,11 +8,12 @@ from json import dumps
 <%namespace file="../helpers/common.html" import="show_title, show_fulldate"/>
 <%namespace file="helpers/detailed_outings_attributes.html" import="get_outing_snow,
     get_outing_access, get_outing_participants, get_outing_general, get_outing_heights"/>
-<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_min_max,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery,
+    photoswipe_gallery, get_document_min_max,
     get_document_locale_text, show_attr, show_missing_langs_links, show_other_langs_links,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, delete_association_confirmation_modal,
-    associated_images_featurelist"/>
+    associated_images_featurelist, show_badge"/>
 
 <%
 outing_id = outing['document_id']
@@ -69,9 +70,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   <h1 class="routes">
     <div class="icons-header routes">${get_route_activities(outing, 'top')}</div>
     <span class="title">${show_route_title(locale)}</span><br>
-    <label class="badge route" onClick="window.location='${request.route_url('outings_index')}' ">
-      <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>outing</span>
-    </label>
+    ${show_badge(outing, 'outing')}
   </h1>
   <div class="outing-date" class="ng-cloak">${show_fulldate(outing['date_start'], outing['date_end'])}</div>
 </header>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -5,15 +5,18 @@ from json import dumps
 %>
 
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery,
+    photoswipe_gallery, get_document_locale_text,
     get_document_locale_text, show_attr, show_missing_langs_links,
     show_other_langs_links, show_archive_data, show_route_title,
     show_areas, show_float_buttons, show_maps, get_route_activities,
     show_associated_waypoints, show_associated_routes, show_associated_outings,
-    delete_association_confirmation_modal, associated_waypoints_featurelist" />
+    delete_association_confirmation_modal, associated_waypoints_featurelist,
+    show_badge" />
 
-<%namespace file="helpers/detailed_route_attributes.html" import="get_route_location, get_route_glacier_gear,
-    get_route_rating, get_route_general, get_route_heights, get_route_access, get_route_associated_maps" />
+<%namespace file="helpers/detailed_route_attributes.html" import="get_route_location,
+    get_route_glacier_gear, get_route_rating, get_route_general, get_route_heights,
+    get_route_access, get_route_associated_maps" />
 
 <%
 route_id = route['document_id']
@@ -82,9 +85,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   <h1 class="routes">
     <div class="icons-header routes">${get_route_activities(route, 'top')}</div>
     <span class="title">${show_route_title(locale)}</span>
-    <label class="badge route" onClick="window.location='${request.route_url('routes_index')}' ">
-      <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>route</span>
-    </label>
+    ${show_badge(route, 'route')}
   </h1>
 </header>
 

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -10,11 +10,13 @@ from json import dumps
     get_waypoint_orientation, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
     get_waypoint_maps_info"/>
-<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery, photoswipe_gallery, get_document_locale_text,
+<%namespace file="../helpers/view.html" import="get_comments, get_image_gallery,
+    photoswipe_gallery, get_document_locale_text,
     show_attr, show_missing_langs_links, show_other_langs_links, show_archive_data,
     show_route_title, show_areas, show_maps, show_float_buttons,
     show_associated_waypoints, show_associated_routes, show_associated_outings,
-    delete_association_confirmation_modal, associated_waypoints_featurelist, associated_routes_featurelist"/>
+    delete_association_confirmation_modal, associated_waypoints_featurelist,
+    associated_routes_featurelist, show_badge"/>
 
 <%
 waypoint_id = waypoint['document_id']
@@ -86,9 +88,7 @@ geometry4326 = geometry
   <h1>
     <span class="icon-${waypoint['waypoint_type']} waypoint-type" uib-tooltip="{{mainCtrl.translate('${waypoint['waypoint_type']}')}}"></span>
     <span>${locale['title']}</span>
-    <label class="badge waypoint" onClick="window.location='${request.route_url('waypoints_index', _query={'wtyp': waypoint['waypoint_type']})}'">
-      <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>waypoint</span>
-    </label>
+    ${show_badge(waypoint, 'waypoint')}
   </h1>
 </header>
 

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -81,6 +81,12 @@
       margin-top: 5px;
       cursor: pointer;
 
+      a {
+        color: white;
+        cursor: pointer;
+        text-decoration: none;
+      }
+
       @media @phone {
         display: none;
       }


### PR DESCRIPTION
This PR:
* adds a mako helper for showing the document title badges
* replaces ``?`` by ``#`` in the badge URLs
* add a ``bbox`` filter in those URLs set as the document point geom with a buffer of 10 km
* use regular HTML link tags instead of JS ``onclick``

Fixes https://github.com/c2corg/v6_ui/issues/567