### PR TITLE
Waypoint view fixes

### DIFF
--- a/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
+++ b/c2corg_ui/templates/waypoint/helpers/detailed_waypoint_attributes.html
@@ -30,6 +30,10 @@
     <p translate>General</p>
   </div>
   <span class="detail-text accordion">
+    % if waypoint.get('elevation'):
+      <p><span translate class="value-title">elevation</span>: <span class="value">${waypoint['elevation']} m</span></p>
+    % endif
+
     % if waypoint.get('waypoint_type'):
       <p><span translate class="value-title">waypoint_type</span>: <span x-translate class="value">${waypoint['waypoint_type']}</span></p>
     % endif

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -431,9 +431,9 @@
       }
 
       &.location {
-        .flex();
+        display: none;
         @media @phone {
-          .flex() !important;
+          .flex();
         }
         .areas {
           @media (min-width: @phone-max) {


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/613

I have also added the elevation attribute to the WP general section (by the way it is useful for the preview since the preview has no map at the moment). Not sure it is really necessary to display the areas+coords (wrong projection by the way)+elevation twice in the doc, but if OK then it's more consistent to show the elevation as well.
![sans titre](https://cloud.githubusercontent.com/assets/1192331/18471009/c9d9be8c-79af-11e6-854a-e2e499b05f40.png)
