### PR TITLE
Remove duration and duration_difficulties fields

### DIFF
--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -134,7 +134,6 @@ appx.Document;
  *   snow_quantity: string,
  *   snow_quality: string,
  *   glacier_rating: string,
- *   duration: number,
  *   avalanche_signs: string,
  *   elevation_access: number,
  *   height_diff_up: number,

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -102,36 +102,6 @@ updating_doc = outing_id and outing_lang
               <span ng-click="editCtrl.pushToArray(outing, 'partial_trip', !outing.partial_trip, $event)"></span>
             </div>
 
-            ## DURATION
-            <div class="form-group half" ng-class="{'has-success': outing.duration, 'has-error': editForm.duration.$touched && editForm.duration.$invalid}">
-              <label translate>duration</label>
-              <div class="input-group">
-                <input type="number" min="1" minlength="1" name="duration" ng-model="outing.duration" class="form-control" />
-                <span class="input-group-addon">min</span>
-              </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.duration.$valid && outing.duration"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.duration.$invalid && outing.duration"></span>
-              <div class="help-block" ng-messages="editForm.duration.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.duration.$invalid && editForm.duration.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-              </div>
-            </div>
-
-            ## DURATION DIFFICULTIES
-            <div class="form-group half" ng-class="{'has-success': outing.duration_difficulties, 'has-error': editForm.duration_difficulties.$touched && editForm.duration_difficulties.$invalid}"
-                 ng-if="outing.activities.indexOf('snow_ice_mixed') > -1 || outing.activities.indexOf('mountain_climbing') > -1 ||
-                           outing.activities.indexOf('rock_climbing') > -1 || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('via_ferrata') > -1">
-              <label translate>duration_difficulties</label>
-              <div class="input-group">
-                <input type="number" min="1" minlength="1" name="duration_difficulties" ng-model="outing.duration_difficulties" class="form-control" />
-                <span class="input-group-addon">min</span>
-              </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.duration_difficulties.$valid && outing.duration_difficulties"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.duration_difficulties.$invalid && outing.duration_difficulties"></span>
-              <div class="help-block" ng-messages="editForm.duration_difficulties.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.duration_difficulties.$invalid && editForm.duration_difficulties.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-              </div>
-            </div>
-
             ## LENGTH TOTAL
             <div id="length_total-group" class="half form-group" ng-class="{ 'has-error': editForm.length_total.$touched && editForm.length_total.$invalid,'has-success': outing.length_total }">
               <label translate>length_total</label>

--- a/c2corg_ui/templates/outing/helpers/view.html
+++ b/c2corg_ui/templates/outing/helpers/view.html
@@ -19,14 +19,6 @@
       </article>
     % endif
 
-    % if outing.get('duration'):
-    <p><span class="value-title" translate>duration</span>: <span class="value">${outing['duration']}</span></p>
-    % endif
-
-    % if outing.get('duration_difficulties'):
-    <p><span class="value-title" translate>duration_difficulties</span>: <span class="value">${outing['duration_difficulties']}&nbsp;min</span></p>
-    % endif
-
     % if outing.get('frequentation'):
     <p><span class="value-title" translate>frequentation</span>: <span class="value" x-translate>${outing['frequentation']}</span></p>
     % endif

--- a/c2corg_ui/tests/views/data/outing.json
+++ b/c2corg_ui/tests/views/data/outing.json
@@ -35,7 +35,6 @@
 		"area_type": "admin_limits"
 	}],
 	"protected": false,
-	"duration": null,
 	"date_end": "2016-03-20",
 	"available_langs": ["fr"],
 	"geometry": {

--- a/c2corg_ui/tests/views/data/outing_archive.json
+++ b/c2corg_ui/tests/views/data/outing_archive.json
@@ -25,7 +25,6 @@
 		"date_start": "2016-03-20",
 		"partial_trip": true,
 		"protected": false,
-		"duration": null,
 		"date_end": "2016-03-20",
 		"access_condition": null,
 		"geometry": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ zope.interface==4.2.0
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@234086c99ad2a67da3ab88fb55379858f5552d1f
+git+https://github.com/c2corg/v6_common.git@12ee89d
 
 -e .


### PR DESCRIPTION
Requires https://github.com/c2corg/v6_common/pull/35 and https://github.com/c2corg/v6_api/pull/448

Those fields are somehow duplicates of the ``timing`` text field. They aim to give more precision but:
* complicate the UI
* are in minutes!