### PR TITLE
Call transifex-send in before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,10 @@ script:
 after_failure:
   cat v6_api/nohup.out
 
+before_deploy:
+- make transifex-send
+
 deploy:
-- provider: script
-  script: make transifex-send
-  skip_cleanup: true
-  on:
-    repo: c2corg/v6_ui
-    branch: master
-    condition: '"$TRAVIS_NODE_VERSION" = "4"'
 - provider: script
   script: make cleanall publish
   on:


### PR DESCRIPTION
Fix deploy script not launched after trasifex push.

Note that ``all_branches: true``  is incompatible with ``tags: true``.
Seems we have to make a choice between tags and branches here.