### PR TITLE
Hide visible SEO links from the view

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -123,7 +123,7 @@
 
 
 ## Links generated only for the search engines, hidden.
-<%def name="add_seo_association_links(documents, doctype, hide=False)">\
+<%def name="add_seo_association_links(documents, doctype, hide=True)">\
   % if len(documents):
     <ul ${'class="ng-hide"' if hide else '' | n}>
       % for doc in documents:


### PR DESCRIPTION
It was accidentally turned on today.
Related to https://github.com/c2corg/v6_ui/issues/433#issuecomment-254916976