### PR TITLE
Add image HTML code to article page

### DIFF
--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -55,6 +55,12 @@ other_langs, missing_langs = get_lang_lists(article, lang)
     ${show_archive_data('articles', article, locale, version)}
   % endif
 
+
+  ## IMAGES
+  % if not version:
+    ${get_image_gallery()}
+  % endif
+
   <div class="view-details-informations col-xs-12  informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>


### PR DESCRIPTION
Close https://github.com/c2corg/v6_ui/issues/804

It looks that HTML was the only part. Associated images are missing because they cannot be retrieved from the server.
"...
`1281991596_1519631005SI.jpg:1 GET http://c2corgv6-images.demo-camptocamp.com/active/1281991596_1519631005SI.jpg 404 (Not Found)`
... etc."

I tried to add my own and they show in the header.

![image](https://cloud.githubusercontent.com/assets/6165660/19761144/f735c644-9c34-11e6-8e31-8038af6e20d0.png)


I noticed that when I go to "topoguide - images" and I want to get to the detail page of an image I added on an `article/route/waypoint` page, then it does not work. It does not look as an article-related mistake because I tried to do the same with routes/waypoint also on the demo server ( http://c2corgv6.demo-camptocamp.com/ ). I will probably create new issue for it...