### PR TITLE
Advanced search filters improvements

### DIFF
--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -21,9 +21,8 @@ app.imageUploaderDirective = function() {
     },
     templateUrl: '/static/partials/imageuploader.html',
     link: function(scope, el, attrs, ctrl) {
-      // dropdown-menus can overlap the modal and it's impossible to fix it with overflow-y: srcoll + overflow-x: visible.
       el.on('click', '.dropdown-toggle', function() {
-        ctrl.repositionMenu_(this);
+        app.utils.repositionMenu({'menu': this, 'boxBoundEl': '.images-container', 'checkBottom': true});
       });
     }
   };
@@ -419,24 +418,6 @@ app.ImageUploaderController.prototype.openModal = function() {
     controller: 'AppImageUploaderModalController as imageModalCtrl',
     size: 'xl'
   });
-};
-
-
-/**
- * @param {HTMLElement} el
- * @private
- */
-app.ImageUploaderController.prototype.repositionMenu_ = function(el) {
-  var menu = $(el).next();
-  menu.css('opacity', 0); // prevent from jumping on the screen
-  setTimeout(function() { // because at the moment of the click the menu is hidden and result would give 0.
-    var boxBounds = $('#image-uploader')[0].getBoundingClientRect();
-    var menuBounds = menu[0].getBoundingClientRect();
-    if (menuBounds.right > boxBounds.right) {
-      menu.css('left', -Math.abs(menuBounds.right - boxBounds.right + 20));
-    }
-    menu.css('opacity', 1);
-  }, 50);
 };
 
 

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -40,7 +40,7 @@ goog.require('app.sidemenu');
 goog.require('app.simpleSearchDirective');
 goog.require('app.slideInfoDirective');
 goog.require('app.sliderDirective');
-goog.require('app.stickyFilters');
+goog.require('app.stickyFiltersDirective');
 goog.require('app.suggestionDirective');
 goog.require('app.userDirective');
 goog.require('app.userProfileDirective');

--- a/c2corg_ui/static/js/search/advancedsearch.js
+++ b/c2corg_ui/static/js/search/advancedsearch.js
@@ -95,6 +95,12 @@ app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
   this.documents = [];
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.noResults = false;
+
+  /**
    * @type {?number}
    * @export
    */
@@ -152,6 +158,7 @@ app.AdvancedSearchController.prototype.successList_ = function(response) {
   var data = /** @type {appx.SearchDocumentResponse} */ (response['data']);
   this.documents = data.documents;
   this.total = data.total;
+  this.noResults = this.documents.length === 0;
   this.scope_.$root['resCounter'] = this.total;
   // TODO: disable map interaction for document types with no geometry
   // "total" is needed for pagination though

--- a/c2corg_ui/static/js/search/searchfilters.js
+++ b/c2corg_ui/static/js/search/searchfilters.js
@@ -28,11 +28,7 @@ app.searchFiltersDirective = function() {
       // that this menu is inside, it will not be shown entirely...
       // If someone can fix it using CSS only, you're da real MVP !
       element.on('click', '.dropdown-toggle', function() {
-        $(this).next().css({
-          position: 'fixed',
-          top: $(this).offset().top + 30,
-          left: $(this).offset().left - 10
-        });
+        app.utils.repositionMenu({'menu': this, 'boxBoundEl': '.filters .simple-filters'});
       });
 
       // This prevents to 'jump' or 'stutter' on phone - before, if you first

--- a/c2corg_ui/static/js/style/stickyfilters.js
+++ b/c2corg_ui/static/js/style/stickyfilters.js
@@ -1,57 +1,101 @@
-goog.provide('app.stickyFilters');
+goog.provide('app.stickyFiltersDirective');
+goog.provide('app.StickyFiltersController');
 
 goog.require('app');
 
 
 /**
+ * @return {angular.Directive} Directive Definition Object.
+ */
+app.stickyFiltersDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'AppStickyFiltersController as stickyCtrl',
+    link: function(scope, el, attrs, ctrl) {
+      // show/hide filters on click, only available on phone
+      $('.show-documents-filters-phone').click(function() {
+        $('form[app-search-filters]').toggleClass('show');
+        $('.map-right').removeClass('show');
+      });
+      // hide/show map on mobile
+      $('.toggle-map').click(function() {
+        $('.map-right').toggleClass('show');
+      });
+      // on mobile, clicking on the 'all filters' btn will scroll up to the top
+      // because opening the whole filters list would only show you the bottom end.
+      $('.orange-btn.more-filters-btn').click(function() {
+        if (window.innerWidth < app.constants.SCREEN.SMARTPHONE) {
+          $('.documents-list-section').scrollTop(0);
+        }
+      });
+
+
+      $('.documents-list-section').scroll(function() {
+        var scrollMax = $('.simple-filters').height() + 30;
+        var documentsListTop = $('.documents-list-section').scrollTop();
+        // if you scroll down and there is no sticky bar, add it
+        if (documentsListTop > scrollMax && $('.sticky-filters-btn-container').length === 0) {
+          ctrl.addStickyFilters_();
+        }
+        //when you scroll up, remove the cloned filters and the sticky classes
+        if (documentsListTop === 0 && $('.sticky-filters-btn-container').length > 0) {
+          ctrl.removeStickyFilters_();
+        }
+      });
+      // on resize, show filters if they have been hidden on smartphone
+      $(window).resize(function() {
+        ctrl.adaptFiltersWidth_();
+      });
+    }
+  };
+};
+
+app.module.directive('appStickyFilters', app.stickyFiltersDirective);
+
+
+/**
+ * @constructor
+ * @struct
  * @export
  */
-app.stickyFilters = function() {
+app.StickyFiltersController = function() {};
 
-  // show/hide filters on click, only available on phone
-  $('.show-documents-filters-phone').click(function() {
-    $('.filters').toggle();
-  });
 
-  $('.documents-list-section').scroll(function() {
-    var scrollMax = $('.simple-filters').height() + 30;
-
-    // if you scroll down and there is no sticky bar, add it
-    if ($(this).scrollTop() > scrollMax && $('.sticky-filters-btn-container').length === 0) {
-      $('.more-filters-btn-container').addClass('sticky-filters-btn-container');
-      $('#moreFilters').addClass('sticky-filters-moreFilters');
-      $('.simple-filters').clone().prependTo('#moreFilters');
-      adaptFiltersWidth();
-      //show only part of filters on small screen
-      if (window.innerWidth < app.constants.SCREEN.SMARTPHONE) {
-        $('#moreFilters').addClass('overflow-scroll');
-      }
-    }
-    //when you scroll up, remove the cloned filters and the sticky classes
-    if ($(this).scrollTop() < scrollMax && $('.sticky-filters-btn-container').length > 0 && $('.simple-filters').length === 2) {
-      var simpleFilters = $('#moreFilters .simple-filters').clone();
-      $('.more-filters-btn-container').removeClass('sticky-filters-btn-container');
-      $('#moreFilters').removeClass('overflow-scroll sticky-filters-moreFilters');
-      $('.simple-filters').remove();
-      $('.filters').prepend(simpleFilters);
-      adaptFiltersWidth();
-    }
-  });
-  // on resize, show filters if they have been hidden on smartphone
-  $(window).resize(function() {
-    adaptFiltersWidth();
-    if (window.innerWidth > app.constants.SCREEN.SMARTPHONE && $('.filters').css('display') === 'none') {
-      $('.filters').show();
-    }
-  });
-
-  function adaptFiltersWidth() {
-    var width = $('.documents-list-section').width();
-    // sticky bar and filters width = filters width
-    if ($('#moreFilters').hasClass('sticky-filters-moreFilters')) {
-      $('#moreFilters, .more-filters-btn-container').css('width', parseInt(width, 10));
-    } else {
-      $('#moreFilters, .more-filters-btn-container').css('width', parseInt($('.filters').width(), 10));
-    }
+/**
+ * if you 1) click on 'all filters' 2) and haven't scrolled yet - #moreFilters will have
+ * will have aria-expanded => don't add sticky filters! it prevents jumping and looks more natural.
+ * @private
+ */
+app.StickyFiltersController.prototype.addStickyFilters_ =  function() {
+  if ($('#moreFilters[aria-expanded="true"]').length === 0) {
+    $('.more-filters-btn-container').addClass('sticky-filters-btn-container');
+    $('#moreFilters').addClass('sticky-filters-moreFilters');
+    this.adaptFiltersWidth_();
   }
 };
+
+
+/**
+ * @private
+ */
+app.StickyFiltersController.prototype.removeStickyFilters_ = function() {
+  $('.more-filters-btn-container').removeClass('sticky-filters-btn-container');
+  $('#moreFilters').removeClass('overflow-scroll sticky-filters-moreFilters');
+  this.adaptFiltersWidth_();
+};
+
+
+/**
+ * @private
+ */
+app.StickyFiltersController.prototype.adaptFiltersWidth_ = function() {
+  var width = $('.documents-list-section').width();
+  // sticky bar and filters width = filters width
+  if ($('#moreFilters').hasClass('sticky-filters-moreFilters')) {
+    $('#moreFilters, .more-filters-btn-container').css('width', parseInt(width, 10));
+  } else {
+    $('#moreFilters, .more-filters-btn-container').css('width', parseInt($('.filters').width(), 10));
+  }
+};
+
+app.module.controller('AppStickyFiltersController', app.StickyFiltersController);

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -240,3 +240,31 @@ app.utils.convertDMSToDecimal = function(degrees, minutes, seconds, direction) {
   }
   return decimal;
 };
+
+
+/**
+ *  dropdown-menus can overlap the modal and it's impossible
+ *  to fix it with overflow-y: srcoll + overflow-x: visible.
+ * @param {Object} els elements needed to reposition
+ * els: {  menu: the dropdown,
+ *            boxBoundEl: the container,
+ *            checkBottom: if true - scroll down if the menu overflows the bottom
+ *         }
+ */
+app.utils.repositionMenu = function(els) {
+  var boxBoundEl = $(els['boxBoundEl']);
+  var menu = $(els['menu']).next();
+  menu.css('opacity', 0); // prevent from jumping on the screen
+
+  setTimeout(function() { // because at the moment of the click the menu is hidden and result would give 0.
+    var boxBounds = boxBoundEl[0].getBoundingClientRect();
+    var menuBounds = menu[0].getBoundingClientRect();
+    if (menuBounds.right > boxBounds.right) {
+      menu.css('left', -Math.abs(menuBounds.right - boxBounds.right + 10));
+    }
+    if (els['checkBottom'] && menuBounds.bottom > boxBounds.bottom) {
+      boxBoundEl.animate({scrollTop: boxBoundEl.height()}, 'slow');
+    }
+    menu.css('opacity', 1);
+  }, 50);
+};

--- a/c2corg_ui/static/partials/advancedsearch.html
+++ b/c2corg_ui/static/partials/advancedsearch.html
@@ -4,3 +4,5 @@
               ng-mouseleave="searchCtrl.onMouseLeave(doc.document_id)"></app-card>
   </div>
 </div>
+<p translate class="text-warning text-center no-results" ng-class="{'show': searchCtrl.noResults}">No results</p>
+

--- a/c2corg_ui/templates/area/filters.html
+++ b/c2corg_ui/templates/area/filters.html
@@ -3,28 +3,34 @@ from c2corg_common.attributes import default_langs, area_types, quality_types
 %>
 <%namespace file="../helpers/filters.html" import="add_multiselect"/>
 
-<form app-search-filters app-search-filters-controller-name="appSearchFiltersController">
-  <div class="filters">
-    <div class="row simple-filters">
 
-      <div class="filter">
-        <label translate>title</label><br>
-        <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
-      </div>
-
-      <div class="filter">
-        <label translate>area_type</label><br>
-        ${add_multiselect('atyp', area_types)}
-      </div>
-
+## Duplicate simple filters into the main filters and into #moreFilters.
+## It is really useful - no need for re-compilation with angular in case of sticky filters.
+<%def name="simple_filters()">
+  <div class="row simple-filters">
+    <div class="filter">
+      <label translate>title</label><br>
+      <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
     </div>
-    <div class="row collapse" id="moreFilters">
 
-      <div class="col-xs-12 col-sm-6 filter">
-        <label translate>document_quality</label><br>
-        <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
-          values-list="['${"','".join(quality_types) |n}']"></app-slider>
-      </div>
+    <div class="filter">
+      <label translate>area_type</label><br>
+      ${add_multiselect('atyp', area_types)}
+    </div>
+
+    <div class="col-xs-12 col-sm-6 filter">
+      <label translate>document_quality</label><br>
+      <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
+                  values-list="['${"','".join(quality_types) |n}']"></app-slider>
+    </div>
+  </div>
+</%def>
+
+<form app-search-filters app-search-filters-controller-name="appSearchFiltersController" app-sticky-filters>
+  <div class="filters areas">
+    ${simple_filters()}
+    <div class="row collapse" id="moreFilters">
+      ${simple_filters()}
 
       <div class="filters-bottom-buttons">
         <button class="btn search-filters-btn orange-btn" data-toggle="collapse"

--- a/c2corg_ui/templates/area/index.html
+++ b/c2corg_ui/templates/area/index.html
@@ -10,22 +10,23 @@
   });
 </%block>
 
+## for 'click' of .toggle-map, .page-main-title button and .show-documents-filters-phone
+## see js/style/stickyFilters.js
+
 <header class="page-main-title">
   <h3><span translate>Areas</span>
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+
 <section class="documents-list-section">
   <%include file="filters.html" />
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
+
     <app-pagination></app-pagination>
   </div>
+
   <app-advanced-search document-type="areas" use-map="false"></app-advanced-search>
 </section>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>

--- a/c2corg_ui/templates/area/index.html
+++ b/c2corg_ui/templates/area/index.html
@@ -25,7 +25,7 @@
     <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
 
-    <app-pagination></app-pagination>
+    <app-pagination class="areas"></app-pagination>
   </div>
 
   <app-advanced-search document-type="areas" use-map="false"></app-advanced-search>

--- a/c2corg_ui/templates/article/index.html
+++ b/c2corg_ui/templates/article/index.html
@@ -22,7 +22,7 @@
 <section class="documents-list-section">
   <%include file="filters.html" />
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('articles_add')}"
             uib-tooltip="{{'Create a new article' | translate }}" tooltip-placement="right">
       <span class="glyphicon glyphicon-plus-sign"></span>

--- a/c2corg_ui/templates/article/index.html
+++ b/c2corg_ui/templates/article/index.html
@@ -27,7 +27,7 @@
             uib-tooltip="{{'Create a new article' | translate }}" tooltip-placement="right">
       <span class="glyphicon glyphicon-plus-sign"></span>
     </button>
-    <app-pagination></app-pagination>
+    <app-pagination class="articles"></app-pagination>
   </div>
   <app-advanced-search document-type="articles" use-map="false"></app-advanced-search>
 </section>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -52,9 +52,8 @@ closure_library_path = settings.get('closure_library_path')
     <main class="page-content">
       ${self.body()}
     </main>
-    <div class="mobile-bg"></div>
-    <button class="btn btn-default menu-open-close header"><span class="glyphicon glyphicon-align-justify"></span></button>
     <div class="page-header">
+      <button class="btn btn-default menu-open-close header"><span class="glyphicon glyphicon-align-justify"></span></button>
       <div class="quick-search">
         <app-simple-search dataset="wrc"></app-simple-search>
       </div>

--- a/c2corg_ui/templates/image/filters.html
+++ b/c2corg_ui/templates/image/filters.html
@@ -3,28 +3,32 @@ from c2corg_common.attributes import default_langs, activities, image_categories
 %>
 <%namespace file="../helpers/filters.html" import="add_multiselect"/>
 
-<form app-search-filters app-search-filters-controller-name="appSearchFiltersController">
+## Duplicate simple filters into the main filters and into #moreFilters.
+## It is really useful - no need for re-compilation with angular in case of sticky filters.
+<%def name="simple_filters()">
+<div class="row simple-filters">
+  <div class="filter">
+    <label translate>categories</label><br>
+    ${add_multiselect('cat', image_categories)}
+  </div>
+
+  <div class="filter">
+    <label translate>activities</label><br>
+    ${add_multiselect('act', activities)}
+  </div>
+
+  <div class="col-xs-12 col-sm-6 filter">
+    <label translate>title</label>
+    <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
+  </div>
+</div>
+</%def>
+
+<form app-search-filters app-search-filters-controller-name="appSearchFiltersController" app-sticky-filters>
   <div class="filters">
-    <div class="row simple-filters">
-
-      <div class="filter">
-        <label translate>categories</label><br>
-        ${add_multiselect('cat', image_categories)}
-      </div>
-
-      <div class="filter">
-        <label translate>activities</label><br>
-        ${add_multiselect('act', activities)}
-      </div>
-
-      <div class="col-xs-12 col-sm-6 filter">
-        <label translate>title</label>
-        <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
-      </div>
-
-    </div>
-
-    <div class="row collapse" id="moreFilters">
+    ${simple_filters()}
+    <div class="row collapse images" id="moreFilters">
+      ${simple_filters()}
 
       <div class="col-xs-12 col-sm-6 filter">
         <label translate>type</label><br>
@@ -35,7 +39,7 @@ from c2corg_common.attributes import default_langs, activities, image_categories
         <label translate>date</label><br>
         <div class="input-group" ng-model="filtersCtrl.dates[0]" datepicker-options="{maxDate: filtersCtrl.dateMaxStart}"
              uib-datepicker-popup="dd MM yyyy" is-open="openDateStart" ng-change="filtersCtrl.setDate('date')">
-          <input type="text" disabled class="form-control" value="{{filtersCtrl.dates[0] | amDateFormat:'Do MMMM YYYY'}}"/>
+          <input type="text" disabled class="form-control" value="{{filtersCtrl.dates[0]| amDateFormat:'Do MMMM YYYY'}}"/>
           <span class="input-group-btn">
             <button type="button" class="btn btn-default" ng-click="openDateStart = true"><span class="glyphicon glyphicon-calendar"></span></button>
           </span>
@@ -51,13 +55,12 @@ from c2corg_common.attributes import default_langs, activities, image_categories
                 ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
       </div>
     </div>
+  </div>
 
-    <div class="more-filters-btn-container">
-      <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
-        aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
-      <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
-              ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
-    </div>
-
+  <div class="more-filters-btn-container">
+    <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
+            aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
+    <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
+            ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
   </div>
 </form>

--- a/c2corg_ui/templates/image/index.html
+++ b/c2corg_ui/templates/image/index.html
@@ -18,20 +18,22 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+
 <section class="documents-list-section">
   <%include file="filters.html" />
+
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
     <app-pagination></app-pagination>
+    <div class="toggle-map">
+      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+    </div>
   </div>
+
   <app-advanced-search document-type="images" use-map="true"></app-advanced-search>
 </section>
+
 <div class="map-right">
   <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true"></app-map>
 </div>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>

--- a/c2corg_ui/templates/outing/filters.html
+++ b/c2corg_ui/templates/outing/filters.html
@@ -3,27 +3,35 @@ from c2corg_common.attributes import default_langs, quality_types, activities, f
     condition_ratings, glacier_ratings, avalanche_signs
 %>
 <%namespace file="../helpers/filters.html" import="add_multiselect"/>
-<form app-search-filters app-search-filters-controller-name="appOutingFiltersController">
-  <div class="filters">
-    <div class="row simple-filters">
 
-      <div class="filter">
-        <label translate>title</label>
-        <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
-      </div>
+## Duplicate simple filters into the main filters and into #moreFilters.
+## It is really useful - no need for re-compilation with angular in case of sticky filters.
+<%def name="simple_filters()">
+  <div class="row simple-filters">
 
-      <div class="filter">
-        <label translate>activities</label><br>
-        ${add_multiselect('act', activities)}
-      </div>
-
-      <div class="filter">
-        <label translate>condition_rating</label><br>
-        <app-slider filter="ocond" filters-list="filtersCtrl.filters" unit=""
-          values-list="['${"','".join(condition_ratings) |n}']"></app-slider>
-      </div>
+    <div class="filter">
+      <label translate>title</label>
+      <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
     </div>
+
+    <div class="filter">
+      <label translate>activities</label><br>
+      ${add_multiselect('act', activities)}
+    </div>
+
+    <div class="filter">
+      <label translate>condition_rating</label><br>
+      <app-slider filter="ocond" filters-list="filtersCtrl.filters" unit=""
+                  values-list="['${"','".join(condition_ratings) |n}']"></app-slider>
+    </div>
+  </div>
+</%def>
+
+<form app-search-filters app-search-filters-controller-name="appOutingFiltersController"  app-sticky-filters>
+  <div class="filters">
+    ${simple_filters()}
     <div class="row collapse" id="moreFilters">
+      ${simple_filters()}
 
       <div class="col-xs-12 col-sm-6 filter">
         <label translate>date_start</label><br>
@@ -45,6 +53,17 @@ from c2corg_common.attributes import default_langs, quality_types, activities, f
             <button type="button" class="btn btn-default" ng-click="openDateEnd = true"><span class="glyphicon glyphicon-calendar"></span></button>
           </span>
         </div>
+      </div>
+
+      <div class="col-xs-12 col-sm-6 filter">
+        <label translate>lang</label><br>
+        ${add_multiselect('l', default_langs)}
+      </div>
+
+      <div class="col-xs-12 col-sm-6 filter">
+        <label translate>document_quality</label><br>
+        <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
+          values-list="['${"','".join(quality_types) |n}']"></app-slider>
       </div>
 
       <div class="col-xs-12 col-sm-6 filter">
@@ -82,6 +101,12 @@ from c2corg_common.attributes import default_langs, quality_types, activities, f
                     filtersCtrl.filters.act.indexOf('snow_ice_mixed') !== -1 ||
                     filtersCtrl.filters.act.indexOf('mountain_climbing') !== -1 ||
                     filtersCtrl.filters.act.indexOf('ice_climbing') !== -1)">
+
+        <div class="col-xs-12 col-sm-6 filter">
+          <label translate>avalanche_signs</label><br>
+          ${add_multiselect('avdate', avalanche_signs)}
+        </div>
+
         <div class="col-xs-12 col-sm-6 filter">
           <label translate>elevation_up_snow</label><br>
           <app-slider filter="swlu" filters-list="filtersCtrl.filters" max="3000"></app-slider>
@@ -110,25 +135,10 @@ from c2corg_common.attributes import default_langs, quality_types, activities, f
             values-list="['${"','".join(glacier_ratings) |n}']"></app-slider>
         </div>
 
-        <div class="col-xs-12 col-sm-6 filter">
-          <label translate>avalanche_signs</label><br>
-          ${add_multiselect('avdate', avalanche_signs)}
-        </div>
-      </div>
-
-      <div class="col-xs-12 col-sm-6 filter">
-        <label translate>lang</label><br>
-        ${add_multiselect('l', default_langs)}
-      </div>
-
-      <div class="col-xs-12 col-sm-6 filter">
-        <label translate>document_quality</label><br>
-        <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
-          values-list="['${"','".join(quality_types) |n}']"></app-slider>
       </div>
 
       <div class="filters-bottom-buttons">
-        <button class="btn search-filters-btn orange-btn" data-toggle="collapse" 
+        <button class="btn search-filters-btn orange-btn" data-toggle="collapse"
                 data-target="#moreFilters" aria-expanded="false">
           <span translate>Show results</span> ({{resCounter}})
         </button>

--- a/c2corg_ui/templates/outing/index.html
+++ b/c2corg_ui/templates/outing/index.html
@@ -17,29 +17,36 @@
   });
 </%block>
 
+## for 'click' of .toggle-map, .page-main-title button and .show-documents-filters-phone
+## see js/style/stickyFilters.js
+
 <header class="page-main-title">
   <h3><span translate>Outings</span>
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+
 <section class="documents-list-section">
   <%include file="filters.html" />
+
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
+
     <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('outings_add')}"
             uib-tooltip="{{'Create a new outing' | translate }}" tooltip-placement="right">
       <span class="glyphicon glyphicon-plus-sign"></span>
     </button>
+
     <app-pagination></app-pagination>
+    <div class="toggle-map">
+      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+    </div>
   </div>
+
   <app-advanced-search document-type="outings" use-map="true"></app-advanced-search>
 </section>
+
 <div class="map-right">
   <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
 </div>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>

--- a/c2corg_ui/templates/route/filters.html
+++ b/c2corg_ui/templates/route/filters.html
@@ -8,30 +8,35 @@ from c2corg_common.attributes import default_langs, quality_types, route_types, 
 
 activities = [activity for activity in activities if activity != 'paragliding']
 %>
+
 <%namespace file="../helpers/filters.html" import="add_multiselect"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
-<form app-search-filters app-search-filters-controller-name="appSearchFiltersController">
-  <div class="filters">
-    <div class="row simple-filters">
 
-      <div class="filter">
-        <label translate>title</label><br>
-        <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
-      </div>
-
-      <div class="filter">
-        <label translate>activities</label><br>
-        ${add_multiselect('act', activities)}
-      </div>
-
-      <div class="filter">
-        <label translate>elevation_max</label><br>
-        <app-slider filter="rmaxa" filters-list="filtersCtrl.filters" max="8850"></app-slider>
-      </div>
-
+## Duplicate simple filters into the main filters and into #moreFilters.
+## It is really useful - no need for re-compilation with angular in case of sticky filters.
+<%def name="simple_filters()">
+  <div class="row simple-filters">
+    <div class="filter">
+      <label translate>title</label><br>
+      <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
     </div>
+    <div class="filter">
+      <label translate>activities</label><br>
+      ${add_multiselect('act', activities)}
+    </div>
+    <div class="filter">
+      <label translate>elevation_max</label><br>
+      <app-slider filter="rmaxa" filters-list="filtersCtrl.filters" max="8850"></app-slider>
+    </div>
+  </div>
+</%def>
+
+<form app-search-filters app-search-filters-controller-name="appSearchFiltersController" app-sticky-filters>
+  <div class="filters">
+    ${simple_filters()}
     <div class="row collapse" id="moreFilters">
-      
+      ${simple_filters()}
+
       <div class="col-xs-12 col-sm-6 filter">
         <label translate>elevation_min</label><br>
         <app-slider filter="rmina" filters-list="filtersCtrl.filters" max="6000"></app-slider>
@@ -61,6 +66,11 @@ activities = [activity for activity in activities if activity != 'paragliding']
       <div class="col-xs-12 col-sm-6 filter">
         <label translate>configuration</label><br>
         ${add_multiselect('conf', route_configuration_types)}
+      </div>
+
+      <div class="col-xs-12 col-sm-6 filter">
+        <label translate>lang</label><br>
+        ${add_multiselect('l', default_langs)}
       </div>
 
       <div class="col-xs-12 col-sm-6 col-md-6 filter orientation">
@@ -122,6 +132,16 @@ activities = [activity for activity in activities if activity != 'paragliding']
         </div>
       </div>
 
+      ## SNOW_ICE_MIXED, ROCK AND ALPINE CLIMBING
+      <div ng-show="filtersCtrl.filters.act.length && (filtersCtrl.filters.act.indexOf('snow_ice_mixed') !== -1 ||
+                    filtersCtrl.filters.act.indexOf('rock_climbing') !== -1 ||
+                    filtersCtrl.filters.act.indexOf('mountain_climbing') !== -1)">
+        <div class="col-xs-12 col-sm-6 filter">
+          <label translate>rock_types</label><br>
+          ${add_multiselect('rock', rock_types)}
+        </div>
+      </div>
+
       ## SNOW, ICE, ROCK AND ALPINE CLIMBING
       <div ng-show="filtersCtrl.filters.act.length && (filtersCtrl.filters.act.indexOf('snow_ice_mixed') !== -1 ||
                     filtersCtrl.filters.act.indexOf('rock_climbing') !== -1 ||
@@ -164,16 +184,6 @@ activities = [activity for activity in activities if activity != 'paragliding']
           <label translate>equipment_rating</label><br>
           <app-slider filter="prat" filters-list="filtersCtrl.filters" unit=""
             values-list="['${"','".join(equipment_ratings) |n}']"></app-slider>
-        </div>
-      </div>
-
-      ## SNOW_ICE_MIXED, ROCK AND ALPINE CLIMBING
-      <div ng-show="filtersCtrl.filters.act.length && (filtersCtrl.filters.act.indexOf('snow_ice_mixed') !== -1 ||
-                    filtersCtrl.filters.act.indexOf('rock_climbing') !== -1 ||
-                    filtersCtrl.filters.act.indexOf('mountain_climbing') !== -1)">
-        <div class="col-xs-12 col-sm-6 filter">
-          <label translate>rock_types</label><br>
-          ${add_multiselect('rock', rock_types)}
         </div>
       </div>
 
@@ -289,18 +299,13 @@ activities = [activity for activity in activities if activity != 'paragliding']
       </div>
 
       <div class="col-xs-12 col-sm-6 filter">
-        <label translate>lang</label><br>
-        ${add_multiselect('l', default_langs)}
-      </div>
-
-      <div class="col-xs-12 col-sm-6 filter">
         <label translate>document_quality</label><br>
         <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
           values-list="['${"','".join(quality_types) |n}']"></app-slider>
       </div>
 
       <div class="filters-bottom-buttons">
-        <button class="btn search-filters-btn orange-btn" data-toggle="collapse" 
+        <button class="btn search-filters-btn orange-btn" data-toggle="collapse"
                 data-target="#moreFilters" aria-expanded="false">
           <span translate>Show results</span> ({{resCounter}})
         </button>
@@ -308,12 +313,12 @@ activities = [activity for activity in activities if activity != 'paragliding']
                 ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
       </div>
     </div>
-    <div class="more-filters-btn-container">
-      <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
-        aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
-      <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
-              ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
-    </div>
+  </div>
 
+  <div class="more-filters-btn-container">
+    <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
+            aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
+    <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
+            ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
   </div>
 </form>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -26,29 +26,36 @@
   });
 </%block>
 
+## for 'click' of .toggle-map, .page-main-title button and .show-documents-filters-phone
+## see js/style/stickyFilters.js
+
 <header class="page-main-title">
   <h3><span translate>Routes</span>
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+
 <section class="documents-list-section">
   <%include file="filters.html" />
+
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
+
     <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('routes_add')}"
             uib-tooltip="{{'Create a new route' | translate }}" tooltip-placement="right">
       <span class="glyphicon glyphicon-plus-sign"></span>
     </button>
+
     <app-pagination></app-pagination>
+    <div class="toggle-map">
+      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+    </div>
   </div>
+
   <app-advanced-search document-type="routes" use-map="true"></app-advanced-search>
 </section>
+
 <div class="map-right">
   <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
 </div>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>

--- a/c2corg_ui/templates/waypoint/filters.html
+++ b/c2corg_ui/templates/waypoint/filters.html
@@ -8,10 +8,10 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
 <%namespace file="../helpers/filters.html" import="add_multiselect"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
 
-<form app-search-filters app-search-filters-controller-name="appSearchFiltersController">
-  <div class="filters">
+## Duplicate simple filters into the main filters and into #moreFilters.
+## It is really useful - no need for re-compilation with angular in case of sticky filters.
+<%def name="simple_filters()">
     <div class="row simple-filters">
-
       <div class="filter">
         <label translate>title</label><br>
         <input type="text" class="form-control" ng-model="filtersCtrl.filters.q">
@@ -26,9 +26,14 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
         <label translate>elevation</label><br>
         <app-slider filter="walt" filters-list="filtersCtrl.filters" max="8850"></app-slider>
       </div>
-      
     </div>
+</%def>
+
+<form app-search-filters app-search-filters-controller-name="appSearchFiltersController" app-sticky-filters>
+  <div class="filters">
+    ${simple_filters()}
     <div class="row collapse" id="moreFilters">
+      ${simple_filters()}
 
       ## SUMMITS
       <div class="filter col-xs-12 col-sm-6" ng-show="filtersCtrl.filters.wtyp.length && filtersCtrl.filters.wtyp.indexOf('summit') !== -1">
@@ -125,6 +130,12 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
         </div>
       </div>
 
+      ## WEATHER STATIONS
+      <div class="filter col-xs-12 col-sm-6" ng-show="filtersCtrl.filters.wtyp.length && filtersCtrl.filters.wtyp.indexOf('weather_station') !== -1">
+        <label translate>weather_station_types</label><br>
+        ${add_multiselect('whtyp', weather_station_types)}
+      </div>
+
       ## HUTS
       <div ng-show="filtersCtrl.filters.wtyp.length && filtersCtrl.filters.wtyp.indexOf('hut') !== -1">
         <div class="filter col-xs-12 col-sm-6">
@@ -176,12 +187,6 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
         ${add_multiselect('ftyp', product_types)}
       </div>
 
-      ## WEATHER STATIONS
-      <div class="filter col-xs-12 col-sm-6" ng-show="filtersCtrl.filters.wtyp.length && filtersCtrl.filters.wtyp.indexOf('weather_station') !== -1">
-        <label translate>weather_station_types</label><br>
-        ${add_multiselect('whtyp', weather_station_types)}
-      </div>
-
       <div class="filter col-xs-12 col-sm-6">
         <label translate>document_quality</label><br>
         <app-slider filter="qa" filters-list="filtersCtrl.filters" unit=""
@@ -189,7 +194,7 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
       </div>
 
       <div class="filters-bottom-buttons">
-        <button class="btn search-filters-btn orange-btn" data-toggle="collapse" 
+        <button class="btn search-filters-btn orange-btn" data-toggle="collapse"
                 data-target="#moreFilters" aria-expanded="false">
           <span translate>Show results</span> ({{resCounter}})
         </button>
@@ -197,12 +202,12 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
                 ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
       </div>
     </div>
+  </div>
+
     <div class="more-filters-btn-container">
       <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
         aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
       <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
               ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
     </div>
-
-  </div>
 </form>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -19,29 +19,35 @@
   });
 </%block>
 
+## for 'click' of .toggle-map, .page-main-title button and .show-documents-filters-phone
+## see js/style/stickyFilters.js
+
 <header class="page-main-title">
   <h3><span translate>Waypoints</span>
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+
 <section class="documents-list-section">
   <%include file="filters.html" />
+
   <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default show-documents-filters-phone" translate>Filters</button>
+    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
     ${add_doctype_selector()}
+
     <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('waypoints_add')}"
             uib-tooltip="{{'Create a new waypoint' | translate }}" tooltip-placement="right">
       <span class="glyphicon glyphicon-plus-sign"></span>
     </button>
+
     <app-pagination></app-pagination>
+    <div class="toggle-map">
+      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+    </div>
   </div>
   <app-advanced-search document-type="waypoints" use-map="true"></app-advanced-search>
 </section>
+
 <div class="map-right">
   <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
 </div>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -234,8 +234,10 @@ main {
 }
 /*articles and areas have no .toggle-map*/
 app-pagination.areas, app-pagination.articles{
-  #pagination {
-    width: 100%;
+  @media @phone {
+    #pagination {
+      width: 100%;
+    }
   }
 }
 #pagination {
@@ -592,11 +594,7 @@ app-pagination.areas, app-pagination.articles{
   }
 }
 .documents-list-section, .map-right .map, .not-found-section {
-  height: calc(~"100vh -" @page-header-height - 8);
-  height: -moz-calc(~"100vh -" @page-header-height - 8);
-  height: -webkit-calc(~"100vh -" @page-header-height - 8);
-  height: -o-calc(~"100vh -" @page-header-height - 8);
-  height: calc(~"100vh -" @page-header-height - 8);
+  .calc(height, "100vh - @{page-header-height} + 4px");
 }
 
 .documents-list-section, .not-found-section {
@@ -612,7 +610,7 @@ app-pagination.areas, app-pagination.articles{
     float:none;
     margin-top: 0;
     padding-top: 0;
-    .calc(height, "100% - 78px");
+    .calc(height, "100vh - 128px");
   }
   .show-documents-filters-phone {
     display: none;
@@ -822,10 +820,7 @@ app-simple-search {
         width: 150px;
       }
       @media @phone {
-        width: -moz-calc(~"100vw - 45px");
-        width: -webkit-calc(~"100vw - 45px");
-        width: -o-calc(~"100vw - 45px");
-        width: calc(~"100vw - 45px");
+        .calc(width, "100vw - 45px");
       }
     }
     @media @phone {
@@ -884,7 +879,6 @@ app-simple-search {
 }
 
 .page-content {
-  height: 100%;
   margin-left: @menu-width;
 
   @media @tablet {
@@ -892,7 +886,6 @@ app-simple-search {
     margin-top:  -41px;
   }
   @media @phone {
-    height: calc(~"100% - 50px");
     margin-left: 0;
     margin-top: @page-header-height;
   }

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -28,6 +28,7 @@ html, body{
   padding: 0;
   margin: 0;
   width: 100%;
+  height: 100%;
   overflow-x: hidden;
   background-color: @body-color;
 }
@@ -63,28 +64,40 @@ html, body{
 }
 
 .page-main-title {
-  top: @page-header-height - 8;
+  top: @page-header-height - 1;
   color: white;
   height: 40px;
   position: relative;
   z-index: 1;
   margin-left: @list-width;
   text-align: center;
-  padding-top: 5px;
-  padding-bottom: 2px;
+  padding-top: 6px;
   background-color: rgba(104, 159, 179, 0.64);
 
+  /*the filters button shown on mobile*/
+  button {
+    display: none;
+    height: 24px;
+    padding: 0 10px;
+  }
+
+  @media @tablet {
+    top: 43px;
+  }
   @media @phone {
-    border-bottom: 1px solid #ccc;
-    font-size: 1.5em;
+    .flex();
+    justify-content: space-around;
+    align-items: center;
     padding: 0;
     position: initial;
     margin-left: 0;
     height: 35px;
-
+    button {
+      display: none;
+    }
     h3 {
       margin: 0;
-      padding: 0.7%;
+      padding: 1%;
     }
   }
 
@@ -229,9 +242,10 @@ main {
     position: fixed;
     align-items: baseline;
     .flex();
+    justify-content: space-around;
     bottom: 0;
     z-index: 2;
-    width: 100%;
+    width: calc(~"100% - 50px"); /* 50px = .toggle-map btn width*/
     height: 45px;
     padding: 5px;
     left: 0;
@@ -244,7 +258,7 @@ main {
       height: 100%;
     }
     .page-numbers  {
-      width: 100%;
+      width: 110px;
       display: block !important;
     }
   }
@@ -259,6 +273,7 @@ main {
     display:inline-block;
     margin-bottom: 0;
     padding-left: 5px;
+    width: 152px;
 
     li {
       display:inline-block;
@@ -276,6 +291,29 @@ main {
         color:white;
       }
     }
+  }
+}
+
+.toggle-map {
+  display: none;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  width: 50px;
+  background-color: @lightgrey;
+  height: 45px;
+  padding-top: 3px;
+  button {
+    border-radius: 50%;
+    width: 38px;
+    height: 38px;
+    font-size: 1.3em;
+    padding-left: 9px;
+    padding-top: 8px;
+  }
+  @media @phone {
+    display: block;
   }
 }
 
@@ -530,7 +568,7 @@ main {
       box-shadow: 0px 0px 36px -10px rgba(0,0,0,0.56);
       height: 250px;
       margin-top: 0;
-      height: 42vh !important;
+      height: 50vh !important;
     }
   }
 
@@ -538,15 +576,17 @@ main {
     margin-left: 0;
     bottom: 40px;
     position: fixed;
+    opacity: 0;
+    pointer-events: none;
     width: 100%;
   }
 }
 .documents-list-section, .map-right .map, .not-found-section {
-  height: calc(~"100vh -" @page-header-height);
-  height: -moz-calc(~"100vh -" @page-header-height);
-  height: -webkit-calc(~"100vh -" @page-header-height);
-  height: -o-calc(~"100vh -" @page-header-height);
-  height: calc(~"100vh -" @page-header-height);
+  height: calc(~"100vh -" @page-header-height - 8);
+  height: -moz-calc(~"100vh -" @page-header-height - 8);
+  height: -webkit-calc(~"100vh -" @page-header-height - 8);
+  height: -o-calc(~"100vh -" @page-header-height - 8);
+  height: calc(~"100vh -" @page-header-height - 8);
 }
 
 .documents-list-section, .not-found-section {
@@ -554,14 +594,15 @@ main {
   position: relative;
   width: @list-width;
   float: left;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: auto;
+  padding-top: 5px;
 
   @media @phone {
     width: 100%;
     float:none;
     margin-top: 0;
-    height: 45vh;
+    padding-top: 0;
+    height: calc(~"100% - 45px");
   }
   .show-documents-filters-phone {
     display: none;
@@ -721,10 +762,10 @@ app-simple-search {
   border: 0;
   padding-bottom: 5px;
   padding-top: 5px;
+  z-index: 33;
 
   @media @phone {
     position: fixed;
-    margin-top: 6px;
   }
   #add-my-outing {
     margin-left: 10px;
@@ -817,7 +858,7 @@ app-simple-search {
   display: none;
   margin-left: 60px;
   margin-bottom: 6px;
-  z-index: 2;
+  z-index: 34;
   width: 80px;
 
   @media (max-width: 1099px){
@@ -833,16 +874,17 @@ app-simple-search {
 }
 
 .page-content {
+  height: 100%;
   margin-left: @menu-width;
-  margin-top:  8px;
 
   @media @tablet {
     margin-left: @menu-width-tablet;
     margin-top:  -41px;
   }
   @media @phone {
+    height: calc(~"100% - 50px");
     margin-left: 0;
-    margin-top: 50px;
+    margin-top: @page-header-height;
   }
 
   .archive-data {

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -244,7 +244,7 @@ main {
     .flex();
     justify-content: space-around;
     bottom: 0;
-    z-index: 2;
+    z-index: 5;
     width: calc(~"100% - 50px"); /* 50px = .toggle-map btn width*/
     height: 45px;
     padding: 5px;
@@ -300,11 +300,13 @@ main {
   right: 0;
   bottom: 0;
   z-index: 2;
-  width: 50px;
+  width: 100%;
   background-color: @lightgrey;
   height: 45px;
   padding-top: 3px;
   button {
+    float: right;
+    margin-right: 10px;
     border-radius: 50%;
     width: 38px;
     height: 38px;
@@ -353,6 +355,9 @@ main {
     -o-column-break-inside:avoid;
     -ms-column-break-inside:avoid;
     column-break-inside:avoid;
+  }
+  & + .no-results {
+    display: none;
   }
 }
 
@@ -568,7 +573,7 @@ main {
       box-shadow: 0px 0px 36px -10px rgba(0,0,0,0.56);
       height: 250px;
       margin-top: 0;
-      height: 50vh !important;
+      height: 80vh !important;
     }
   }
 
@@ -760,7 +765,7 @@ app-simple-search {
   top: 0;
   margin-bottom: 0;
   border: 0;
-  padding-bottom: 5px;
+  padding-bottom: 6px;
   padding-top: 5px;
   z-index: 33;
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -232,7 +232,12 @@ main {
     }
   }
 }
-
+/*articles and areas have no .toggle-map*/
+app-pagination.areas, app-pagination.articles{
+  #pagination {
+    width: 100%;
+  }
+}
 #pagination {
   color: lightslategrey;
   position: absolute;
@@ -607,7 +612,7 @@ main {
     float:none;
     margin-top: 0;
     padding-top: 0;
-    height: calc(~"100% - 45px");
+    .calc(height, "100% - 78px");
   }
   .show-documents-filters-phone {
     display: none;

--- a/less/filters.less
+++ b/less/filters.less
@@ -2,9 +2,14 @@
 
 form[app-search-filters] {
   background-color: white;
+  width: 100%;
 
   @media @phone {
     display: none;
+  }
+  .dropdown-menu {
+    left: 10px;
+    top: initial;
   }
   .more-filters-btn {
     position: relative;
@@ -46,10 +51,7 @@ form[app-search-filters] {
       }
     }
   }
-  .dropdown-menu {
-    left: 10px;
-    top: initial;
-  }
+
   label {
     margin-bottom: 0;
     @media @phone {
@@ -78,7 +80,7 @@ form[app-search-filters] {
     margin-top: 19px;
     top: @page-header-height - 1;
     width: 100%;
-    overflow-x: visible;
+    overflow: auto;
     box-shadow: 0 14px 14px -14px #332;
     -webkit-box-shadow: 0 14px 14px -14px #332;
     -moz-box-shadow:  0 14px 14px -14px #332;

--- a/less/filters.less
+++ b/less/filters.less
@@ -298,4 +298,7 @@ form[app-search-filters] {
   .flex();
   justify-content: center;
   padding-top: 5px;
+  @media @phone {
+    width: 100% !important;
+  }
 }

--- a/less/filters.less
+++ b/less/filters.less
@@ -3,6 +3,7 @@
 form[app-search-filters] {
   background-color: white;
   width: 100%;
+  padding-bottom: 10px;
 
   @media @phone {
     display: none;
@@ -76,29 +77,28 @@ form[app-search-filters] {
     background-color: white;
     position: absolute;
     z-index: 30;
-    padding-bottom: 20px;
+    padding: 0 10px  20px 10px;
     margin-top: 19px;
-    top: @page-header-height - 1;
     width: 100%;
+    top: @page-header-height - 1;
     overflow: auto;
     box-shadow: 0 14px 14px -14px #332;
     -webkit-box-shadow: 0 14px 14px -14px #332;
     -moz-box-shadow:  0 14px 14px -14px #332;
     max-height: 400vh;
 
+    @media @phone {
+      top: 165px;
+      overflow: hidden;
+      width: 100% !important;
+      padding: 0 0 20px 0;
+    }
     &.images .collapse.in {
       overflow-y: visible;
-      @media @phone {
-        overflow-y: auto;
-      }
     }
-
     /*show simple-filters only when #moreFilters has .sticky-filters-moreFilters*/
     &:not(.sticky-filters-moreFilters) .simple-filters {
       display: none;
-    }
-    @media @phone {
-      top: 165px;
     }
 
     .filters-bottom-buttons {

--- a/less/filters.less
+++ b/less/filters.less
@@ -1,31 +1,55 @@
 @import "variables.less";
 
-.filters-phone {
-  overflow-y: scroll;
-  height: 40vh;
+form[app-search-filters] {
+  background-color: white;
+
+  @media @phone {
+    display: none;
+  }
+  .more-filters-btn {
+    position: relative;
+    margin-bottom: 10px;
+    margin-left: 5px;
+
+    @media @phone {
+      margin-top: 5px;
+      margin-bottom: 5px;
+      padding: 4px;
+      left: -5px;
+    }
+  }
 }
 
 .filters {
   text-align: center;
   position: relative;
-  background-color: white;
   transition: 0.2s;
 
-  @media @phone {
-    display: none;
+  /*too little filters in areas - do not show more-filters-bnt*/
+  &.areas  {
+    .more-filters-btn-container {
+      display: none;
+    }
+    .sticky-filters-btn-container {
+      .flex();
+    }
   }
-
+  /*there are 2 of them: one in .filters and one in #moreFilters*/
   .simple-filters {
-    position: relative;
-    z-index: 23;
     justify-content: space-between;
     flex-flow: wrap row;
     .flex();
     .filter {
       width:  33%;
+      @media @phone {
+        width: 100%;
+      }
     }
   }
-
+  .dropdown-menu {
+    left: 10px;
+    top: initial;
+  }
   label {
     margin-bottom: 0;
     @media @phone {
@@ -44,35 +68,36 @@
         margin-top: -12px;
       }
     }
-    }
-
-    .more-filters-btn {
-    position: relative;
-    margin-bottom: 10px;
-
-    @media @phone {
-      margin-top: 5px;
-      margin-bottom: 5px;
-      padding: 4px;
-      left: -5px;
-    }
   }
 
   #moreFilters {
     background-color: white;
     position: absolute;
-    width: 100%;
-    z-index: 5;
+    z-index: 30;
     padding-bottom: 20px;
-    padding-top: 10px;
-    top: 60px;
+    margin-top: 19px;
+    top: @page-header-height - 1;
+    width: 100%;
+    overflow-x: visible;
     box-shadow: 0 14px 14px -14px #332;
     -webkit-box-shadow: 0 14px 14px -14px #332;
     -moz-box-shadow:  0 14px 14px -14px #332;
-    height: -moz-calc(~"100vh - 105px");
-    height: -webkit-calc(~"100vh - 105px");
-    height: -o-calc(~"100vh - 105px");
-    height: calc(~"100vh - 105px");
+    max-height: 400vh;
+
+    &.images .collapse.in {
+      overflow-y: visible;
+      @media @phone {
+        overflow-y: auto;
+      }
+    }
+
+    /*show simple-filters only when #moreFilters has .sticky-filters-moreFilters*/
+    &:not(.sticky-filters-moreFilters) .simple-filters {
+      display: none;
+    }
+    @media @phone {
+      top: 165px;
+    }
 
     .filters-bottom-buttons {
       width: 100%;
@@ -81,22 +106,24 @@
       position: relative;
 
       @media @phone {
-        padding-top: 20px;
         padding-bottom: 1%;
         position: static;
         top: 25px;
+        flex-flow: wrap row;
+
+        button {
+          margin-top: 5px;
+        }
       }
       @media (max-height: 580px){
         position: relative !important;
         margin-bottom: 10px !important;
         bottom: -10px !important;
       }
-      @media @tablet {
-        @media (max-height: @screen-sm-max){
+      @media (max-height: @screen-sm-max){
         position: relative !important;
         margin-bottom: 10px !important;
         bottom: -10px !important;
-      }
       }
       button {
         font-variant: small-caps;
@@ -105,7 +132,6 @@
 
         @media (max-width:@screen-md-min) {
           font-size: 1em;
-          width: 45%;
         }
       }
     }
@@ -121,7 +147,6 @@
       }
       .activity {
         width: 33.33%;
-
         @media (max-width: 900px) and (min-width: @phone-max) {
           width: 50%;
         }
@@ -236,12 +261,11 @@
   margin-left: 1%;
 
   @media @phone {
-   -webkit-columns: inherit;
-   -moz-columns: inherit;
+    -webkit-columns: inherit;
+    -moz-columns: inherit;
     overflow-x: hidden;
     overflow-y: scroll;
     max-height : 250px;
-    margin-left: -5%;
   }
 
   @media @tablet {
@@ -266,3 +290,10 @@
     transition: 0.3s;
   }
 } /* multi-selectbox */
+
+.more-filters-btn-container {
+  transition: .2s;
+  .flex();
+  justify-content: center;
+  padding-top: 5px;
+}

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -58,7 +58,7 @@
   &:hover {
     color: white;
   }
-  &:focus {
+  &:focus, &:active {
     color: white;
   }
   .glyphicon {
@@ -75,7 +75,7 @@
 }
 .orange-btn {
   background-color: @C2C-orange;
-  &:hover {
+  &:hover, &:active {
     background-color: #FF9416;
     transition: 0.1s;
   }

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -1,4 +1,5 @@
 @import 'variables.less';
+
 .text-center-vertical {
   .flex() !important;
   -ms-flex-align: center;
@@ -6,6 +7,23 @@
   -webkit-box-align: center;
   align-items: center;
   justify-content: center;
+}
+.hide-only-mobile {
+  display: block;
+  @media @phone {
+   display: none;
+  }
+}
+.show-only-mobile {
+  display: none;
+  @media @phone {
+   display: block !important;
+  }
+}
+.show {
+  opacity: 1 !important;
+  visibility: visible !important;
+  pointer-events: all !important;
 }
 
 .upload-file {
@@ -117,19 +135,6 @@ input[type=checkbox]:checked + * {
 
 .green-text {
   color: @bright-green;
-}
-
-.mobile-bg {
-  display: none;
-  @media @phone {
-    border-bottom: 1px solid #D7D7D7;
-    background-color: #FBFAF7;
-    height: 50px;
-    width: 100%;
-    position: fixed;
-    top: 0;
-    display: block;
-  }
 }
 
 .rotate-arrow-down {

--- a/less/images.less
+++ b/less/images.less
@@ -35,6 +35,7 @@
   width: 100%;
   height: 100%;
   overflow: auto;
+  padding-bottom: 200px;
 }
 .uploaded-image {
   flex-basis: 23%;

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -62,7 +62,7 @@
   position: fixed;
   top: 0;
   white-space: nowrap;
-  z-index: 24;
+  z-index: 35;
   height: 100%;
   font-size: 1em;
   transition: 0.3s;
@@ -241,7 +241,7 @@
   top: 6px;
   position: fixed;
   left: 4px;
-  z-index: 2;
+  z-index: 31;
 
   @media @phone {
     display: block;

--- a/less/stickyfilters.less
+++ b/less/stickyfilters.less
@@ -37,13 +37,12 @@
   position: fixed !important;
   top: @page-header-height - 1 !important;
   margin-top: 0 !important;
-  max-height: -moz-calc(~"100vh -"  @page-header-height) !important;
-  max-height: -webkit-calc(~"100vh -"  @page-header-height) !important;
-  max-height: -o-calc(~"100vh -"  @page-header-height) !important;
-  max-height: calc(~"100vh -"  @page-header-height) !important;
+  .calc(max-height, "100vh -  @{page-header-height}") !important;
 
   @media @phone {
     top: 90px;
+    overflow: auto !important;
+    .calc(max-height, "100vh -  100px") !important;
   }
 }
 

--- a/less/stickyfilters.less
+++ b/less/stickyfilters.less
@@ -3,11 +3,12 @@
 .sticky-filters-btn-container {
   position: fixed !important;
   font-size: 20px;
-  z-index: 1;
-  top: @page-header-height;
+  z-index: 29;
+  top: @page-header-height - 1;
   height: 40px;
   left: @menu-width;
   padding-left: 10px;
+  padding-top: 2px !important;
   background-color: #DDDDDD;
   text-align: left;
 
@@ -19,21 +20,27 @@
     left: 0;
     padding-top: 0;
     width: 100%;
-    top: 50px;
     height: 40px;
+
+    .more-filters-btn {
+      margin: 6px !important;
+    }
   }
   .more-filters-btn {
+    height: 30px;
+    padding: 0 10px;
     margin: 3px !important;
   }
 }
+
 .sticky-filters-moreFilters {
   position: fixed !important;
-  top: @page-header-height !important;
-  overflow-y: scroll;
-  height: -moz-calc(~"100vh -"  @page-header-height) !important;
-  height: -webkit-calc(~"100vh -"  @page-header-height) !important;
-  height: -o-calc(~"100vh -"  @page-header-height) !important;
-  height: calc(~"100vh -"  @page-header-height) !important;
+  top: @page-header-height - 1 !important;
+  margin-top: 0 !important;
+  max-height: -moz-calc(~"100vh -"  @page-header-height) !important;
+  max-height: -webkit-calc(~"100vh -"  @page-header-height) !important;
+  max-height: -o-calc(~"100vh -"  @page-header-height) !important;
+  max-height: calc(~"100vh -"  @page-header-height) !important;
 
   @media @phone {
     top: 90px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -26,3 +26,10 @@
   display: -webkit-flex;
   display: flex;
 }
+
+.calc(@prop; @val) {
+  @{prop}: calc(~'@{val}');
+  @{prop}: -moz-calc(~'@{val}');
+  @{prop}: -webkit-calc(~'@{val}');
+  @{prop}: -o-calc(~'@{val}');
+}

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -132,7 +132,7 @@
   height: 73%;
   margin-left: 3%;
   width: 91%;
-  padding-bottom: 266px;
+  padding-bottom: 200px;
   overflow: hidden;
 
   @media @phone {


### PR DESCRIPTION
probably fixes #692 
related to #655, #657


Some filters improvements:

+ stickyFilters directive and controller
+ when you first open 'more filters' and scroll down the list - it will not jump and become a 'sticky filter'.
+ only when you scroll down the list without first opening the dropdown - it will become a 'sticky filter'
+ solves the problem where 'activities' sometimes became unusable 
+ solves the problem with reaching the list's bottom 'show results'
+ one filter per line on mobile
+ hide the map on mobile by default, let the user toggle it with a button
+ dropdown menus FINALLY don't overflow to the right under he map - they are repositioned (as it was done for image uploader).
+ dropdown menus are not position: fixed - they move with the list as you scroll (more natural)

![screenshot from 2016-10-26 11-12-49](https://cloud.githubusercontent.com/assets/7814311/19720130/280cf29c-9b6d-11e6-9923-a040ff1c4a5f.png)

This pr only works for routes, but before I add the changes for other documents, I would like to know it what i'm doing is ok.
