### PR TITLE
Add a robots.txt file

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -3,6 +3,8 @@ WSGIDaemonProcess c2corg_ui-{instanceid} python-path={site_packages}
 
 WSGIScriptAlias {base_url} {base_dir}/apache/app-c2corg_ui.wsgi
 
+Alias /robots.txt {base_dir}/c2corg_ui/static/robots.txt
+
 <Location {base_url}>
   WSGIProcessGroup c2corg_ui-{instanceid}
   WSGIApplicationGroup %{{GLOBAL}}

--- a/c2corg_ui/static/robots.txt
+++ b/c2corg_ui/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -26,7 +26,8 @@ area['doctype'] = 'areas'
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   % endif
 </%block>
 

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -25,7 +25,8 @@ other_langs, missing_langs = get_lang_lists(article, lang)
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   % endif
 </%block>
 

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -26,7 +26,8 @@ closure_library_path = settings.get('closure_library_path')
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="msapplication-TileImage" content="${request.static_path('c2corg_ui:static/img/logo.svg')}">
     <meta name="msapplication-TileColor" content="#FF0000">
-    <%block name="metarobots"><meta name="robots" content="index,follow"></%block>
+    ## FIXME: set back to "index,follow" before going to prod
+    <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 % if debug:
     <link rel="stylesheet" href="${request.static_path('%s/bootstrap/dist/css/bootstrap.css' % node_modules_path)}">
     <link rel="stylesheet" href="${request.static_path('%s/bootstrap-slider/dist/css/bootstrap-slider.css' % node_modules_path)}">

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -25,7 +25,8 @@ from json import dumps
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   % endif
 </%block>
 

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -28,7 +28,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   % endif
 </%block>
 

--- a/c2corg_ui/templates/profile/view.html
+++ b/c2corg_ui/templates/profile/view.html
@@ -12,7 +12,8 @@
 <%block name="pagetitle"><title>${show_route_title(locales[0], True)}</title></%block>
 
 <%block name="metarobots">
-  <meta name="robots" content="noindex,follow">
+  ## FIXME: set back to "noindex,follow" before going to prod
+  <meta name="robots" content="noindex,nofollow">
 </%block>
 
 <%

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -32,7 +32,8 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   %endif
 </%block>
 

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -36,7 +36,8 @@ geometry4326 = geometry
   % if version:
     <meta name="robots" content="noindex,follow">
   % else:
-    <meta name="robots" content="index,follow">
+    ## FIXME: set back to "index,follow" before going to prod
+    <meta name="robots" content="noindex,nofollow">
   % endif
 </%block>
 


### PR DESCRIPTION
The proposed ``robots.txt`` file disables all indexing of the site (useful for the demos - of course it should be updated at golive). See http://robots-txt.com/ressources/robots-txt-disallow-all/

According to this page it might be not enough to block the indexing. Using meta robots might be needed: http://robots-txt.com/meta-robots/
Actually it's already the case:
* generic template: https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/templates/base.html#L29
* overridden in specific templates: https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/templates/waypoint/view.html#L35-L41
If we have to change those values, it means we'll have to make sure to roll the changes back before golive as well.

The ``robots.txt`` file must be made available at the route of the website. Which is not that easy with Pyramid: 
http://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/pylons/static.html#static-view
> It can't serve top-level file URLs such as "/robots.txt" and "/favicon.ico".

A solution is to use a server alias:
http://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/pylons/static.html#top-level-file-urls

Note sure the change suggested in this PR works. It seems not in my dev instance => "page not found" (but not using Apache!?)