### PR TITLE
delete-association btn +  activity-icon css fix

### DIFF
--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -265,7 +265,7 @@ main {
   flex-flow: wrap row;
   align-items: baseline;
   align-content: flex-start;
-  
+
   .list-item {
     flex-basis: 48%;
     @media @big {
@@ -1081,14 +1081,10 @@ ul {
     flex-wrap: wrap;
 
     app-delete-association {
-      position: absolute;
-      bottom: 30px;
-      right: 0;
-      margin-right: 5px;
       font-size: 15px;
 
       @media @phone {
-        font-size: 13px;
+        font-size: 14px;
       }
       .glyphicon {
         color: red;
@@ -1102,14 +1098,7 @@ ul {
       color: red;
       font-size: 1.3em;
       right: 10px;
-          top: calc(~"100% - 25px");
-      @media @phone {
-        font-size: 1em;
-        top: 78%;
-      }
+      top: calc(~"100% - 30px");
     }
-  }
-  .route-activities {
-    justify-content: flex-start !important;
   }
 }

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -120,9 +120,6 @@
     width: 100%;
 
     .route-activities {
-      .flex();
-      justify-content: space-around;
-      flex-flow: wrap row;
       @media @phone {
         justify-content: space-between;
       }
@@ -132,9 +129,6 @@
         cursor: pointer;
         @media (max-width: @screen-md-min) {
           width: 33%;
-        }
-        p {
-          text-align: center;
         }
       }
      [class^="icon-"] {
@@ -153,7 +147,7 @@
         }
       }
     }
-    #image{
+    #image {
       width: 100%;
       .image {
         height: 300px;
@@ -288,7 +282,9 @@
         padding: 2%;
       }
       .associated-documents {
-        padding-bottom: 10px;
+        padding: 0 10px 10px 10px;
+        border: 2px solid #eee;
+        border-radius: 5px;
       }
     }
     .heading {
@@ -571,6 +567,15 @@
     }
   }
 }
+
+.step-1, .step-2 {
+  .route-activities {
+    .flex();
+    flex-flow: wrap;
+    justify-content: center;
+  }
+}
+
 .bullet-container {
   position: absolute;
   width: 100%;

--- a/less/filters.less
+++ b/less/filters.less
@@ -62,7 +62,7 @@
     position: absolute;
     width: 100%;
     z-index: 5;
-    padding: 0;
+    padding-bottom: 20px;
     padding-top: 10px;
     top: 60px;
     box-shadow: 0 14px 14px -14px #332;

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -193,7 +193,7 @@ input[type=checkbox]:checked + * {
   }
 
   &.closed {
-    background-color: white;
+    background-color: white !important;
     color: @C2C-orange;
     transition: .2s ease-in-out;
 


### PR DESCRIPTION
- app-delete-association btn had an inconsistent margin in the cards.
- somehow activity-icons didn't appear on editing pages in the cards
- add a small padding-bottom at the end of the filters list
- ` heading.outing.closed` white text