### PR TITLE
Change typo in English word

### DIFF
--- a/c2corg_ui/templates/area/preview.html
+++ b/c2corg_ui/templates/area/preview.html
@@ -23,7 +23,7 @@ ${show_preview_warning()}
 
   <div class="view-details-informations col-xs-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_area_general(area)}

--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -85,7 +85,7 @@ area['doctype'] = 'areas'
 
   <div class="view-details-informations col-xs-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_area_general(area)}

--- a/c2corg_ui/templates/image/preview.html
+++ b/c2corg_ui/templates/image/preview.html
@@ -28,7 +28,7 @@ ${show_preview_warning()}
     <div class="view-details-informations col-xs-12  informations">
       <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)"
           data-toggle="collapse" data-target="#document-informations">
-        <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+        <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
       </h3>
 
       <section id="document-informations" class="collapse in">

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -83,7 +83,7 @@ from json import dumps
 
     <div class="view-details-informations col-xs-12  informations">
       <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-        <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+        <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
       </h3>
 
       <section id="document-informations" class="collapse in">

--- a/c2corg_ui/templates/outing/preview.html
+++ b/c2corg_ui/templates/outing/preview.html
@@ -27,7 +27,7 @@ outing['date_end'] = outing['date_end'] if outing.get('date_end') else outing['d
 
   <div class="view-details-informations col-xs-12  informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_outing_general(outing)}

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -96,7 +96,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   <div class="view-details-informations col-xs-12  informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_outing_general(outing)}

--- a/c2corg_ui/templates/route/preview.html
+++ b/c2corg_ui/templates/route/preview.html
@@ -26,7 +26,7 @@ ${show_preview_warning()}
 
   <div class="thumbnail view-details-informations col-sm-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_route_general(route, locale)}

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -109,7 +109,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   <div class="thumbnail view-details-informations col-sm-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_route_general(route, locale)}

--- a/c2corg_ui/templates/waypoint/preview.html
+++ b/c2corg_ui/templates/waypoint/preview.html
@@ -27,7 +27,7 @@ ${show_preview_warning()}
 
   <div class="view-details-informations col-xs-12  informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_waypoint_general(waypoint)}

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -116,7 +116,7 @@ geometry4326 = geometry
 
   <div class="view-details-informations col-xs-12  informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
-      <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
+      <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_waypoint_general(waypoint)}


### PR DESCRIPTION
"Information" is not plural in English (but it can be maybe used like that in French?). I found it 12x at "preview" and "view" pages. It would be nice for the user to see a web page without any grammar mistakes. What do you think about this change?

More info f.e. here http://dictionary.cambridge.org/dictionary/english/information OR http://ell.stackexchange.com/questions/17748/information-or-informations