### PR TITLE
[WIP] Add guidebook homepage

### DIFF
--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -49,6 +49,7 @@ def main(global_config, **settings):
 
     # page views
     config.add_route('index', '/')
+    config.add_route('guidebook', '/guidebook')
 
     config.add_route('waypoints_index', '/waypoints')
     config.add_route('waypoints_sitemap_default', '/waypoints/sitemap')

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -78,7 +78,12 @@ app.MainController.prototype.isPath = function(path) {
     return 'home';
   // if topoguide, it can be all kinds of documents
   } else if (path === 'topoguide') {
-    return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1 || location.indexOf('outings') > -1 || location.indexOf('areas') > -1;
+    return location.indexOf('guidebook') > -1 ||
+           location.indexOf('waypoints') > -1 ||
+           location.indexOf('routes') > -1 ||
+           location.indexOf('outings') > -1 ||
+           location.indexOf('images') > -1 ||
+           location.indexOf('areas') > -1;
   } else {
     return location.indexOf(path) > -1;
   }

--- a/c2corg_ui/templates/guidebook.html
+++ b/c2corg_ui/templates/guidebook.html
@@ -1,0 +1,25 @@
+<%!
+from c2corg_common.attributes import activities
+%>
+<%inherit file="base.html"/>
+<%namespace file="helpers/common.html" import="show_title"/>
+<%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Topoguide')">${show_title('Topoguide')}</title></%block>
+
+<div class="guidebook-home">
+
+  <section>
+    <h1 translate class="text-center">Topoguide</h1>
+    <p translate class="text-center">Some intro to the guidebook</p>
+  </section>
+
+  <section>
+    % for module in ['routes', 'waypoints', 'outings', 'images', 'areas']:
+      <div class="list-item">
+        <a href="${request.route_path(module + '_index')}">
+          <span class="icon-${'misc' if module == 'waypoints' else module}"></span>
+          <span class="list-item-title" translate>${module.capitalize()}</span>
+        </a>
+      </div>
+    % endfor
+  </section>
+</div>

--- a/c2corg_ui/templates/sidemenu.html
+++ b/c2corg_ui/templates/sidemenu.html
@@ -16,7 +16,7 @@
       </a>
     </li>
     <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('topoguide')}">
-      <a href="${request.route_path('routes_index')}">
+      <a href="${request.route_path('guidebook')}">
         <i class="glyphicon glyphicon-arrow-right" tooltip-placement="right" uib-tooltip="{{'Topoguide' | translate}}"></i>
         <span class="menu-text" translate>Topoguide</span>
       </a>

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -24,6 +24,11 @@ class Pages(object):
     def index(self):
         return self._get_page('index', 'c2corg_ui:templates/index.html')
 
+    @view_config(route_name='guidebook')
+    def guidebook(self):
+        return self._get_page(
+            'guidebook', 'c2corg_ui:templates/guidebook.html')
+
     @view_config(route_name='auth')
     def auth(self):
         return self._get_page('auth', 'c2corg_ui:templates/auth.html')

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -940,7 +940,7 @@ app-alerts {
   }
 }
 
-.auth-form, .preferences {
+.auth-form, .preferences, .guidebook-home {
   padding: 0 10% 0 10%;
   margin-top: 100px;
   margin-bottom: 20px;


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/254

At least a basic version. Some work is still needed for fixing the styles and have a nice layout but I don't feel skilled enough.

Some other cards (shortcuts? activities?) would probably be relevant too.

Question: I have used "guidebook" as page path + in the filenames etc. Should it rather be "topoguide", in order to be consistent with the menu and the page title? (In the API I think we use "guidebook").

<img width="400" alt="capture d ecran 2016-11-05 a 19 08 48" src="https://cloud.githubusercontent.com/assets/1192331/20032505/a24cfb9e-a38b-11e6-8d3f-a1b485ca0c58.png">
