### PR TITLE
Make sure constant name is not renamed

### DIFF
--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -10,12 +10,12 @@ goog.provide('app.constants');
 app.module.constant('constants', app.constants);
 
 app.constants = {
-  SCREEN : {
+  SCREEN: {
     SMARTPHONE : 620,
     TABLET : 1099,
     DEKTOP : 1400
   },
-  STEPS : {
+  STEPS: {
     'climbing_outdoor' : 4,
     'climbing_indoor' :  4,
     'hut' : 4,
@@ -28,11 +28,11 @@ app.constants = {
     'paragliding_landing' : 4,
     'webcam': 4
   },
-  REQUIRED_FIELDS : {
-    waypoints: ['title' , 'lang', 'waypoint_type', 'elevation', 'longitude', 'latitude'],
-    routes : ['title' , 'lang', 'activities', 'waypoints'],
-    outings : ['title' , 'lang', 'date_start', 'routes', 'activities'],
-    images: ['image_type']
+  REQUIRED_FIELDS: {
+    'waypoints': ['title' , 'lang', 'waypoint_type', 'elevation', 'longitude', 'latitude'],
+    'routes' : ['title' , 'lang', 'activities', 'waypoints'],
+    'outings' : ['title' , 'lang', 'date_start', 'routes', 'activities'],
+    'images': ['image_type']
   },
   documentEditing: {
     FORM_PROJ: 'EPSG:4326',


### PR DESCRIPTION
With the Closure compiler you have to be consistent on how you access object properties. E.g. if you have a property `obj.name = '...'`, you will have to access the property with `obj.name` (and not `obj['name']`). Otherwise the compiler can not properly rename the properties. If you want to access the property with `obj['name']` (as it was the case in this issue), you will have to set the property also with ` obj['name'] = '...'`.

See also: https://developers.google.com/closure/compiler/docs/limitations#implications-of-global-variable-function-and-property-renaming

Closes https://github.com/c2corg/v6_ui/issues/631
Closes https://github.com/c2corg/v6_ui/issues/658