### PR TITLE
Show associated outings in image detail view page

### DIFF
--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -39,6 +39,7 @@ app.Document = function(appAuthentication, $rootScope) {
       'all_routes': {'total': 0, 'documents': []},
       'users': [],
       'recent_outings': {'total': 0, 'documents': []},
+      'outings': [],
       'articles': [],
       'images': [],
       'areas': []
@@ -56,12 +57,14 @@ app.Document = function(appAuthentication, $rootScope) {
    *  users: Array<number>,
    *  images: Array<number>,
    *  areas: Array<number>,
+   *  outings: Array<number>,
    *  articles: Array<number>
    * }}
    * @private
    */
   this.associationsIds_ = {
-    'routes': [], 'waypoints': [], 'images': [], 'users': [], 'areas': [], 'articles': []
+    'routes': [], 'waypoints': [], 'images': [], 'users': [], 'areas': [],
+    'articles': [], 'outings': []
   };
 };
 
@@ -149,9 +152,7 @@ app.Document.prototype.pushToAssociations = function(doc, doctype,
  * @export
  */
 app.Document.prototype.removeAssociation = function(id, type, event) {
-  var associations = type === 'outings' ?
-          this.document.associations.recent_outings.documents :
-          this.document.associations[type];
+  var associations = this.document.associations[type];
 
   event.currentTarget.closest('.list-item').className += ' remove-item';
   // you need settimeout because if you splice the array immediatly, the animation

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -303,13 +303,28 @@
 <%def name="show_associated_outings(document)">\
   <%
       associations = document['associations']
+      if 'recent_outings' in associations:
+          isRecentOutings = True
+          outings = associations['recent_outings']['documents']
+          total = associations['recent_outings']['total']
+      elif 'outings' in associations:
+          isRecentOutings = False
+          outings = associations['outings']
+          total = len(outings)
+      else:
+          total = 0
   %>
-  % if 'recent_outings' in associations and associations['recent_outings']['total'] > 0:
-    ${add_seo_association_links(associations['recent_outings']['documents'], 'outings')}
+  % if total > 0:
+    ${add_seo_association_links(outings, 'outings')}
     <article>
       <h3 class="heading show-phone outings" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-outings">
         <span class="glyphicon glyphicon-map-marker"></span>
-        <span translate>Last outings</span><span class="glyphicon glyphicon-menu-down"></span>
+        % if isRecentOutings:
+          <span translate>Last outings</span>
+        % else:
+          <span translate>Associated outings</span>
+        % endif
+        <span class="glyphicon glyphicon-menu-down"></span>
       </h3>
       <div class="associated-documents collapse in" id="associated-outings">
         % if document['doctype'] == 'routes':
@@ -320,10 +335,17 @@
             </a>
           </div>
         % endif
-        <div class="list-item outings" ng-repeat="doc in detailsCtrl.documentService.document.associations.recent_outings.documents">
+        <div class="list-item outings" ng-repeat="doc in detailsCtrl.documentService.document.associations.${'recent_outings.documents' if isRecentOutings else 'outings'}">
           <app-card app-card-doc="doc"></app-card>
+          % if not isRecentOutings and document['doctype'] == 'images':
+            <%
+                options = {"imageType": document["image_type"], "imageCreator": document["creator"]["user_id"]}
+            %>
+            <app-delete-association child-doctype="o" parent-id="${document['document_id']}" child-id="doc.document_id"
+              ng-if="userCtrl.hasEditRights('images', ${options})"></app-delete-association>
+          % endif
         </div>
-        % if associations['recent_outings']['total'] > len(associations['recent_outings']['documents']) :
+        % if isRecentOutings and total > len(outings) :
           <%
               fragment = '{0}={1}'.format(document['type'], document['document_id'])
           %>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -9,7 +9,8 @@ from json import dumps
 <%namespace file="../helpers/view.html" import="get_image_gallery, photoswipe_gallery,
     show_attr, show_missing_langs_links, show_other_langs_links, show_badge,
     show_archive_data, show_route_title, get_route_activities, show_areas, show_float_buttons,
-    show_associated_waypoints, show_associated_routes, show_associated_articles, delete_association_confirmation_modal,
+    show_associated_waypoints, show_associated_routes, show_associated_articles,
+    show_associated_outings, delete_association_confirmation_modal,
     get_document_description, get_comments, get_licence"/>
 <%namespace file="helpers/view.html" import="get_image_general, get_image_camera_settings, create_image_link"/>
 
@@ -120,6 +121,7 @@ from json import dumps
         <app-add-association parent-doctype="images" parent-id="${image_id}" dataset="wrc"></app-add-association>
       </div>
       <section>
+        ${show_associated_outings(image)}
         ${show_associated_routes(image)}
         ${show_associated_waypoints(image)}
         ${show_associated_articles(image)}


### PR DESCRIPTION
Fixes https://github.com/c2corg/v6_ui/issues/609

I expect problems with the `removeAssociation` button because it's based upon `associations.recent_outings` whereas image detail views provide `associations.outings`.
See https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/documentservice.js#L151-L154
