### PR TITLE
Add basic support of Google Analytics

### DIFF
--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -143,6 +143,7 @@ class NotFound():
           'error_msg': self.context.detail if self.context.detail else '',
           'ign_api_key': self.settings['ign_api_key'],
           'bing_api_key': self.settings['bing_api_key'],
+          'ganalytics_key': self.settings['ganalytics_key'],
           'image_backend_url': self.settings['image_backend_url'],
           'image_url': self.settings['image_url'],
           'discourse_url': self.settings['discourse_url'],

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -149,5 +149,11 @@ closure_library_path = settings.get('closure_library_path')
          app.sidemenu();
       })();
     </script>
+    <script>
+      window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+      ga('create','${ganalytics_key}',{'cookieDomain':window.location.host});
+      ga('send','pageview',{'anonymizeIp':true});
+    </script>
+    <script src="https://www.google-analytics.com/analytics.js" async defer></script>
   </body>
 </html>

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -50,6 +50,7 @@ class Document(object):
             'api_url': self.settings['api_url'],
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
+            'ganalytics_key': self.settings['ganalytics_key'],
             'image_backend_url': self.settings['image_backend_url'],
             'image_url': self.settings['image_url'],
             'discourse_url': self.settings['discourse_url']

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -14,6 +14,7 @@ class Pages(object):
             'api_url': self.settings['api_url'],
             'ign_api_key': self.settings['ign_api_key'],
             'bing_api_key': self.settings['bing_api_key'],
+            'ganalytics_key': self.settings['ganalytics_key'],
             'image_backend_url': self.settings['image_backend_url'],
             'image_url': self.settings['image_url'],
             'discourse_url': self.settings['discourse_url']

--- a/common.ini.in
+++ b/common.ini.in
@@ -18,6 +18,7 @@ redis.cache_pool = 20
 
 ign_api_key = {ign_api_key}
 bing_api_key = {bing_api_key}
+ganalytics_key = {ganalytics_key}
 
 pyramid.default_locale_name = fr
 

--- a/config/default
+++ b/config/default
@@ -20,6 +20,8 @@ export discourse_url = http://c2corgv6-discourse.demo-camptocamp.com/
 export ign_api_key = 9qxhimhvm24i40p8j86n7de3
 export bing_api_key = AudizIfCd3NAdt91ubJMGkMI-swfHxe1R-_U7KiLxCHqepDy70txQ-_-89_eevxc
 
+export ganalytics_key = FIXME
+
 export logging_level = WARNING
 export skip_captcha_validation = False
 


### PR DESCRIPTION
Simple integration based upon the code of v5:
https://github.com/c2corg/camptocamp.org/blob/1e60b94803765ca09fba533755dad0ecd4cad262/apps/frontend/modules/common/templates/_tracker.php

Please note though that:
* dimensions from v5 are not supported yet. They were used to track form factor and user status (connected or not)
* forum pages are not impacted by this PR. See https://github.com/c2corg/v6_forum/issues/46

I have also noticed there were AngularJS libs for integrating Google Analytics. For instance:
* https://www.npmjs.com/package/angular-google-analytics / https://github.com/revolunet/angular-google-analytics
* http://angulartics.github.io/
Should we use such tools instead?