### PR TITLE
Save-Confirmation-Modal for editing pages

### DIFF
--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -16,17 +16,17 @@ app.constants = {
     DEKTOP : 1400
   },
   STEPS: {
-    'climbing_outdoor' : 4,
-    'climbing_indoor' :  4,
-    'hut' : 4,
-    'gite' : 4,
-    'shelter' : 4,
-    'access' : 4,
-    'camp_site' : 4,
-    'local_product' : 4,
-    'paragliding_takeoff' : 4,
-    'paragliding_landing' : 4,
-    'webcam': 4
+    'climbing_outdoor' : 3,
+    'climbing_indoor' :  3,
+    'hut' : 3,
+    'gite' : 3,
+    'shelter' : 3,
+    'access' : 3,
+    'camp_site' : 3,
+    'local_product' : 3,
+    'paragliding_takeoff' : 3,
+    'paragliding_landing' : 3,
+    'webcam': 3
   },
   REQUIRED_FIELDS: {
     'waypoints': ['title' , 'lang', 'waypoint_type', 'elevation', 'longitude', 'latitude'],

--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -1,6 +1,7 @@
 goog.provide('app.DocumentEditingController');
 goog.provide('app.PreviewModalController');
 goog.provide('app.documentEditingDirective');
+goog.provide('app.ConfirmSaveController');
 
 goog.require('app');
 goog.require('app.Alerts');
@@ -571,7 +572,68 @@ app.DocumentEditingController.prototype.preview = function() {
 };
 
 
+/**
+ * @export
+ */
+app.DocumentEditingController.prototype.confirmSave = function(isValid) {
+  var template = angular.element('#save-confirmation-modal').clone();
+  var modalInstance = this.modal_.open({
+    animation: true,
+    template: this.compile_(template)(this.scope),
+    controller: 'appConfirmSaveModalController as saveCtrl'
+  });
+
+  modalInstance.result.then(function(res) {
+    if (res) {
+      this.scope[this.modelName]['message'] = res.message;
+      this.scope[this.modelName]['quality'] = res.quality;
+      this.submitForm(isValid);
+    }
+  }.bind(this));
+};
+
+
 app.module.controller('appDocumentEditingController', app.DocumentEditingController);
+
+
+/**
+ * We have to use a secondary controller for the modal so that we can inject
+ * uibModalInstance which is not available from the first level controller.
+ * @param {Object} $uibModalInstance modal from angular bootstrap
+ * @constructor
+ * @ngInject
+ */
+app.ConfirmSaveController = function($uibModalInstance, appDocument) {
+
+  /**
+   * @type {Object} $uibModalInstance angular bootstrap
+   * @private
+   */
+  this.modalInstance_ = $uibModalInstance;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.message = appDocument.document.message;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.quality = appDocument.document.quality;
+};
+
+
+/**
+ * @export
+ */
+app.ConfirmSaveController.prototype.close = function(action) {
+  this.modalInstance_.close(action);
+};
+
+
+app.module.controller('appConfirmSaveModalController', app.ConfirmSaveController);
 
 
 /**

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -78,7 +78,9 @@ app.MainController.prototype.isPath = function(path) {
     return 'home';
   // if topoguide, it can be all kinds of documents
   } else if (path === 'topoguide') {
-    return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1 || location.indexOf('outings') > -1 || location.indexOf('areas') > -1;
+    return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1 || location.indexOf('outings') > -1
+            || location.indexOf('areas') > -1 || location.indexOf('images') > -1 || location.indexOf('books')
+            || location.indexOf('articles') > -1;
   } else {
     return location.indexOf(path) > -1;
   }

--- a/c2corg_ui/static/js/style/progressbar.js
+++ b/c2corg_ui/static/js/style/progressbar.js
@@ -109,14 +109,6 @@ app.ProgressBarController.prototype.step = function(step, document, direction) {
       this.nextStep = 5;
       break;
 
-    case 5:
-      $(el).animate({left: '-457%'});
-      this.animateBar_(step, direction);
-      this.previousStep = 4;
-      this.currentStep = 5;
-      this.nextStep = 6;
-      break;
-
     default:
       break;
   }
@@ -195,7 +187,7 @@ app.ProgressBarController.prototype.animateBar_ = function(step, direction) {
  * @export
  */
 app.ProgressBarController.prototype.updateMaxSteps = function(waypointType) {
-  this.maxSteps = app.constants.STEPS[waypointType] || 3;
+  this.maxSteps = app.constants.STEPS[waypointType] || 2;
 };
 
 app.module.controller('appProgressBarController', app.ProgressBarController);

--- a/c2corg_ui/templates/area/edit.html
+++ b/c2corg_ui/templates/area/edit.html
@@ -1,12 +1,13 @@
 <%!
-from c2corg_common.attributes import default_langs, quality_types, area_types
+from c2corg_common.attributes import default_langs, area_types
 %>
 <%inherit file="../base.html"/>
 <%
   updating_doc = area_id and area_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons"/>
+<%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons,
+    show_save_confirmation_modal"/>
 
 <%block name="pagetitle">
 <title ng-init="id = ${area_id if area_id else 0}" ng-bind="id ?
@@ -27,7 +28,7 @@ from c2corg_common.attributes import default_langs, quality_types, area_types
   % if updating_doc:
     app-document-editing-id="${area_id}" app-document-editing-lang="${area_lang}"
   % endif
-    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
 
     <section class="editing">
 
@@ -99,14 +100,6 @@ from c2corg_common.attributes import default_langs, quality_types, area_types
               <textarea name="description" ng-model="area.locales[0].description" class="form-control description"></textarea>
             </div>
 
-            ## QUALITY
-            <div class="half" ng-class="{'has-success': area.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{area.quality = area.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="area.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="area.quality"></span>
-            </div>
           </div>
         </section>
 
@@ -114,6 +107,7 @@ from c2corg_common.attributes import default_langs, quality_types, area_types
 
     </section>
   </form>
+  ${show_save_confirmation_modal(updating_doc)}
+  ${show_preview_container()}
 </section>
 
-${show_preview_container()}

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -1,12 +1,12 @@
 <%!
-from c2corg_common.attributes import default_langs, quality_types, activities, article_categories, article_types
+from c2corg_common.attributes import default_langs, activities, article_categories, article_types
 %>
 <%inherit file="../base.html"/>
 <%
   updating_doc = article_id and article_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons"/>
+<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons"/>
 
 <%block name="pagetitle"><title ng-init="id = ${article_id if article_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an article') : mainCtrl.page_title('Creating an article')">${show_title('Create/edit article')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -22,7 +22,7 @@ from c2corg_common.attributes import default_langs, quality_types, activities, a
   % if updating_doc:
     app-document-editing-id="${article_id}" app-document-editing-lang="${article_lang}"
   % endif
-    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
 
     <section class="editing">
 
@@ -124,23 +124,6 @@ from c2corg_common.attributes import default_langs, quality_types, activities, a
               <textarea name="description" ng-model="article.locales[0].description" class="form-control description"></textarea>
             </div>
 
-            ## QUALITY
-            <div class="half" ng-class="{'has-success': article.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{article.quality = article.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="article.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="article.quality"></span>
-            </div>
-
-            % if updating_doc:
-            <div id="message-group" class="full">
-              <label translate>Comment about the changes</label>
-              <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.message"></span>
-            </div>
-            % endif
-
           </div>
         </section>
 
@@ -148,6 +131,6 @@ from c2corg_common.attributes import default_langs, quality_types, activities, a
 
     </section>
   </form>
+  ${show_preview_container()}
+  ${show_save_confirmation_modal(updating_doc)}
 </section>
-
-${show_preview_container()}

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -1,3 +1,7 @@
+<%!
+    from c2corg_common.attributes import quality_types
+%>
+
 <%def name="show_editing_associated_waypoints(model, type='waypoints')">\
   <section ng-show="${model}.associations.${type}.length > 0" class="associated-section">
     <label translate>Associated waypoints</label>
@@ -7,8 +11,8 @@
            ng-class="{'main-waypoint': ${model}.main_waypoint_id === wp.document_id, 'new-item': wp['new']}">
         <app-card app-card-doc="wp" app-card-disable-click="true"></app-card>
         % if model == 'route':
-          <div ng-if="${model}.main_waypoint_id === wp.document_id" ng-init="${model}.main_waypoint_title = wp.locales[0].title" translate>main waypoint</div>
-          <button class="btn btn-sm btn-default" translate
+          <div class="set-main-waypoint" ng-if="${model}.main_waypoint_id === wp.document_id" ng-init="${model}.main_waypoint_title = wp.locales[0].title" translate>main waypoint</div>
+          <button class="btn btn-sm btn-default set-main-waypoint" translate
                   ng-click="${model}.main_waypoint_id = wp.document_id; ${model}.main_waypoint_title = wp.locales[0].title"
                   ng-if="${model}.main_waypoint_id != wp.document_id">
             Set as main waypoint
@@ -31,6 +35,31 @@
         <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(rte.document_id, 'routes', $event)"></span>
       </div>
     </article>
+  </section>
+</%def>
+
+<%def name="show_save_confirmation_modal(updating_doc)">\
+  <section id="save-confirmation-modal">
+    <h3 class="heading show-phone" translate>summary</h3>
+    ## COMMENT
+    <div class="content">
+      % if updating_doc:
+      <div id="message-group" class="full">
+        <label translate>Comment about the changes</label>
+        <input type="text" name="message" ng-model="saveCtrl.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
+      </div>
+      % endif
+      ## QUALITY
+      <div class="full comment" ng-class="{'has-success': saveCtrl.quality}" ng-init="qualityTypes = ${quality_types}">
+        <label translate>document_quality</label>
+        <select ng-options="type for type in qualityTypes" ng-model="saveCtrl.quality" class="form-control"><option value=""></option></select>
+      </div>
+
+      <div class="text-center">
+        <button ng-click="saveCtrl.close({'message': saveCtrl.message, 'quality': saveCtrl.quality})" class="btn btn-success" translate>Save</button>
+        <button ng-click="saveCtrl.close()" class="btn btn-danger" translate>Cancel</button>
+      </div>
+    </div>
   </section>
 </%def>
 

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -1,5 +1,5 @@
 <%!
-from c2corg_common.attributes import default_langs, activities, quality_types, image_types, image_categories
+from c2corg_common.attributes import default_langs, activities, image_types, image_categories
 %>
 <%inherit file="../base.html"/>
 <%
@@ -8,7 +8,7 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
 <%namespace file="../helpers/common.html" import="show_title"/>
 
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
-    show_editing_associated_routes, show_preview_container,
+    show_editing_associated_routes, show_preview_container, show_save_confirmation_modal,
     show_editing_buttons"/>
 
 <%block name="pagetitle">
@@ -30,7 +30,7 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
   % if updating_doc:
     app-document-editing-id="${image_id}" app-document-editing-lang="${image_lang}"
   % endif
-    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
 
     ## PROGRESS BAR
     <app-progress-bar ng-init="progressBarCtrl.maxSteps = 2">
@@ -265,16 +265,6 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
               <label translate>author</label>
               <input type="text" class="form-control" ng-model="image.author">
             </div>
-
-            ## QUALITY
-            <div class="half" ng-class="{'has-success': image.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{image.quality = image.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="image.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.quality"></span>
-            </div>
-          </div>
         </section>
 
         <section class="section associations">
@@ -291,6 +281,6 @@ from c2corg_common.attributes import default_langs, activities, quality_types, i
 
     </section>
   </form>
+  ${show_preview_container()}
+  ${show_save_confirmation_modal(updating_doc)}
 </section>
-
-${show_preview_container()}

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import default_langs, activities, condition_ratings, \
-    quality_types, hut_status, lift_status, frequentation_types, avalanche_signs, \
+    hut_status, lift_status, frequentation_types, avalanche_signs, \
     route_duration_types, access_conditions, glacier_ratings
 %>
 
@@ -12,7 +12,7 @@ updating_doc = outing_id and outing_lang
 
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
-    show_editing_associated_routes,show_preview_container,
+    show_editing_associated_routes,show_preview_container, show_save_confirmation_modal,
     show_editing_buttons"/>
 
 <%block name="pagetitle"><title ng-init="id=${outing_id if outing_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an outing') : mainCtrl.page_title('Creating an outing')">${show_title('Create/edit outing')}</title></%block>
@@ -29,18 +29,17 @@ updating_doc = outing_id and outing_lang
   % if updating_doc:
     app-document-editing-id="${outing_id}" app-document-editing-lang="${outing_lang}"
   % endif
-    name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)" class="document-editing">
+    name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)" class="document-editing">
 
     <app-progress-bar>
       ## It won't work with ng-init
-      <span class="ng-hide">{{progressBarCtrl.maxSteps = 4}}</span>
+      <span class="ng-hide">{{progressBarCtrl.maxSteps = 3}}</span>
 
       ## PROGRESS BAR
       <ul class="progress-bar-edit">
         <li class="nav-step-1" ng-click="progressBarCtrl.step(1, 'outing',  'backwards')" ng-class="{'nav-step-selected': progressBarCtrl.currentStep == 1 }"><span class="nav-text"><span translate>track</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-2" ng-click="progressBarCtrl.step(2, 'outing', progressBarCtrl.previousStep >= 2 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>weather</span> & <span translate>conditions</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-3" ng-click="progressBarCtrl.step(3, 'outing', progressBarCtrl.previousStep >= 3 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>personal informations</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
-        <li class="nav-step-4" ng-click="progressBarCtrl.step(4, 'outing',  'forwards')"><span translate class="nav-text">review</span><span class="bullet-container"><span class="bullet"></span></span></li>
       </ul>
 
       ## NAV BUTTONS
@@ -526,38 +525,11 @@ updating_doc = outing_id and outing_lang
 
           </div>
         </section>
-
       </div>
-
-      <div class="step step-4">
-        <section class="section summary">
-          <h2 class="heading show-phone"><span translate>summary</span></h2>
-
-          <div class="content collapse in">
-            % if updating_doc:
-            <div id="message-group" class="form-group">
-              <label translate>Comment about the changes</label>
-              <input type="text" name="message" ng-model="outing.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.message"></span>
-            </div>
-            % endif
-
-            ## QUALITY
-            <div class="form-group half" ng-class="{'has-success': outing.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{outing.quality = outing.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="outing.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.quality"></span>
-            </div>
-          </div>
-        </section>
-      </div>
-
       ${show_editing_buttons('outing', updating_doc, outing_id, outing_lang)}
 
     </section>
   </form>
+  ${show_preview_container()}
+  ${show_save_confirmation_modal(updating_doc)}
 </section>
-
-${show_preview_container()}

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -4,7 +4,7 @@ from c2corg_common.attributes import via_ferrata_ratings, default_langs, activit
     ski_ratings, labande_ski_ratings, global_ratings, engagement_ratings, risk_ratings, ice_ratings, \
     mixed_ratings, aid_ratings, exposition_ratings, equipment_ratings, rock_types, hiking_ratings, \
     exposition_rock_ratings, climbing_outdoor_types, snowshoe_ratings,mtb_up_ratings, mtb_down_ratings, \
-    climbing_ratings, quality_types
+    climbing_ratings
 %>
 <%inherit file="../base.html"/>
 <%
@@ -12,7 +12,7 @@ updating_doc = route_id and route_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
-    show_editing_associated_routes, show_preview_container, show_editing_buttons"/>
+    show_editing_associated_routes, show_preview_container, show_editing_buttons, show_save_confirmation_modal"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
 
 <%block name="pagetitle"><title ng-init="id=${route_id if route_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a route') : mainCtrl.page_title('Creating a route')">${show_title('Create/edit route')}</title></%block>
@@ -28,18 +28,17 @@ updating_doc = route_id and route_lang
   % if updating_doc:
     app-document-editing-id="${route_id}" app-document-editing-lang="${route_lang}"
   % endif
-     name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)" class="document-editing">
+     name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)" class="document-editing">
 
     <app-progress-bar>
       ## It won't work with ng-init
-      <span class="ng-hide">{{progressBarCtrl.maxSteps = 4}} </span>
+      <span class="ng-hide">{{progressBarCtrl.maxSteps = 3}} </span>
 
       ## PROGRESS BAR
       <ul class="progress-bar-edit">
         <li class="nav-step-1" ng-click="progressBarCtrl.step(1, 'route',  'backwards')" ng-class="{'nav-step-selected': progressBarCtrl.currentStep == 1 }"><span class="nav-text"><span translate>route</span> & <span translate>associations</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-2" ng-click="progressBarCtrl.step(2, 'route', progressBarCtrl.previousStep >= 2 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>figures</span></span><span class="bullet-container"><span class="bullet"></span></span></li>
         <li class="nav-step-3" ng-click="progressBarCtrl.step(3, 'route', progressBarCtrl.previousStep >= 3 ? 'backwards' : 'forwards')"><span class="nav-text"><span translate>Comments</span></span></span><span class="bullet-container"><span class="bullet"></span></span></li>
-        <li class="nav-step-4" ng-click="progressBarCtrl.step(4, 'route',  'forwards')"><span translate class="nav-text">review</span><span class="bullet-container"><span class="bullet"></span></span></li>
       </ul>
 
       ## NAV BUTTONS
@@ -647,35 +646,12 @@ updating_doc = route_id and route_lang
         </section>
       </div>
 
-      <div class="step step-4">
-        <section class="section summary">
-          <h2 class="heading show-phone" translate>summary</h2>
-
-          <div class="content">
-            % if updating_doc:
-            <div id="message-group" class="full">
-              <label translate>Comment about the changes</label>
-              <input type="text" name="message" ng-model="route.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.message"></span>
-            </div>
-            % endif
-
-            ## QUALITY
-            <div class="half" ng-class="{'has-success': route.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{route.quality = route.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="route.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.quality"></span>
-            </div>
-          </div>
-        </section>
-      </div>
-
       ${show_editing_buttons('route', updating_doc, route_id, route_lang)}
 
     </section>
   </form>
+
+  ${show_preview_container()}
+  ${show_save_confirmation_modal(updating_doc)}
 </section>
 
-${show_preview_container()}

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -3,7 +3,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
     custodianship_types, climbing_indoor_types, product_types, ground_types, weather_station_types, \
     rain_proof_types, public_transportation_ratings, children_proof_types, snow_clearance_ratings, \
     exposition_ratings, rock_types, orientation_types, months, parking_fee_types, climbing_styles, \
-    access_times, climbing_ratings, equipment_ratings, map_editors, quality_types
+    access_times, climbing_ratings, equipment_ratings, map_editors
 %>
 <%inherit file="../base.html"/>
 <%
@@ -12,7 +12,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
     show_editing_associated_routes, show_preview_container,
-    show_editing_buttons"/>
+    show_editing_buttons, show_save_confirmation_modal"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
 
 <%block name="pagetitle">
@@ -34,7 +34,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
   % if updating_doc:
     app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
   % endif
-    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
 
     <div class="ng-hide">{{type = waypoint.waypoint_type}}</div>
 
@@ -54,9 +54,6 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
         </li>
         <li class="nav-step-{{progressBarCtrl.maxSteps -1}}" ng-click="progressBarCtrl.step((progressBarCtrl.maxSteps == 4 ? 3 : 2), 'waypoint',  progressBarCtrl.previousStep >= ((progressBarCtrl.maxSteps == 4) ? 3 : 2) ? 'backwards' : 'forwards')" >
           <span class="nav-text"><span ng-if="type != 'climbing_indoor' "><span translate>associations</span> & </span><span translate>description</span></span></span><span class="bullet-container"><span class="bullet"></span></span>
-        </li>
-        <li class="nav-step-{{progressBarCtrl.maxSteps}}" ng-click="progressBarCtrl.step(progressBarCtrl.maxSteps, 'forwards')"><span translate class="nav-text">review</span>
-          <span class="bullet-container"><span class="bullet"></span></span>
         </li>
       </ul>
 
@@ -753,37 +750,12 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
           </div>
         </section>
-
-      </div>
-
-      ##SUMMARY
-      <div class="step step-{{progressBarCtrl.maxSteps}}">
-        <section class="section summary">
-          <h2 class="heading show-phone" translate>summary</h2>
-          <div class="content">
-            % if updating_doc:
-            <div id="message-group" class="full">
-              <label translate>Comment about the changes</label>
-              <input type="text" name="message" ng-model="waypoint.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
-            </div>
-            % endif
-
-            ## QUALITY
-            <div class="half" ng-class="{'has-success': waypoint.quality}" ng-init="qualityTypes = ${quality_types}">
-              ## I tried with ng-init, ng-selected..so hacking
-              <div class="ng-hide">{{waypoint.quality = waypoint.quality || qualityTypes[1]}}</div>
-              <label translate>quality</label>
-              <select ng-options="type as mainCtrl.translate(type) for type in qualityTypes" ng-model="waypoint.quality" class="form-control"><option value=""></option></select>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.quality"></span>
-            </div>
-          </div>
-        </section>
       </div>
 
       ${show_editing_buttons('waypoint', updating_doc, waypoint_id, waypoint_lang)}
 
     </section>
   </form>
+  ${show_preview_container()}
+  ${show_save_confirmation_modal(updating_doc)}
 </section>
-
-${show_preview_container()}

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -465,6 +465,7 @@ app-pagination.areas, app-pagination.articles {
       font-size: 3em;
     }
   }
+  /*list-item.*/
   &.main-waypoint {
     border: 2px solid @bright-green;
   }
@@ -498,6 +499,9 @@ app-pagination.areas, app-pagination.articles {
     .glyphicon-trash {
       top: 65% !important;
     }
+  }
+  .set-main-waypoint {
+    margin: -10px 0 10px 10px;
   }
   a {
     display: block;
@@ -729,7 +733,6 @@ app-simple-search {
   padding-left: 10px;
   margin-right: 10px;
   background: @C2C-orange;
-  width: 25%;
 
   .glyphicon {
     color: #F9F9F9;

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -1,6 +1,5 @@
 @import: 'variables.less';
 
-
 .create-edit-document {
   margin-top: @page-header-height;
 
@@ -21,12 +20,13 @@
       margin-left: 2px;
     }
   }
+  #save-confirmation-modal {
+    display: none;
+  }
   .nav-buttons {
-
     @media @phone {
       display: none;
     }
-
     .prev, .next {
       position: fixed;
       top: 50vh;
@@ -474,7 +474,7 @@
       color: @brand-success;
     }
   }
-  label, .months, .types, #route-activities, h2, #message-group  {
+  label, .months, .types, #route-activities, h2 {
     width: 100%;
   }
 }
@@ -635,5 +635,19 @@ ul.uib-datepicker {
     float: right;
     margin-top: 10px;
     margin-left: 5px;
+  }
+}
+
+
+#save-confirmation-modal {
+   .comment {
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+  .heading {
+    margin-top: 0
+  }
+  .content {
+    padding: 20px;
   }
 }


### PR DESCRIPTION
related to #800 

modal with 'quality' and 'change comment' that appears before definitely saving the document. 
Thanks to that users won't miss those fields and change the quality and comment accordingly.

In addition, we get rid of the last 'review' step.

![screenshot from 2016-11-04 16-43-21](https://cloud.githubusercontent.com/assets/7814311/20012200/975f2960-a2ae-11e6-9113-b07e1d6e8cd5.png)
