### PR TITLE
Image slide

### DIFF
--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -439,17 +439,31 @@ app.Api.prototype.createImages = function(files, document) {
   var associations = {};
   associations[documentType] = [{'document_id': document.document_id}];
   var images = [];
+
   for (var i = 0; i < files.length; i++) {
-    var image = files[i]['metadata'];
-    image['size'] = files[i]['size'];
+    var file = files[i];
+    var meta = file['metadata'];
+    var date = meta['DateTime'] ? meta['DateTime'].substring(0, 10).split(':') : null; // convert "2015:12:31 20:56:09"
+    var image = meta;
+
+    image['categories'] = meta['categories'];
+    image['activities'] = meta['activities'];
+    image['file_size'] = file['size'];
+    image['exposure_time'] = meta['ExposureTime'];
     image['associations'] = associations;
     image['locales'] = [{'lang': document.lang, 'title': image['title']}];
+    image['date_time'] = date ? date[0] + '-' + date[1] + '-' + date[2] : window.moment(new Date()).format('YYYY-MM-DD');
+    image['iso_speed'] = meta['PhotographicSensitivity'];
+    image['focal_legth'] = meta['FocalLengthIn35mmFilm'];
+    image['fnumber'] = meta['FNumber'];
+    image['camera_name'] = (meta['Make'] && meta['Model']) ? (meta['Make'] + ' ' + meta['Model']) : null;
+
     images.push(image);
   }
-  var json = {'images': images};
 
-  var promise = this.postJson_('/images/list', json);
+  var promise = this.postJson_('/images/list', {'images': images});
   promise.catch(this.errorSaveDocument_.bind(this));
+  promise['images'] = images;
   return promise;
 };
 

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -220,7 +220,8 @@ app.CardController.prototype.getFullRatings = function() {
 };
 
 /**
- * @private
+ * @param {string} rating1
+ * @param {string} rating2
  * @return {string} rating
  */
 app.CardController.prototype.slashSeparatedRating_ = function(rating1, rating2) {

--- a/c2corg_ui/static/js/slideinfo.js
+++ b/c2corg_ui/static/js/slideinfo.js
@@ -4,9 +4,11 @@ goog.require('app');
 
 
 /**
+ * @param {angular.$compile} $compile Angular compile service.
  * @return {angular.Directive} Directive Definition Object.
+ * @ngInject
  */
-app.slideInfoDirective = function() {
+app.slideInfoDirective = function($compile) {
   return {
     restrict: 'E',
     controller: 'AppSlideInfoController as slideCtrl',
@@ -15,6 +17,7 @@ app.slideInfoDirective = function() {
     templateUrl: '/static/partials/slideinfo.html',
     link: function(scope, el) {
       angular.extend(scope, scope.$parent['photo']);
+      $compile(el.contents())(scope);
     }
   };
 };
@@ -43,37 +46,6 @@ app.SlideInfoController = function(appApi, $scope) {
    * @private
    */
   this.scope_ = $scope;
-
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.editing = false;
 };
-
-
-/**
- * @export
- */
-app.SlideInfoController.prototype.edit = function() {
-  this.editing = true;
-};
-
-
-/**
- * @export
- */
-app.SlideInfoController.prototype.save = function() {
-  this.editing = false;
-};
-
-
-/**
- * @export
- */
-app.SlideInfoController.prototype.cancel = function() {
-  this.editing = false;
-};
-
 
 app.module.controller('AppSlideInfoController', app.SlideInfoController);

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -119,23 +119,13 @@ app.utils.getImageFileBase64Source = function(file) {
  * @export
  */
 app.utils.createImageSlide = function(file, imageUrl) {
-  var img;
-  var ahref;
-  // if !src => it's an already existing image, else it's an image that has just been uploaded
-  if (!file['src']) {
-    ahref = '<a href="' + imageUrl + file.filename + '" data-info-id="' + file['document_id'] + '">';
-    img = '<img src="' + imageUrl + file.filename + '">';
-  } else {
-    ahref = '<a href="' + file['src'] + '" data-info-id="' + file['document_id'] + '">';
-    img = '<img src=" ' + file['src'] + '">';
-  }
-  return '<figure id="image-' + file['document_id'] + '">' +
-               ahref + img +
-               '</a>' +
-               '<app-slide-info></app-slide-info>' +
-             '</figure>';
-};
+  var smallImage = app.utils.createImageUrl(file.filename, 'SI');
+  var bigImage = app.utils.createImageUrl(file.filename, 'BI');
+  var ahref = '<a href="' + imageUrl + bigImage + '" data-info-id="' + file['image_id'] + '-slide">';
+  var img = '<img src="' + imageUrl + smallImage + '"></a>';
 
+  return '<figure id="' + file['image_id'] + '">' + ahref + img +  '<app-slide-info></app-slide-info></figure>';
+};
 
 /**
  * @param {string} url

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -2,13 +2,13 @@
        ngf-drop
        ngf-select
        ng-model="uplCtrl.files"
-       class="drop-box" 
+       class="drop-box"
        ngf-drag-over-class="'dragover'"
        ngf-multiple="true"
-       ngf-keep="'distinct'" 
+       ngf-keep="'distinct'"
        ngf-fix-orientation="true"
        ngf-allow-dir="true"
-       accept="image/*" 
+       accept="image/*"
        ngf-pattern="'image/*'">
     <span translate>Drop images here or click to upload</span>
   </div>
@@ -20,9 +20,10 @@
         <!-- EXIF INFO-->
         <div class="exif" ng-style="file.metadata.FocalLength && {'opacity': 1} || {'opacity' : 0}">
           <p ng-if="file.metadata.DateTime"><span class="glyphicon glyphicon-calendar"></span><span>{{file.metadata.DateTime}}</span></p>
-          <p><span class="glyphicon glyphicon-certificate"></span><span>{{file.metadata.FocalLength}}f</span>&nbsp;
-            <span ng-if="file.metadata.ShutterSpeedValue">1/{{file.metadata.ShutterSpeedValue}}s</span> &nbsp; 
-            <span><b>ISO:</b> <span>{{file.metadata.PhotographicSensitivity}}</span></span>
+          <p><span class="glyphicon glyphicon-certificate"></span><span>f/{{file.metadata.FNumber}}</span>&nbsp;
+            <span ng-if="file.metadata.ExposureTime">1/{{1/file.metadata.ExposureTime}}&nbsp;s</span> &nbsp;
+            <span ng-if="file.metadata.FocalLengthIn35mmFilm">{{file.metadata.FocalLengthIn35mmFilm}}&nbsp;mm</span> &nbsp;
+            <span ng-if="file.metadata.PhotographicSensitivity">{{file.metadata.PhotographicSensitivity}}&nbsp;ISO</span>
           </p>
           <p ng-if="file.metadata.geo"><span class="glyphicon glyphicon-map-marker"></span><b>{{file.metadata.geo.label}}</b></p>
         </div>
@@ -31,7 +32,7 @@
 
       <div class="img-data">
         <!-- TITLE-->
-        <input type="text" class="form-control" ng-model="file.metadata.title" placeholder="title" ng-change="uplCtrl.rename(file, file.metadata.title)">
+        <input type="text" class="form-control" ng-model="file.metadata.title" placeholder="{{'title' | translate}}" ng-change="uplCtrl.rename(file, file.metadata.title)">
 
         <div class="image-attributes btn-group" ng-show="file['processed']">
           <!-- GEOLOCATION-->
@@ -107,14 +108,14 @@
          ngf-select
          multiple
          ng-model="uplCtrl.files"
-         class="drop-box" 
+         class="drop-box"
          ngf-drag-over-class="'dragover'"
          ngf-multiple="true"
-         ngf-keep="'distinct'" 
+         ngf-keep="'distinct'"
          ngf-fix-orientation="true"
          ngf-allow-dir="true"
-         accept="image/*" 
-         ngf-pattern="'image/*'"> 
+         accept="image/*"
+         ngf-pattern="'image/*'">
       <button class="orange-btn btn" type="button" translate>Add images</button>
     </div>
   </div>

--- a/c2corg_ui/static/partials/slideinfo.html
+++ b/c2corg_ui/static/partials/slideinfo.html
@@ -1,42 +1,46 @@
-<div id="{{document_id}}" class="ng-hide"> 
-  <h1 class="image-title">{{locales[0].title}}</h1> 
-  <div class="image-infos"> 
-    <h2 translate>Infos</h2> 
-    <p ng-show="date_time"><span class="glyphicon glyphicon-calendar"></span>{{date_time}}</p> 
-    <p><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p> 
-    <span ng-show="activities">
-      <label translate>activities</label> 
-      <ul> 
-        <li ng-repeat="activity in activities">{{activity| translate}}</li> 
-      </ul> 
-    </span>
-    <span ng-show="categories">
-      <label translate>categories</label> 
-      <ul> 
-        <li ng-repeat="category in categories">{{category| translate}}</li> 
-      </ul> 
-    </span>
-    <p ng-show="camera_name"><span class="glyphicon glyphicon-camera"></span> <label x-translate>{{camera_name}}</label></p> 
-    <p ng-show="image_type"><span class="glyphicon glyphicon-copyright-mark"></span><label x-translate>{{image_type[0]}}</label></p> 
-    <p ng-show="elevation"><span translate>elevation</span>: {{elevation}}m<p/> 
-    <div ng-show="iso_speed || fnumber || exposure_time">  
-      <label translate>Settings</label> 
-      <ul> 
-        <li ng-show="iso_speed"><span >{{iso_speed}} ISO</span></li>  
-        <li ng-show="exposure_time"><span translate>Shutter speed</span>: <span>{{exposure_time}}</span></li>  
-        <li ng-show="fnumber"><span translate>Aperture</span> : <span>{{fnumber}}</span></li>  
-      </ul> 
-    </div> 
-    <span class="image-infos-buttons"> 
-      <button class="btn btn-default" ng-click="slideCtrl.edit()" ng-show="!slideCtrl.editing"> 
-        <span class="glyphicon glyphicon-pencil"></span> 
-      </button> 
-      <button class="btn btn-success" ng-show="slideCtrl.editing" ng-click="slideCtrl.save()"> 
-        <span class="glyphicon glyphicon-ok"></span> 
-      </button> 
-      <button class="btn btn-danger" ng-show="slideCtrl.editing" ng-click="slideCtrl.cancel()"> 
-        <span class="glyphicon glyphicon-remove"></span> 
-      </button> 
-    </span> 
-  </div> 
+<div id="{{image_id}}-slide" class="ng-hide">
+  <h2 class="image-title">{{locales[0].title}}</h2>
+
+  <div class="image-infos">
+    <h2 translate>Infos</h2>
+
+    <p ng-show="date_time" class="date"><span class="glyphicon glyphicon-calendar"></span>{{date_time | amDateFormat:'Do MMMM YYYY'}}</p>
+    <p class="title"><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p>
+    <p ng-show="locales[0].description" class="description">{{locales[0].description}}</p>
+    <p ng-show="image_type" class="image-type"><span class="glyphicon glyphicon-copyright-mark"></span><label x-translate>{{image_type}}</label></p>
+
+    <div ng-show="activities.length > 0" class="activities">
+      <label translate>activities</label>
+      <ul>
+        <li ng-repeat="activity in activities">{{activity | translate}}</li>
+      </ul>
+    </div>
+
+    <div ng-show="categories.length > 0" class="categories">
+      <label translate>categories</label>
+      <ul>
+        <li ng-repeat="category in categories">{{category | translate}}</li>
+      </ul>
+    </div>
+
+    <div ng-show="iso_speed || focal_length || exposure_time || camera_name" class="settings">
+      <label translate>Settings</label>
+      <ul>
+        <li ng-show="camera_name"><span>{{camera_name}}</span></li>
+        <li ng-show="exposure_time" uib-tooltip="{{'exposure_time' | translate}}"><span>1/{{exposure_time}}&nbsp;s</span></li>
+        <li ng-show="fnumber" uib-tooltip="{{'fnumber' | translate}}"><span>f/{{fnumber}}</span></li>
+        <li ng-show="focal_length" uib-tooltip="{{'focal_length' | translate}}"><span>{{focal_length}}&nbsp;mm</span></li>
+        <li ng-show="iso_speed" uib-tooltip="{{'iso_speed' | translate}}"><span>{{iso_speed}}&nbsp;ISO</span></li>
+        <li ng-show="width && height" uib-tooltip="{{'resolution' | translate}}">{{height}} x {{width}} <span translate>pixels</span></li>
+      </ul>
+    </div>
+
+    <div class="image-infos-buttons">
+      <button class="btn btn-default" protected-url-btn url="{{edit_url}}">
+        <span class="glyphicon glyphicon-edit"></span>
+      </button>
+    </div>
+
+  </div>
+
 </div>

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -165,7 +165,7 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
               </div>
             </div>
 
-            <app-map class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-draw-type="Point" class="map-edit"></app-map>
 
           </div>
         </section>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -108,7 +108,7 @@ other_langs, missing_langs = get_lang_lists(image, lang)
       % endif
 
       <div class="view-details-description col-xs-12  description">
-        <span class="lead">
+        <span class="lead text-center">
           <img class="image" src="${image_url}/${image['filename']}" alt="${locale['title']}">
         </span>
       </div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1097,7 +1097,7 @@ ul {
       color: red;
       font-size: 1.3em;
       right: 10px;
-      top: calc(~"100% - 30px");
+      top: calc(~"100% - 60px");
     }
   }
 }

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -449,10 +449,6 @@
 .section {
   .associations {
     padding: 1%;
-    margin: 10px 2% 10px 2%;
-    .route-associations {
-      width: 100%;
-    }
   }
   &:last-child:not(.associations) {
     margin-bottom: 20%;

--- a/less/filters.less
+++ b/less/filters.less
@@ -1,6 +1,5 @@
 @import "variables.less";
 
-
 .filters-phone {
   overflow-y: scroll;
   height: 40vh;
@@ -240,7 +239,6 @@
     overflow-x: hidden;
     overflow-y: scroll;
     max-height : 250px;
-    width: 70%;
     margin-left: -5%;
   }
 

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -339,7 +339,7 @@ p {
   background-repeat: no-repeat;
   display: inline-table;
   position: absolute;
-  right: 10px;
+  right: 5px;
   bottom: 10px;
 
   &.draft {

--- a/less/images.less
+++ b/less/images.less
@@ -42,7 +42,7 @@
   margin-right: 1%;
   text-align: center;
   height: 280px;
-  
+
   @media @desktop {
     flex-basis: 31%;
   }
@@ -139,7 +139,7 @@
 .modal-xl {
   width: 90%;
   height: 90%;
-  
+
   @media @phone{
     width: 100%;
     height: 95%;
@@ -168,31 +168,13 @@
       transition: 0.3s;
     }
   }
-  &.vertical {
-    img {
-      height: 100%;
-      width: auto;
-      margin: auto;
-      transition: 0.3s;
-      &.showing-info {
-        transition: 0.3s;
-        width: auto;
-      }
-    }
-  }
   img {
-    width: 100%;
-    transition: 0.3s;
-    
+    max-width: 100%;
+    max-height: 100%;
+    margin: auto;
+
     &.showing-info {
-      width: 80%;
       transition: 0.3s;
-      @media @tablet {
-        width: 70%;
-      }
-      @media @phone {
-        width: 100%;
-      }
     }
   }
   .image-title {
@@ -210,7 +192,7 @@
   .image-infos {
     width: 20%;
     right: -20%;
-    padding: 3.5% 1.5% 0 2%;
+    padding: 50px 1.5% 0 2%;
     color: white;
     height: 100%;
     top: 0;
@@ -225,17 +207,29 @@
       transition: 0.3s;
       background-color: #1D1D1D;
       @media @phone {
-        width: 70%;
-        padding-left: 7%;
+        width: 50%;
+        padding: 30px;
       }
     }
-    .glyphicon:not(button) {
+    .activities, .categories, .image-type, .image-infos-buttons, .settings,
+    .title, .date, .description {
+      margin-top: 10px;
+    }
+    .glyphicon:not(.glyphicon-edit) {
       margin-right: 5px;
       color: gray;
     }
     .image-infos-buttons button {
-      margin-left: 5px;
-      float: right;
+      margin-top: 10px;
+      float: left;
+      padding: 9px 5px 5px 5px;
+      width: 40px;
+      border-radius: 50%;
+      height: 40px;
+      font-size: 1.3em;
+      .glyphicon-edit {
+        color: gray;
+      }
     }
     .glyphicon-ok {
       color: white !important;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -146,8 +146,8 @@
   }
 
   .view-details-photos {
-    width: 92% !important;
-    margin-right: 4%;
+    width: 90% !important;
+    margin-right: 5%;
     padding: 10px 0 10px 0;
     @media @phone {
       width: 88% !important;
@@ -684,7 +684,7 @@ app-add-association {
 }
 .view-details-description {
   img.image {
-    width: 100%;
+    max-width: 100%;
   }
   @media @phone {
     min-height:  50px;


### PR DESCRIPTION
fixes partly #478

- uses small/big images for thumbnails/gallery
- edit-button is working and redirects to the editing page
- more fields are saved and sent to the API
- user can geolocate the image on the editing page

To-do : API side - return all the relevant fields of a document's associated images.