### PR TITLE
make docker image publishing work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ deploy:
   script: make cleanall publish
   on:
     repo: c2corg/v6_ui
+    all_branches: true
+    tags: true
     condition: '"$TRAVIS_NODE_VERSION" = "4"'
 
 notifications:


### PR DESCRIPTION
See error at https://travis-ci.org/c2corg/v6_ui/jobs/159540799#L3954 for example.

cf https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A

This seems to have been broken (for non-master branches) since fe10809.