### PR TITLE
Fix some translate directives

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -713,6 +713,6 @@
   %>
   <label class="badge ${type}">
     <a href="${request.route_url(type + 's_index')}#${'&'.join(['='.join(fragment) for fragment in fragments])}"><span
-       class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>${type}</span></a>
+       class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span x-translate>${type}</span></a>
   </label>
 </%def>

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -61,7 +61,6 @@
 <span translate>summary</span>
 
 ## auth
-<span translate>Login failed</span>
 <span translate>Invalid email address</span>
 <span translate>already used username</span>
 <span translate>Register success</span>

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -68,7 +68,7 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
             <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
               <label><span translate>lang</span> *</label>
               % if image_lang:
-              <input disabled x-translate class="form-control" value="${image_lang}">
+              <input disabled class="form-control" value="{{mainCtrl.translate('${image_lang}')}}">
               % else:
               <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="image.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
@@ -86,8 +86,8 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
             </div>
 
             ## THE IMAGE
-            <a class="full" href="#" translate data-target="#image" data-toggle="collapse"><label translate>see the image</label></a>
-            <div  id="image" class="collapse">
+            <a class="full" href="#" data-target="#image" data-toggle="collapse"><label translate>see the image</label></a>
+            <div id="image" class="collapse">
               <div class="image" style="background-image: url('{{editCtrl.createImgUrl(image.filename)}}');"></div>
             </div>
 
@@ -119,8 +119,8 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
             <div class="form-group half">
               <label translate>image_categories</label>
               <ul class="types">
-                <li ng-repeat="type in ${image_categories}" ng-click="editCtrl.pushToArray(image, 'categories', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="image.categories.indexOf(type) > -1"><span>{{type|| translate}}</span></div>
+                <li ng-repeat="category in ${image_categories}" ng-click="editCtrl.pushToArray(image, 'categories', category, $event)">
+                  <div class="checkbox"><input type="checkbox" ng-checked="image.categories.indexOf(category) > -1"><span>{{category | translate}}</span></div>
                 </li>
               </ul>
             </div>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -210,7 +210,7 @@ updating_doc = outing_id and outing_lang
 
       <div class="step step-2">
         <section class="section weather">
-          <h2 class="heading show-phone"><span translate>weather </span></h2>
+          <h2 class="heading show-phone"><span translate>weather</span></h2>
           <div class="content outing-weather" id="title-edit">
 
             ## DATE START
@@ -268,7 +268,7 @@ updating_doc = outing_id and outing_lang
               <table class="table table-striped conditions-levels" ng-if="outing.locales[0].conditions_levels[0]">
                 <thead>
                   <tr>
-                    <th class="location"><span translate>location</span> / <span translate>altitude</span> / <span translate>orientations</span></th>
+                    <th class="location"><span translate>location</span> / <span translate>elevation</span> / <span translate>orientations</span></th>
                     <th class="soft-snow"><span translate>soft snow</span> (cm)</th>
                     <th class="total-snow"><span translate>total snow</span> (cm)</th>
                     <th class="comment" translate>comment</th>
@@ -372,11 +372,11 @@ updating_doc = outing_id and outing_lang
               <label translate>avalanche_signs</label>
               <ul class="types">
                 <li ng-click="outing.avalanche_signs.indexOf('no') == -1 ? (outing.avalanche_signs = ['no']) : (outing.avalanche_signs[outing.avalanche_signs.indexOf('no')] = null)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="outing.avalanche_signs.indexOf('no') > -1"><span>{{'no' | translate}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="outing.avalanche_signs.indexOf('no') > -1"><span translate>no</span></div>
                 </li>
                 ## don't show other options if 'no' is selected
                 <li ng-repeat="type in signs" ng-click="editCtrl.pushToArray(outing, 'avalanche_signs', type, $event)" ng-if="$index > 0 && outing.avalanche_signs.indexOf('no') == -1">
-                  <div class="checkbox"><input type="checkbox" ng-checked="outing.avalanche_signs.indexOf(type) > -1"><span>{{type | translate}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="outing.avalanche_signs.indexOf(type) > -1"><span x-translate>{{type}}</span></div>
                 </li>
               </ul>
             </div>
@@ -492,7 +492,7 @@ updating_doc = outing_id and outing_lang
             <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
               <label><span translate>lang</span> *</label>
               % if outing_lang:
-                <input disabled x-translate class="form-control" value="${outing_lang}">
+                <input disabled class="form-control" value="{{mainCtrl.translate('${outing_lang}')}}">
               % else:
                 <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="outing.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -74,7 +74,7 @@ updating_doc = route_id and route_lang
             <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
               <label><span translate>lang</span> *</label>
               % if route_lang:
-                <input disabled x-translate class="form-control" value="${route_lang}">
+                <input disabled class="form-control" value="{{mainCtrl.translate('${route_lang}')}}">
               % else:
                 <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="route.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
@@ -93,7 +93,7 @@ updating_doc = route_id and route_lang
         </section>
 
         <section class="section associations">
-          <h2 class="heading show-phone"><span translate>associations </span></h2>
+          <h2 class="heading show-phone"><span translate>associations</span></h2>
           <h5 class="full" translate ng-show="editCtrl.documentService.document.associations.routes.length == 0 && editCtrl.documentService.document.associations.waypoints.length == 0">
             You can add associated routes and waypoints by searching in the field.
           </h5>
@@ -154,7 +154,7 @@ updating_doc = route_id and route_lang
               <label translate>route_types</label>
               <ul class="types">
                 <li ng-repeat="type in ${route_types}" ng-click="editCtrl.pushToArray(route, 'route_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="route.route_types.indexOf(type) > -1"><span>{{type|| translate}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="route.route_types.indexOf(type) > -1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
 
@@ -165,7 +165,7 @@ updating_doc = route_id and route_lang
                 <label translate>route_configuration_types</label>
                 <ul class="types">
                   <li ng-repeat="type in ${route_configuration_types}" ng-click="editCtrl.pushToArray(route, 'configuration', type, $event)">
-                    <div class="checkbox"><input type="checkbox" ng-checked="route.configuration.indexOf(type) > -1"><span x-translate>{{type}}</span></div>
+                    <div class="checkbox"><input type="checkbox" ng-checked="route.configuration.indexOf(type) > -1"><span>{{type | translate}}</span></div>
                   </li>
                 </ul>
               </div>
@@ -177,7 +177,7 @@ updating_doc = route_id and route_lang
               <label translate>rock_types</label>
               <ul class="types long">
                 <li ng-repeat="type in ${rock_types}" ng-click="editCtrl.pushToArray(route, 'rock_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="route.rock_types.indexOf(type) > -1"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="route.rock_types.indexOf(type) > -1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -354,7 +354,7 @@ updating_doc = route_id and route_lang
               <label><span translate>durations</span> (<span translate>days</span>)</span></label>
               <ul class="types">
                 <li ng-repeat="type in ${route_duration_types}" ng-click="editCtrl.pushToArray(route, 'durations', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="route.durations.indexOf(type) > -1"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="route.durations.indexOf(type) > -1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -364,8 +364,8 @@ updating_doc = route_id and route_lang
               <label translate>lift_access</label>
               <div class="input-group">
                <select class="form-control" ng-model="route.lift_access">
-                  <option value="true" ng-selected="route.lift_access == true"><span translate>yes</span></option>
-                  <option value="false" ng-selected="route.lift_access == false"><span translate>no</span></option>
+                  <option value="true" ng-selected="route.lift_access == true" translate>yes</option>
+                  <option value="false" ng-selected="route.lift_access == false" translate>no</option>
                   <option value="" translate>no info</option>
                 </select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-resize-vertical"></span></span>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -90,7 +90,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
                  ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
               <label><span translate>lang</span> *</label>
               % if waypoint_lang:
-              <input class="form-control" disabled x-translate value="${waypoint_lang}">
+              <input class="form-control" disabled value="{{mainCtrl.translate('${waypoint_lang}')}}">
               % else:
               <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate"
                       ng-model="waypoint.locales[0].lang" class="form-control" required><option value=""></option></select>
@@ -237,7 +237,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate>rock_types</label>
               <ul class="types long">
                 <li ng-repeat="type in ${rock_types}" ng-click="editCtrl.pushToArray(waypoint, 'rock_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.rock_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.rock_types.indexOf(type) > - 1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -249,7 +249,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
                 <label translate>climbing_outdoor_types</label>
                 <ul class="types">
                   <li ng-repeat="type in ${climbing_outdoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_outdoor_types', type, $event)">
-                    <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_outdoor_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                    <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_outdoor_types.indexOf(type) > - 1"><span>{{type | translate}}</span></div>
                   </li>
                 </ul>
               </div>
@@ -258,8 +258,8 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <div class="form-group" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'">
                 <label translate>climbing_styles</label>
                 <ul class="types">
-                  <li ng-repeat="type in ${climbing_styles}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_styles', type, $event)">
-                    <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_styles.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                  <li ng-repeat="style in ${climbing_styles}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_styles', style, $event)">
+                    <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_styles.indexOf(style) > - 1"><span>{{style | translate}}</span></div>
                   </li>
                 </ul>
               </div>
@@ -271,7 +271,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate>best_periods</label>
               <ul class="types">
                 <li ng-click="editCtrl.pushToArray(waypoint, 'best_periods', month, $event)" ng-repeat="month in ${months}">
-                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.best_periods.indexOf(month) > - 1"><span x-translate>{{month}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.best_periods.indexOf(month) > - 1"><span>{{month | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -303,7 +303,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label><span translate>weather_station_types</span></label>
               <ul class="types">
                 <li ng-repeat="type in ${weather_station_types}" ng-click="editCtrl.pushToArray(waypoint, 'weather_station_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.weather_station_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.weather_station_types.indexOf(type) > - 1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -313,7 +313,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate>climbing_indoor_types</label>
               <ul class="types">
                 <li ng-repeat="type in ${climbing_indoor_types}" ng-click="editCtrl.pushToArray(waypoint, 'climbing_indoor_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_indoor_types.indexOf(type) > - 1"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox" ng-checked="waypoint.climbing_indoor_types.indexOf(type) > - 1"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -323,7 +323,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label><span translate>product_types</span><span ng-if="type == 'local_product'"> *</span></label>
               <ul class="types" required>
                 <li ng-repeat="type in ${product_types}" ng-click="editCtrl.pushToArray(waypoint, 'product_types', type, $event)">
-                  <div class="checkbox"><input type="checkbox"><span x-translate>{{type}}</span></div>
+                  <div class="checkbox"><input type="checkbox"><span>{{type | translate}}</span></div>
                 </li>
               </ul>
             </div>
@@ -500,9 +500,9 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
                  ng-class="{'has-success': waypoint.equipment_ratings }">
               <label><span translate>equipment_ratings</span></label><br>
               <ul class="types">
-                <li ng-repeat="type in ${equipment_ratings}" ng-click="editCtrl.pushToArray(waypoint, 'equipment_ratings', type, $event)">
+                <li ng-repeat="rating in ${equipment_ratings}" ng-click="editCtrl.pushToArray(waypoint, 'equipment_ratings', rating, $event)">
                   <div class="checkbox">
-                    <input type="checkbox" ng-checked="waypoint.equipment_ratings.indexOf(type) > - 1"><span x-translate>{{type}}</span>
+                    <input type="checkbox" ng-checked="waypoint.equipment_ratings.indexOf(rating) > - 1"><span>{{rating | translate}}</span>
                   </div>
                 </li>
               </ul>
@@ -556,9 +556,9 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate>lift_access</label>
               <div class="input-group">
                 <select class="form-control" ng-model="waypoint.lift_access">
-                  <option value="" translate></option>
-                  <option value="true" ng-selected="waypoint.lift_access == true"><span translate>yes</span></option>
-                  <option value="false" ng-selected="waypoint.lift_access == false"><span translate>no</span></option>
+                  <option value="" translate>no info</option>
+                  <option value="true" ng-selected="waypoint.lift_access == true" translate>yes</option>
+                  <option value="false" ng-selected="waypoint.lift_access == false" translate>no</option>
                 </select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-resize-vertical"></span></span>
               </div>
@@ -571,7 +571,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <ul class="types">
                 <li ng-repeat="type in ${public_transportation_types}" ng-click="editCtrl.pushToArray(waypoint, 'public_transportation_types', type, $event)">
                   <div class="checkbox">
-                    <input type="checkbox" ng-checked="waypoint.public_transportation_types.indexOf(type) > - 1"><span x-translate>{{type}}</span>
+                    <input type="checkbox" ng-checked="waypoint.public_transportation_types.indexOf(type) > - 1"><span>{{type | translate}}</span>
                   </div>
                 </li>
               </ul>
@@ -588,7 +588,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             </div>
 
             ## PARKING FEE TYPES
-            <div class="form-group data half" ng-if="type == 'access' " ng-class="{'has-success': waypoint.parking_fee}">
+            <div class="form-group data half" ng-if="type == 'access'" ng-class="{'has-success': waypoint.parking_fee}">
               <label translate>parking_fee_types</label>
               <select ng-options="type as mainCtrl.translate(type) for type in ${parking_fee_types}" ng-model="waypoint.parking_fee" class="form-control"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.parking_fee"></span>
@@ -739,7 +739,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## ACCESS PERIOD
             <div id="access-period" class="form-group data full" ng-if="['access', 'local_product', 'hut', 'gite', 'camp_site', 'climbing_outdoor'].indexOf(type) > -1">
-              <label translate ng-if="type == 'access' ">access_period</label>
+              <label translate ng-if="type == 'access'">access_period</label>
               <label translate ng-if="type == 'hut' || type == 'gite' || type == 'camp_site'">opening_periods</label>
               <label translate ng-if="type == 'local_product'">opening_hours</label>
               <textarea name="access_period" ng-model="waypoint.locales[0].access_period" class="form-control"


### PR DESCRIPTION
This PR:
* fix some incorrect "translate" directives that made variables being extracted and pushed to Transifex
* replaced some ``<span>{{type | translate}}</span>`` by ``<span x-translate>{{type}}</span>`` to be consistent with what we have done most of the time (for instance in the waypoint edit template)

By the way, does ``<span x-translate>{{type}}</span>`` really work? I was wondering if it could explain why some (all?) dropdown values were not translated (see https://github.com/c2corg/v6_ui/issues/602). Or maybe it's simply because those strings are not explicitely available in the templates and thus not extracted/pushed to Transifex.