### PR TITLE
Transport select

### DIFF
--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -368,7 +368,7 @@ updating_doc = outing_id and outing_lang
             <div class="form-group half" ng-class="{'has-success': outing.public_transport != undefined}">
               <label translate>public_transport</label>
               <input type="checkbox" ng-model="outing.public_transport" ng-checked="outing.public_transport == true">
-              <span></span>
+              <span ng-click="editCtrl.pushToArray(outing, 'public_transport', !outing.public_transport, $event)"></span>
             </div>
 
             ## FREQUENTATION

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1045,10 +1045,10 @@ input[type=checkbox] + * {
   padding-left:21px;
   height:16px;
   display:inline-block;
-  line-height:16px;
+  line-height: 20px;
   background-repeat:no-repeat;
-  background-position: 0 0;
-  font-size:16px;
+  background-position: 0 1px;
+  font-size:15px;
   vertical-align:middle;
   cursor:pointer;
   background-image:url(../img/checkbox-bg.svg);
@@ -1056,7 +1056,7 @@ input[type=checkbox] + * {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  display: inline-block;
+  display: inline;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;


### PR DESCRIPTION
related to #826 

 + fixes the click on public transportation
 + finally the long texts of checkbox lists don't overflow on each other (i don't recall what issue it was, but it was mentioned somewhere)