### PR TITLE
mobile vesion of conditions levels table

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -380,48 +380,7 @@
           % endif
 
           % if conditions_levels_exist:
-            <div class="table-responsive">
-              <table class="table table-striped conditions-levels">
-                <thead>
-                  <tr>
-                    <th class="location"><span translate>location</span> |
-                      <span translate>altitude</span> |
-                      <span translate>orientations</span>
-                    </th>
-                    <th class="soft-snow" translate>soft snow</th>
-                    <th class="total-snow" translate>total snow</th>
-                    <th class="comment" translate>comment</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  % for condition in cond:
-                  <tr>
-                    ## print empty td for alignement
-                    % if 'level_place' and condition.get('level_place'):
-                      <td>${condition['level_place']}</td>
-                    % else:
-                      <td></td>
-                    % endif
-                    % if 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '' and condition['level_snow_height_soft'] is not None:
-                      <td>${condition['level_snow_height_soft']} cm</td>
-                    % else:
-                    <td></td>
-                    % endif
-                    % if 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '' and condition['level_snow_height_total']:
-                      <td>${condition['level_snow_height_total']} cm</td>
-                    % else:
-                    <td></td>
-                    % endif
-                    % if 'level_comment' and condition.get('level_comment'):
-                      <td >${condition['level_comment']}</td>
-                    % else:
-                      <td></td>
-                    % endif
-                  </tr>
-                  % endfor
-                </tbody>
-              </table>
-            </div>
+            ${create_conditions_levels_tables(cond)}
           % endif
         </div>
       </section>
@@ -450,6 +409,101 @@
       </div>
     % endif
   % endif
+</%def>
+
+
+<%def name="create_conditions_levels_tables(cond)">\
+
+  <label translate>conditions_levels</label>
+  <div class="show-only-mobile conditions-levels">
+      % for condition in cond:
+       <%
+       level = 'level_place' and condition.get('level_place')
+       comment = 'level_comment' and condition.get('level_comment')
+       total_snow = 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '' and condition['level_snow_height_total']
+       soft_snow = 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '' and condition['level_snow_height_soft'] is not None
+       %>
+       <div class="condition">
+         % if level:
+          <p class="key">
+            <span translate>location</span> |
+          <span translate>altitude</span> |
+          <span translate>orientations</span>
+          </p>
+          <p class="val">${condition['level_place']}</p>
+         % endif
+          <div class="snow">
+            <p class="key" translate>soft snow</p>
+            % if soft_snow:
+              <p class="val">${condition['level_snow_height_soft']} cm<p>
+              % else:
+              <p  class="val" translate>no info</p>
+            % endif
+          </div>
+            <div class="snow">
+              <p class="key" translate>total snow</b></p>
+              % if total_snow:
+                <p  class="val">${condition['level_snow_height_total']} cm}</p>
+              % else:
+                <p  class="val" translate>no info</p>
+              % endif
+            </div>
+         % if comment:
+          <p class="key" translate>comment</p>
+          <p class="val">${condition['level_comment']}</p>
+         % endif
+       </div>
+      % endfor
+  </div>
+
+  <table class="table table-striped conditions-levels">
+    <thead>
+      <tr>
+        <th class="location">
+          <span translate>location</span> |
+          <span translate>altitude</span> |
+          <span translate>orientations</span>
+        </th>
+        <th class="soft-snow" translate>soft snow</th>
+        <th class="total-snow" translate>total snow</th>
+        <th class="comment" translate>comment</th>
+      </tr>
+    </thead>
+    <tbody>
+      % for condition in cond:
+      <%
+      level = 'level_place' and condition.get('level_place')
+      comment = 'level_comment' and condition.get('level_comment')
+      total_snow = 'level_snow_height_total' in condition and condition['level_snow_height_total'] != '' and condition['level_snow_height_total']
+      soft_snow = 'level_snow_height_soft' in condition and condition['level_snow_height_soft'] != '' and condition['level_snow_height_soft'] is not None
+      %>
+      <tr>
+        ## print empty td for alignement
+        % if level:
+          <td>${condition['level_place']}</td>
+        % else:
+          <td></td>
+        % endif
+        % if soft_snow:
+          <td>${condition['level_snow_height_soft']} cm</td>
+        % else:
+          <td></td>
+        % endif
+        % if total_snow:
+          <td>${condition['level_snow_height_total']} cm</td>
+        % else:
+          <td></td>
+        % endif
+        % if comment:
+          <td >${condition['level_comment']}</td>
+        % else:
+          <td></td>
+        % endif
+      </tr>
+      % endfor
+    </tbody>
+  </table>
+
 </%def>
 
 ## Float buttons

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,7 +1,7 @@
 @big: ~"only screen and (min-width: 1400px) and (max-width: 3000px)";
 @desktop: ~"only screen and (min-width: 1100px) and (max-width: 1399px)";
 @tablet: ~"only screen and (min-width: 620px) and (max-width: 1099px)";
-@phone: ~"only screen and (min-width: 130px) and (max-width: 619px)";
+@phone: ~"only screen and (max-width: 619px)";
 @phone-max: 620px;
 @lightgrey: #F0F0F0;
 @C2C-orange: #FFAA45;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -229,8 +229,31 @@
       }
     }
     .conditions-levels {
-      font-size: 1em;
-      th {
+      font-size: .9em;
+      @media @phone {
+        display: none;
+      }
+      .condition {
+        overflow: hidden;
+        background-color: #f8f8f8;
+        margin-bottom: 30px;
+        border-radius: 5px;
+        border: 1px solid #acacac;
+
+        .key {
+          background-color: #7a979b;
+          color: white !important;
+          padding: 3px 10px;
+        }
+        .val {
+          padding-left: 10px;
+        }
+        .snow:first-of-type {
+          width: 50%;
+          float: left;
+        }
+      }
+      th, .key {
         line-height: 16px;
         color: #8D8D8D;
         font-variant: small-caps;


### PR DESCRIPTION
related to #410

this is a suggestion for fixing the `conditions_levels` table of an outing, which is very difficult to navigate on mobile.

After browsing https://css-tricks.com/responsive-data-table-roundup/, I decided that the easiest way would be to duplicate the table: show one on desktop and another one on mobile only (that's what one of the listed plugin's just did). 

That said, tables are not very suitable for mobiles...:P 

Awaiting your opinion.

![screenshot from 2016-11-01 17-29-22](https://cloud.githubusercontent.com/assets/7814311/19922244/105649e4-a0e2-11e6-8b83-fdb4177ed137.png)
