### PR TITLE
list page with no map fix

### DIFF
--- a/c2corg_ui/templates/area/index.html
+++ b/c2corg_ui/templates/area/index.html
@@ -18,15 +18,16 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+<div class="documents-list-section-container no-map">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
 
-<section class="documents-list-section">
-  <%include file="filters.html" />
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    ${add_doctype_selector()}
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      ${add_doctype_selector()}
+      <app-pagination class="areas"></app-pagination>
+    </div>
 
-    <app-pagination class="areas"></app-pagination>
-  </div>
-
-  <app-advanced-search document-type="areas" use-map="false"></app-advanced-search>
-</section>
+    <app-advanced-search document-type="areas" use-map="false"></app-advanced-search>
+  </section>
+</div>

--- a/c2corg_ui/templates/article/index.html
+++ b/c2corg_ui/templates/article/index.html
@@ -19,20 +19,18 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
-<section class="documents-list-section">
-  <%include file="filters.html" />
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('articles_add')}"
-            uib-tooltip="{{'Create a new article' | translate }}" tooltip-placement="right">
-      <span class="glyphicon glyphicon-plus-sign"></span>
-    </button>
-    <app-pagination class="articles"></app-pagination>
-  </div>
-  <app-advanced-search document-type="articles" use-map="false"></app-advanced-search>
-</section>
-<script>
-window.onload = function(){
-  app.stickyFilters();
-}
-</script>
+<div class="documents-list-section-container no-map">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('articles_add')}"
+              uib-tooltip="{{'Create a new article' | translate }}" tooltip-placement="right">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+      </button>
+      <app-pagination class="articles"></app-pagination>
+    </div>
+
+    <app-advanced-search document-type="articles" use-map="false"></app-advanced-search>
+  </section>
+</div>

--- a/c2corg_ui/templates/image/index.html
+++ b/c2corg_ui/templates/image/index.html
@@ -18,22 +18,23 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+<div class="documents-list-section-container">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
 
-<section class="documents-list-section">
-  <%include file="filters.html" />
-
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    ${add_doctype_selector()}
-    <app-pagination></app-pagination>
-    <div class="toggle-map">
-      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      ${add_doctype_selector()}
+      <app-pagination></app-pagination>
+      <div class="toggle-map">
+        <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      </div>
     </div>
+
+    <app-advanced-search document-type="images" use-map="true"></app-advanced-search>
+  </section>
+
+  <div class="map-right">
+    <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true"></app-map>
   </div>
-
-  <app-advanced-search document-type="images" use-map="true"></app-advanced-search>
-</section>
-
-<div class="map-right">
-  <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true"></app-map>
 </div>

--- a/c2corg_ui/templates/outing/index.html
+++ b/c2corg_ui/templates/outing/index.html
@@ -25,28 +25,29 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+<div class="documents-list-section-container">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
 
-<section class="documents-list-section">
-  <%include file="filters.html" />
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      ${add_doctype_selector()}
 
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    ${add_doctype_selector()}
+      <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('outings_add')}"
+              uib-tooltip="{{'Create a new outing' | translate }}" tooltip-placement="right">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+      </button>
 
-    <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('outings_add')}"
-            uib-tooltip="{{'Create a new outing' | translate }}" tooltip-placement="right">
-      <span class="glyphicon glyphicon-plus-sign"></span>
-    </button>
-
-    <app-pagination></app-pagination>
-    <div class="toggle-map">
-      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      <app-pagination></app-pagination>
+      <div class="toggle-map">
+        <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      </div>
     </div>
+
+    <app-advanced-search document-type="outings" use-map="true"></app-advanced-search>
+  </section>
+
+  <div class="map-right">
+    <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
   </div>
-
-  <app-advanced-search document-type="outings" use-map="true"></app-advanced-search>
-</section>
-
-<div class="map-right">
-  <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
 </div>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -34,28 +34,29 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+<div class="documents-list-section-container">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
 
-<section class="documents-list-section">
-  <%include file="filters.html" />
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      ${add_doctype_selector()}
 
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    ${add_doctype_selector()}
+      <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('routes_add')}"
+              uib-tooltip="{{'Create a new route' | translate }}" tooltip-placement="right">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+      </button>
 
-    <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('routes_add')}"
-            uib-tooltip="{{'Create a new route' | translate }}" tooltip-placement="right">
-      <span class="glyphicon glyphicon-plus-sign"></span>
-    </button>
-
-    <app-pagination></app-pagination>
-    <div class="toggle-map">
-      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      <app-pagination></app-pagination>
+      <div class="toggle-map">
+        <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      </div>
     </div>
+
+    <app-advanced-search document-type="routes" use-map="true"></app-advanced-search>
+  </section>
+
+  <div class="map-right">
+    <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
   </div>
-
-  <app-advanced-search document-type="routes" use-map="true"></app-advanced-search>
-</section>
-
-<div class="map-right">
-  <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
 </div>

--- a/c2corg_ui/templates/waypoint/index.html
+++ b/c2corg_ui/templates/waypoint/index.html
@@ -27,27 +27,28 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
+<div class="documents-list-section-container">
+  <section class="documents-list-section">
+    <%include file="filters.html" />
 
-<section class="documents-list-section">
-  <%include file="filters.html" />
+    <div class="documents-nav-buttons text-center">
+      <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
+      ${add_doctype_selector()}
 
-  <div class="documents-nav-buttons text-center">
-    <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
-    ${add_doctype_selector()}
+      <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('waypoints_add')}"
+              uib-tooltip="{{'Create a new waypoint' | translate }}" tooltip-placement="right">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+      </button>
 
-    <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('waypoints_add')}"
-            uib-tooltip="{{'Create a new waypoint' | translate }}" tooltip-placement="right">
-      <span class="glyphicon glyphicon-plus-sign"></span>
-    </button>
-
-    <app-pagination></app-pagination>
-    <div class="toggle-map">
-      <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      <app-pagination></app-pagination>
+      <div class="toggle-map">
+        <button class="btn btn-default"><span class="glyphicon glyphicon-globe"></span></button>
+      </div>
     </div>
-  </div>
-  <app-advanced-search document-type="waypoints" use-map="true"></app-advanced-search>
-</section>
+    <app-advanced-search document-type="waypoints" use-map="true"></app-advanced-search>
+  </section>
 
-<div class="map-right">
-  <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
+  <div class="map-right">
+    <app-map app-map-advanced-search="true" app-map-show-recenter-tools="true" app-map-default-map-filter="true"></app-map>
+  </div>
 </div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -33,9 +33,6 @@ html, body{
   background-color: @body-color;
 }
 
-.ol-zoom {
-  top: 44px;
-}
 .modal-dialog {
   margin-top: 30vh;
 
@@ -45,13 +42,15 @@ html, body{
 }
 
 .documents-nav-buttons {
-  .flex();
-  flex-flow: wrap row;
-  padding: 10px 10px 0 10px;
+  display: inline-block;
+  width: 100%;
+  padding: 10px 2% 0 2%;
 
   button[protected-url-btn] {
     padding: 0 5px;
     font-size: 20px;
+    float: left;
+    height: 34px;
     span {
       top: 3px;
       font-size: 20px;
@@ -64,33 +63,21 @@ html, body{
 }
 
 .page-main-title {
-  top: @page-header-height - 1;
   color: white;
-  height: 40px;
-  position: relative;
-  z-index: 1;
-  margin-left: @list-width;
+  height: @page-main-title-height;
+  position: absolute;
+  .calc(width, "100% - @{menu-width}");
+  z-index: 31;
   text-align: center;
-  padding-top: 6px;
-  background-color: rgba(104, 159, 179, 0.64);
-
-  /*the filters button shown on mobile*/
-  button {
-    display: none;
-    height: 24px;
-    padding: 0 10px;
-  }
+  padding-top: 2px;
+  background-color: rgb(152, 181, 205);
 
   @media @tablet {
-    top: 43px;
+    .calc(width, "100% - @{menu-width-tablet}");
   }
   @media @phone {
-    .flex();
-    justify-content: space-around;
-    align-items: center;
     padding: 0;
-    position: initial;
-    margin-left: 0;
+    width: 100%;
     height: 35px;
     button {
       display: none;
@@ -100,6 +87,12 @@ html, body{
       padding: 1%;
     }
   }
+  /*the filters button shown on mobile*/
+  button {
+    display: none;
+    height: 24px;
+    padding: 0 10px;
+  }
 
   .badge {
     background-color: @C2C-orange;
@@ -108,20 +101,6 @@ html, body{
 
 h1 {
   font-size: 3em;
-}
-
-#waypoints, #routes {
-  padding-right: 2%;
-  margin-bottom: 2%;
-  margin-left: 2%;
-  width:98%;
-  min-height:100px;
-  height: 69vh;
-  overflow-y: auto;
-
-  @media @phone {
-    height: 45vh;
-  }
 }
 
 #missing-langs, #other-langs {
@@ -233,7 +212,7 @@ main {
   }
 }
 /*articles and areas have no .toggle-map*/
-app-pagination.areas, app-pagination.articles{
+app-pagination.areas, app-pagination.articles {
   @media @phone {
     #pagination {
       width: 100%;
@@ -242,8 +221,7 @@ app-pagination.areas, app-pagination.articles{
 }
 #pagination {
   color: lightslategrey;
-  position: absolute;
-  right: 10px;
+  float: right;
 
   @media @phone {
     position: fixed;
@@ -567,9 +545,18 @@ app-pagination.areas, app-pagination.articles{
 }
 
 .map-right {
+  float: left;
   position: relative;
-  margin-left: @list-width;
+  width: 40%;
 
+  @media @phone {
+    margin-left: 0;
+    bottom: 40px;
+    position: fixed;
+    opacity: 0;
+    pointer-events: none;
+    width: 100%;
+  }
   .map {
     @media (max-height: 300px) {
       height: 70vh;
@@ -583,39 +570,37 @@ app-pagination.areas, app-pagination.articles{
       height: 80vh !important;
     }
   }
+}
 
-  @media @phone {
-    margin-left: 0;
-    bottom: 40px;
-    position: fixed;
-    opacity: 0;
-    pointer-events: none;
+.documents-list-section-container {
+  position: relative;
+  &.no-map .documents-list-section, &.no-map .page-main-title {
     width: 100%;
   }
 }
-.documents-list-section, .map-right .map, .not-found-section {
-  .calc(height, "100vh - @{page-header-height} + 4px");
+.documents-list-section, .not-found-section, .map-right .map {
+  margin-top: @page-main-title-height;
+  .calc(height, "100vh - @{page-header-height} - @{page-main-title-height}");
 }
 
 .documents-list-section, .not-found-section {
+  float: left;
   background-color: @lightgrey;
   position: relative;
   width: @list-width;
-  float: left;
   overflow: auto;
-  padding-top: 5px;
 
   @media @phone {
     width: 100%;
     float:none;
-    margin-top: 0;
-    padding-top: 0;
-    .calc(height, "100vh - 128px");
+    padding-top: 35px;
+    .calc(height, "100vh - 92px");
   }
   .show-documents-filters-phone {
     display: none;
     height: 33px;
     margin-right: 5px;
+    float: right;
 
     @media @phone {
       display: block;
@@ -879,11 +864,12 @@ app-simple-search {
 }
 
 .page-content {
+  margin-top: @page-header-height;
   margin-left: @menu-width;
 
   @media @tablet {
     margin-left: @menu-width-tablet;
-    margin-top:  -41px;
+    margin-top:  9px;
   }
   @media @phone {
     margin-left: 0;
@@ -919,8 +905,8 @@ app-simple-search {
 }
 
 @keyframes fadein {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 app-alerts {
@@ -1145,6 +1131,7 @@ ul {
 .select-document {
   width: 170px;
   margin-right: 10px;
+  float: left;
 }
 
 .section.associations, .view-details-section {

--- a/less/filters.less
+++ b/less/filters.less
@@ -3,7 +3,6 @@
 form[app-search-filters] {
   background-color: white;
   width: 100%;
-  padding-bottom: 10px;
 
   @media @phone {
     display: none;
@@ -20,8 +19,6 @@ form[app-search-filters] {
     @media @phone {
       margin-top: 5px;
       margin-bottom: 5px;
-      padding: 4px;
-      left: -5px;
     }
   }
 }
@@ -294,10 +291,10 @@ form[app-search-filters] {
 } /* multi-selectbox */
 
 .more-filters-btn-container {
-  transition: .2s;
   .flex();
   justify-content: center;
   padding-top: 5px;
+  transition: .2s;
   @media @phone {
     width: 100% !important;
   }

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -168,6 +168,9 @@ input[type=checkbox]:checked + * {
   overflow: hidden;
 }
 
+.overflow-scroll {
+  overflow-y: scroll;
+}
 
 .glyphicon-ok {
   color: #3c763d !important;

--- a/less/map.less
+++ b/less/map.less
@@ -15,7 +15,6 @@
 
   .map-filter-switch {
     position: absolute;
-    top: 50px;
     right: 10px;
     z-index: 2;
     background-color: rgba(255, 255, 255, 0.7);
@@ -41,16 +40,6 @@
       display: block !important;
     }
   }
-  @media @phone {
-    .map-filter-switch {
-      top: 4px;
-      right: 6px;
-    }
-    .map-recenter-tools {
-      top: 4px;
-      left: 10px;
-    }
-  }
 }
 
 app-baselayer-selector {
@@ -62,7 +51,6 @@ app-baselayer-selector {
 
 .map-recenter-tools {
   position: absolute;
-  top: 50px;
   left: 50px;
   z-index: 1;
 }
@@ -114,4 +102,8 @@ app-map-search {
       }
     }
   }
+}
+
+.ol-zoom, .map-recenter-tools, .map-filter-switch {
+  top: 10px;
 }

--- a/less/stickyfilters.less
+++ b/less/stickyfilters.less
@@ -4,13 +4,13 @@
   position: fixed !important;
   font-size: 20px;
   z-index: 29;
-  top: @page-header-height - 1;
-  height: 40px;
+  top: @page-header-height + @page-main-title-height;
+  height: @page-main-title-height + 10;
   left: @menu-width;
-  padding-left: 10px;
   padding-top: 2px !important;
   background-color: #DDDDDD;
   text-align: left;
+  box-shadow: -2px 4px 14px rgba(128, 128, 128, 0.4);
 
   @media @tablet {
     left: @menu-width - (@menu-width - @menu-width-tablet);
@@ -20,32 +20,23 @@
     left: 0;
     padding-top: 0;
     width: 100%;
-    height: 40px;
-
-    .more-filters-btn {
-      margin: 6px !important;
-    }
   }
   .more-filters-btn {
+    margin: 3px !important;
     height: 30px;
     padding: 0 10px;
-    margin: 3px !important;
+
+    @media @phone {
+      margin: 7px !important;
+      height: 26px;
+    }
   }
 }
 
 .sticky-filters-moreFilters {
   position: fixed !important;
-  top: @page-header-height - 1 !important;
+  top: @page-header-height + @page-main-title-height !important;
   margin-top: 0 !important;
-  .calc(max-height, "100vh -  @{page-header-height}") !important;
-
-  @media @phone {
-    top: 90px;
-    overflow: auto !important;
-    .calc(max-height, "100vh -  100px") !important;
-  }
-}
-
-.overflow-scroll {
-  overflow-y: scroll;
+  .calc(max-height, "100vh -  @{page-header-height} - @{page-main-title-height}") !important;
+  transition: .2s;
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -13,6 +13,7 @@
 @float-buttons-bar-height: 65px;
 @list-width: 60%;
 @body-color: #FBFAF6;
+@page-main-title-height: 30px;
 
 .shadow(@right, @bottom, @spread, @color) {
   -moz-box-shadow: @right @bottom @spread @color;


### PR DESCRIPTION

![screenshot from 2016-11-01 13-26-09](https://cloud.githubusercontent.com/assets/7814311/19889728/dbba2170-a036-11e6-8ecc-65e3f53abddd.png)

fixes #733

just put the `<div class="documents-list-section-container no-map"></div>` around the content of an index.html file. 

I have also made a small change: the title ("Outings" or "Waypoints" for example) has been moved inside .map-right because it was shown on the map and therefore it was like a part of the map. It is not shown on mobile anymore as it was previously, on the top. You still know what document type you are seeing because of the select box where the doc type is selected.

This was a problem because if there is no map - where should this big title go? It's true that now it's less evident what we're seeing. Maybe a title just above the list would do the trick, but it would be redoundant with the select box.

To be approved.