### PR TITLE
Outing-participants fix

### DIFF
--- a/c2corg_ui/static/js/outingediting.js
+++ b/c2corg_ui/static/js/outingediting.js
@@ -80,7 +80,7 @@ app.OutingEditingController = function($scope, $element, $attrs, $http,
   if (this.auth.isAuthenticated()) {
     this.scope[this.modelName]['associations']['users'].push({
       'document_id': this.auth.userData.id,
-      'username': this.auth.userData.username
+      'name': this.auth.userData.username
     });
     this.formatOuting_(this.scope[this.modelName]);
   }

--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -311,19 +311,11 @@ app.SimpleSearchController.prototype.createAndInitBloodhound_ = function(type) {
                 /** @type {appx.SimpleSearchDocumentResponse} */ (resp[type]);
         if (documentResponse) {
           var documents = documentResponse.documents;
-          var currentLang = this.gettextCatalog_.currentLanguage;
           var hasAssociation;
 
           return documents.map(function(/** appx.SimpleSearchDocument */ doc) {
             hasAssociation = this.documentService_.hasAssociation(type,  doc.document_id);
-
-            var locale = doc.locales[0];
-            doc.label = (type === 'routes' && locale.title_prefix) ? locale.title_prefix + ' : ' : '';
-            doc.label += locale.title;
-
-            if (currentLang !== locale.lang) {
-              doc.label += ' (' + locale.lang + ')';
-            }
+            doc.label = this.createDocLabel_(doc, this.gettextCatalog_.currentLanguage);
             doc.documentType = type;
 
             // don't show already associated docs in the results, but only in the app-add-association
@@ -338,6 +330,30 @@ app.SimpleSearchController.prototype.createAndInitBloodhound_ = function(type) {
   }));
   bloodhound.initialize();
   return bloodhound;
+};
+
+/**
+ * Return username as label or create a document title
+ * @param {!appx.SimpleSearchDocument} doc Suggested document.
+ * @param {string} currentLang
+ * @return {string} label
+ * @private
+ */
+app.SimpleSearchController.prototype.createDocLabel_ = function(doc, currentLang) {
+  var locale = doc.locales[0];
+  var label;
+  if (doc.type === 'u') {
+    return doc.name;
+  }
+  if (doc.type === 'r' && locale.title_prefix) {
+    label = locale.title_prefix + ' : ';
+  }
+  label += locale.title;
+
+  if (currentLang !== locale.lang) {
+    label += ' (' + locale.lang + ')';
+  }
+  return label;
 };
 
 

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -508,26 +508,26 @@ updating_doc = outing_id and outing_lang
             ## ASSOCIATED PARTICIPANTS
             ## TODO better to show all users in one row, will have to convert users in controller.
             <div id="participants-group" class="form-group  full" ng-class="{'has-success': outing.locales[0]['participants']}">
-              <app-simple-search parent-id="outing.document_id"
-                app-select="editCtrl.documentService.pushToAssociations(doc)" dataset="u"></app-simple-search>
-              <section class="section associations" ng-show="outing.associations.users.length > 0">
-                <label translate>associated_participants</label>
+              <label translate>associated_participants</label>
 
-                <section class="associated-section">
-                  <article class="associated-documents">
-                    <h5 translate ng-show="outing.associations.users.length == 0">You can look up for users that were with you during the outing.</h5>
-                    <div class="list-item outings user-id-{{user.document_id}}" ng-repeat="user in outing.associations.users">
-                      <a>
-                        <div class="outing-author text-center">
-                          <span class="icon-user"></span><br>
-                        </div>
-                        <div class="list-item-info">
-                          <span class="list-item-title outing">{{user.name}}</span>
-                        </div>
-                      </a>
-                      <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(user.document_id, 'users', $event)"></span>
-                    </div>
-                  </article>
+              <section class="section associations" ng-show="outing.associations.users.length > 0">
+                <app-simple-search parent-id="outing.document_id"
+                                   app-select="editCtrl.documentService.pushToAssociations(doc, 'users')" dataset="u"></app-simple-search>
+                <section class="associated-section flex wrap-row">
+                  <h5 translate ng-show="outing.associations.users.length == 0">You can look up for users that were with you during the outing.</h5>
+                  <div class="list-item outings new-item" ng-repeat="user in outing.associations.users">
+                    <a>
+                      <div class="outing-author text-center">
+                        <span class="icon-user"></span><br>
+                      </div>
+                      <div class="list-item-info">
+                        <span class="list-item-title outing">{{user.name}}</span>
+                      </div>
+                    </a>
+                    <span class="glyphicon glyphicon-trash"
+                          ng-click="editCtrl.documentService.removeAssociation(user.document_id, 'users', $event)"
+                          ng-show="outing.associations.users.length > 1"></span>
+                  </div>
                 </section>
 
               </section>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -359,7 +359,7 @@ main {
   }
 
   .list-item-info {
-    margin-top: 5px;
+    margin: auto;
     width: 100%;
     text-decoration: none;
     color: #919191;
@@ -444,8 +444,10 @@ main {
     }
   }
   &.outings {
+    min-height: 80px;
     a {
       .flex() !important;
+      height: 100%;
     }
     .outing-author, .outing-date {
       font-size: 0.9em;
@@ -1137,12 +1139,13 @@ ul {
         padding: 5px;
       }
     }
-    .glyphicon-trash:not(app-delete-association) {
-      position: absolute;
-      color: red;
-      font-size: 1.3em;
-      right: 10px;
-      top: calc(~"100% - 30px");
-    }
   }
+}
+
+.glyphicon-trash:not(app-delete-association) {
+  position: absolute;
+  color: red;
+  font-size: 1.3em;
+  right: 10px;
+  top: calc(~"100% - 30px");
 }

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -59,6 +59,7 @@
     width: 600%;
     @media @phone {
       position: static;
+      margin-bottom: 100px;
     }
   }
   .form-group {
@@ -558,9 +559,6 @@
   @media @phone {
     float: none;
     width: 18%;
-    &:last-of-type {
-      margin-bottom: 5%;
-    }
   }
 }
 
@@ -643,8 +641,8 @@ input[type="radio"] {
   transition: 0.2s ease-in-out;
 }
 
-#participants-group {
-  margin-top: 10px;
+#participants-group app-simple-search{
+  margin-bottom: 0;
 }
 
 ul.uib-datepicker {

--- a/less/simplesearch.less
+++ b/less/simplesearch.less
@@ -53,7 +53,7 @@ app-simple-search span.twitter-typeahead {
   .tt-dropdown-menu {
     &:extend(.dropdown-menu);
   }
-  
+
   .tt-suggestion {
     padding: 5px 10px 5px 25px;
     margin-bottom: 0 !important;
@@ -61,7 +61,7 @@ app-simple-search span.twitter-typeahead {
     background-clip: padding-box; /* for IE9+, Firefox 4+, Opera, Chrome */
     justify-content: space-between;
     .flex();
-    
+
     .glyphicon {
       color: @C2C-orange;
     }
@@ -75,8 +75,7 @@ app-simple-search span.twitter-typeahead {
       margin-top: auto;
       margin-bottom: auto;
     }
-
-    @media @phone { 
+    @media @phone {
       white-space : normal;
     }
     @media @tablet {
@@ -88,11 +87,14 @@ app-simple-search span.twitter-typeahead {
       cursor: pointer;
       .suggestion-title {
         color: white;
-      } 
+      }
     }
     .suggestion-title {
       font-weight: bold;
       color: graytext;
+    }
+    .suggestion-text {
+      width: 100%;
     }
   }
 
@@ -155,7 +157,7 @@ app-simple-search span.twitter-typeahead {
 .tt-menu {
   border: none !important;
   min-width: 35vw !important;
-  
+
   @media @phone {
     min-width: 80vw !important;
   }


### PR DESCRIPTION
fixes #623
related to (fixes) #710

related to #711 "When adding a participant to an outing, the search field is then filled with "undefined (en)" instead of "Rechercher" (it is OK before adding a participant)"

Also: 
  + unable to delete the last associated user (at least 1 is required)
  + animate card when adding a new user
  + add margin bottom to the last step (mobile)