### PR TITLE
Activate map recentering tools in editing forms

### DIFF
--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -165,7 +165,7 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
               </div>
             </div>
 
-            <app-map app-map-edit="true" app-map-draw-type="Point" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-show-recenter-tools="true" app-map-draw-type="Point" class="map-edit"></app-map>
 
           </div>
         </section>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -105,7 +105,7 @@ updating_doc = outing_id and outing_lang
 
             ## MAP
             <app-gpx-upload></app-gpx-upload>
-            <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-show-recenter-tools="true" app-map-draw-type="LineString" class="map-edit"></app-map>
 
             ## ROUTE TAKEN
             <div class="full" class="form-group">

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -88,7 +88,7 @@ updating_doc = route_id and route_lang
 
             ## MAP + upload
             <app-gpx-upload></app-gpx-upload>
-            <app-map app-map-edit="true" app-map-draw-type="LineString" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-show-recenter-tools="true" app-map-draw-type="LineString" class="map-edit"></app-map>
 
           </div>
         </section>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -207,7 +207,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               </div>
             </div>
 
-            <app-map app-map-edit="true" app-map-draw-type="Point" class="map-edit"></app-map>
+            <app-map app-map-edit="true" app-map-show-recenter-tools="true" app-map-draw-type="Point" class="map-edit"></app-map>
 
             ## MAPS REF
             <div id="maps_info-group" class="input-group" ng-if="type != 'climbing_indoor' ">


### PR DESCRIPTION
Fixes https://github.com/c2corg/v6_ui/issues/834

This change is quite simple. A small downside is that the geonames tool comes with the "recenter on my position" button, which is probably not really relevant here (?).

<img width="400" alt="capture d ecran 2016-11-03 a 22 28 04" src="https://cloud.githubusercontent.com/assets/1192331/19985980/4f12924e-a215-11e6-9689-4a5087d9dfad.png">
