### PR TITLE
Enable markdown extensions for TOC and linebreaks

### DIFF
--- a/c2corg_ui/templates/utils/format.py
+++ b/c2corg_ui/templates/utils/format.py
@@ -3,6 +3,8 @@ import markdown
 import html
 
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
+from markdown.extensions.nl2br import Nl2BrExtension
+from markdown.extensions.toc import TocExtension
 
 
 _markdown_parser = None
@@ -14,6 +16,8 @@ def _get_markdown_parser():
     if not _markdown_parser:
         extensions = [
             C2CWikiLinkExtension(),
+            Nl2BrExtension(),
+            TocExtension(marker='[toc]', baselevel=2),
         ]
         _markdown_parser = markdown.Markdown(output_format='xhtml5',
                                              extensions=extensions)


### PR DESCRIPTION
This PR activates 2 Python-Markdown extensions to support:
* line breaks, see https://pythonhosted.org/Markdown/extensions/nl2br.html
* table of contents, see https://pythonhosted.org/Markdown/extensions/toc.html

## Line breaks

handled pretty fine.

## Tables of contents

are supported quite well except the following limitations:

* the default TOC marker is ``[TOC]``. I have changed it to ``[toc]`` but it only works with ``[toc]`` in the text to convert,  variants such as ``[toc 2 right]`` are not supported (remains unreplaced). I have tried with ``[toc(.*)]`` but with no more success. Of course using ``[toc 2 right]`` as the marker is possible but that's obviously not relevant. Perhaps we could convert all ``[toc(.*)]`` variants to ``[toc]`` using the migration script?
* the extension has a ``baselevel`` option that can be used to specify the "biggest" level of header that is taken into account in the TOC. For instance if ``baselevel=3``, only ``<h3>``,  ``<h4>``, etc. will be taken into account, not ``<h1>`` or  ``<h2>``. On the other hand it's not possible to limit the number of sublevels (in v5 ``[toc 2]`` means that only "h2" and "h3" are referenced, not "h4" or "h5". Maybe not a big deal.
* with the current setting, the TOC is actually created and ids are added to the section headers:
```
<div class="toc">
<ul>
<li><a href="#presentation">Présentation</a><ul>
<li><a href="#historique">Historique</a></li>
...
```
```
<h3 id="presentation">Présentation</h3>
<h4 id="historique">Historique</h4>
```
The weird thing is that when I click on the TOC links, the URL in the address bar becomes ``waypoints/37355/fr/mont-blanc#/presentation`` instead of ``waypoints/37355/fr/mont-blanc#presentation`` (note the ``#/``) => the first URL does not redirect to the section whereas the second one does. Same problem in Chrome or FF!

Here is what the generated TOC looks like for http://c2corgv6.demo-camptocamp.com/waypoints/37355/fr/mont-blanc

<img width="772" alt="capture d ecran 2016-10-05 a 23 18 22" src="https://cloud.githubusercontent.com/assets/1192331/19133167/3b298d20-8b57-11e6-8f15-e9f173dbe3ec.png">

## Tables

I have also tried to enable the "tables" extension https://pythonhosted.org/Markdown/extensions/tables.html

hoping it would help manage the v5 ``L#`` tag (see https://github.com/c2corg/v6_ui/issues/131#issuecomment-237195445)

but this was quite a disaster because:

* there are conflicts with some of the C2C-custom wikilinks (``[[routes/12345|foo bar]]``), perhaps because of the ``|`` sign (used also as a cell separator for tables combined with some combinations of blank spaces and ``-``). See for instance:
<img width="927" alt="capture d ecran 2016-10-05 a 23 00 55" src="https://cloud.githubusercontent.com/assets/1192331/19133317/f0604c9c-8b57-11e6-964e-56fde4d802d8.png">
* the syntax of this parser is not really flexible and intuitive, it's a bit painful to figure out what syntaxes work and what don't.
* anyway it seems it has no effect on ``L#`` cells. And if by chance it does, the first line is emphasized (bold) as the table headers.

So for me this extension does not help at all.
