### PR TITLE
Associated user documents id change

### DIFF
--- a/c2corg_ui/static/js/outingediting.js
+++ b/c2corg_ui/static/js/outingediting.js
@@ -147,10 +147,6 @@ app.DocumentEditingController.prototype.formatOuting_ = function(outing) {
       outing.date_end = window.moment(outing.date_end).format('YYYY-MM-DD');
     }
 
-    var associations = outing.associations;
-    for (var i = 0; i < associations['users'].length; i++) {
-      associations['users'][i]['id'] = associations['users'][i]['document_id'];
-    }
     // remove 'null' from the array, it's not accepted by the API
     if (outing.avalanche_signs && outing.avalanche_signs[0] === null) {
       if (outing.avalanche_signs.length === 1) {


### PR DESCRIPTION
The API now use 'document_id' instead of 'id' for associated users as well.
See https://github.com/c2corg/v6_api/commit/e0f61cde92e45830b856b3f930f4b3d5e1f7d271

See also https://github.com/c2corg/v6_ui/issues/619#issuecomment-247307134