### PR TITLE
open embedded images in a slideshow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ c2corg_ui/static/build/locale_moment: .build/node_modules.timestamp
 # copy skins of photoswipe.js
 photoswipe-skins: .build/node_modules.timestamp
 	cp node_modules/photoswipe/dist/default-skin/default-skin.png c2corg_ui/static/build/default-skin.png
+	cp node_modules/photoswipe/dist/default-skin/default-skin.svg c2corg_ui/static/build/default-skin.svg
 
 # copy files used by "slick-carousel" (?!)
 slick-assets: .build/node_modules.timestamp

--- a/c2corg_ui/format/img.py
+++ b/c2corg_ui/format/img.py
@@ -63,31 +63,23 @@ class C2CImage(Pattern):
         if img_size:
             img_url += '?size=' + img_size
         img.set('src', img_url)
+        img.set('class', 'thumbnail embedded-image ')
         img.set('alt', caption or img_id)
+        img.set('caption', caption)
+        img.set('img-id', img_id)
 
-        img_container = etree.Element('a')
-        img_container.set('href', '/images/%s' % img_id)
-        # TODO: open slideshow instead when the image is clicked
-        img_container.append(img)
+        fig = etree.Element('figure')
+        fig.set('ng-click', 'detailsCtrl.openEmbeddedImage("' + img_url + '", \
+           "' + img_id + '")')
+        fig.append(img)
+        fig.set('class', 'embedded_' + position + ' ' + img_size)
 
         if caption:
-            fig = etree.Element('figure')
-            fig.set('class', 'embedded_' + position)
-            fig.append(img_container)
-
-            img_link = etree.Element('a')
-            img_link.set('href', '/images/%s' % img_id)
-            img_link.text = caption
-
             img_caption = etree.Element('figcaption')
-            img_caption.append(img_link)
-
+            img_caption.text = caption
             fig.append(img_caption)
-            return fig
 
-        else:
-            img_container.set('class', 'embedded_' + position)
-            return img_container
+        return fig
 
 
 def makeExtension(*args, **kwargs):  # noqa

--- a/c2corg_ui/format/img.py
+++ b/c2corg_ui/format/img.py
@@ -65,7 +65,6 @@ class C2CImage(Pattern):
         img.set('src', img_url)
         img.set('class', 'thumbnail embedded-image ')
         img.set('alt', caption or img_id)
-        img.set('caption', caption)
         img.set('img-id', img_id)
 
         fig = etree.Element('figure')

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -299,24 +299,23 @@ app.ImageUploaderController.prototype.save = function() {
 
   this.api_.createImages(this.files, this.documentService.document)
   .then(function(data) {
-    var id;
     var images = data['config']['data']['images'];
     var imageIds = data['data']['images']; // newly created document_id
 
     $('.img-container').each(function(i) {
-      id = 'image-' + (+new Date());
-      images[i]['image_id'] = id;
-
+      var id = imageIds[i]['document_id'];
+      images[i]['image_id'] = 'image-' + id;
       var element = app.utils.createImageSlide(images[i], this.imageUrl_);
       $('.photos').slick('slickAdd', element, true);
 
       var scope = this.scope_.$new(true);
       scope['photo'] = images[i];
-      scope['photo']['image_id'] = id;
-      scope['photo']['edit_url'] = '/images/edit/' + imageIds[i]['document_id'] + '/' + images[i]['locales'][0]['lang'];
-      scope['photo']['view_url'] = this.url_.buildDocumentUrl('images', imageIds[i]['document_id'], images[i]['locales'][0], images[i]['locales'][0]['lang']);
+      scope['photo']['image_id'] = 'image-' + id;
+      scope['photo']['edit_url'] = '/images/edit/' + id + '/' + images[i]['locales'][0]['lang'];
+      scope['photo']['view_url'] = this.url_.buildDocumentUrl('images', id, images[i]['locales'][0]);
       this.documentService.document.associations['images'].push(scope['photo']);
-      this.compile_($('#' + id).contents())(scope);
+      this.compile_($('#image-' + id).contents())(scope); // compile the figure thumbnail with <app-slide-info>c
+
     }.bind(this));
 
     defer.resolve();

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -133,6 +133,35 @@ app.utils.createImageSlide = function(file, imageUrl) {
   return '<figure id="' + file['image_id'] + '">' + ahref + img +  '<app-slide-info></app-slide-info></figure>';
 };
 
+
+/**
+ * based on partials/slideinfo.html
+ * @param {string} imgUrl
+ * @param {jQuery | string} imgCaption
+ * @param {number} imgId
+ * @param {string} lang
+ * @export
+ */
+app.utils.createSimpleImageSlide = function(imgUrl, imgCaption, imgId, lang) {
+  return '<div class="photoswipe-image-container">' +
+               '<img src="' + imgUrl + '" >' +
+               '<h2 class="image-title ng-binding">' + imgCaption + '</h2>' +
+               '<div class="image-infos-buttons">' +
+                 '<button>' +
+                   '<a href="/images/' + imgId + '">' +
+                     '<span class="glyphicon glyphicon-eye-open"></span>' +
+                   '</a>' +
+                 '</button>' +
+                 '<button>' +
+                   '<a href="/images/edit/' + imgId + '/'  + lang + '">' +
+                     '<span class="glyphicon glyphicon-edit"></span>' +
+                   '</a>' +
+                 '</button>' +
+               '</div>' +
+             '</div>';
+};
+
+
 /**
  * @param {string} url
  * @param {string} suffix

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -137,27 +137,14 @@ app.utils.createImageSlide = function(file, imageUrl) {
 /**
  * based on partials/slideinfo.html
  * @param {string} imgUrl
- * @param {jQuery | string} imgCaption
  * @param {number} imgId
- * @param {string} lang
+ * @param {string} selector
  * @export
  */
-app.utils.createSimpleImageSlide = function(imgUrl, imgCaption, imgId, lang) {
+app.utils.createPhotoswipeSlideHTML = function(imgUrl, imgId, selector) {
+  var slide = $(selector + imgId + '-slide');
   return '<div class="photoswipe-image-container">' +
-               '<img src="' + imgUrl + '" >' +
-               '<h2 class="image-title ng-binding">' + imgCaption + '</h2>' +
-               '<div class="image-infos-buttons">' +
-                 '<button>' +
-                   '<a href="/images/' + imgId + '">' +
-                     '<span class="glyphicon glyphicon-eye-open"></span>' +
-                   '</a>' +
-                 '</button>' +
-                 '<button>' +
-                   '<a href="/images/edit/' + imgId + '/'  + lang + '">' +
-                     '<span class="glyphicon glyphicon-edit"></span>' +
-                   '</a>' +
-                 '</button>' +
-               '</div>' +
+               '<img src="' + imgUrl + '" >' + slide.html() +
              '</div>';
 };
 

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -20,15 +20,17 @@ app.viewDetailsDirective = function() {
         ctrl.initPhotoswipe_();
       }
       ctrl.loadImages_(initGalleries);
+      ctrl.watchPswpContainer_();
 
-      $('.pswp').on('click', '.image-infos-buttons', function (e) {
-        $('.photoswipe-image-container .image-infos, .photoswipe-image-container img').toggleClass('showing-info');
+      // clicking on 'info' btn will open slide from the right and get the infos
+      $('.pswp').on('click touchend', '.pswp__button.info', function(e) {
+        $('.image-infos, .photoswipe-image-container img').toggleClass('showing-info');
+        ctrl.getImageInfo_($(e.target).attr('img-id').split('-')[1]);
       });
 
       $('.pswp__button--arrow--left, .pswp__button--arrow--right').click(function() {
         $('.showing-info').removeClass('showing-info');
-        console.log('qwe')
-         // recompile the protected-url-btn on each slide change
+        ctrl.compile_($('.image-infos-buttons').contents())(ctrl.scope_); // recompile the protected-url-btn on each slide change
       });
     }
   };
@@ -165,22 +167,17 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
       var linkEl;
       var item;
       var id;
-      var info;
 
       for (var i = 0; i < thumbElements.length; i++) {
         figureEl = thumbElements[i]; // <figure> element
         linkEl = figureEl.children[0]; // <a> element
         // get the data-info-id and clone into the slide that's being opened
         id = linkEl.getAttribute('data-info-id');
-        info = $(document.getElementById(id));
         var image = new Image();
         image['src'] = linkEl.getAttribute('href');
-        var imgHtml = '<img src="' + linkEl.getAttribute('href') + '">';
 
         item = { // create slide object
-          html: '<div class="photoswipe-image-container">' +
-                      info.html() + imgHtml +
-                    '</div>'
+          html: app.utils.createPhotoswipeSlideHTML(image['src'], id.split('-')[1], '#image-')
          // TODO: for zoom in animation -> add this when WIDTH & HEIGHT will be returned by API in image properties
          // w: image.naturalWidth,
          // h: image.naturalHeight
@@ -241,7 +238,7 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
       gallery = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default, items, options);
       gallery.init();
       this.compile_($('.image-infos-buttons').contents())(this.scope_);  // recompile the protected-url-btn on gallery open
-      $('.pswp__button.info').show();
+      $('.showing-info').removeClass('showing-info');
 
     }.bind(this);
 
@@ -346,11 +343,11 @@ app.ViewDetailsController.prototype.createTopic = function() {
 
 
 /**
- * Loads images and appends them to .photos gallery
  * @param {Function} initGalleries callback
  * @private
  */
 app.ViewDetailsController.prototype.loadImages_ = function(initGalleries) {
+  // prepare document images for slideshow
   var photos = this.documentService.document['associations']['images'];
   for (var i in photos) {
     var scope = this.scope_.$new(true);
@@ -361,10 +358,26 @@ app.ViewDetailsController.prototype.loadImages_ = function(initGalleries) {
     scope['photo'] = photos[i];
 
     var element = app.utils.createImageSlide(photos[i], this.imageUrl_);
-    $('.photos').prepend(element);
-
+    $('.photos').append(element);
     this.compile_($('#' + id).contents())(scope);
   }
+
+  // prepare the embedded images for slideshow
+  $('[class^="embedded_"').each(function(i, el) {
+    $(el).append('<app-slide-info></app-slide-info>');
+    var img = $(el).find('img')[0];
+    var id = img.getAttribute('img-id');
+    var caption = $(el).find('figcaption')[0] ? $(el).find('figcaption')[0].textContent : '';
+
+    var scope = this.scope_.$new(true);
+    scope['edit_url'] = '/images/edit/' + id + '/' + this.lang.getLang();
+    scope['view_url'] = '/images/' + id + '/' + this.lang.getLang();
+    scope['image_id'] = 'embedded-' + id;
+    scope['locales'] = [{'title': caption}];
+
+    this.compile_($(el).contents())(scope);
+  }.bind(this));
+
   initGalleries();
 };
 
@@ -375,9 +388,10 @@ app.ViewDetailsController.prototype.loadImages_ = function(initGalleries) {
  * @export
  */
 app.ViewDetailsController.prototype.openEmbeddedImage = function(imgUrl, imgId) {
+  $('.showing-info').removeClass('showing-info');
+
   // Replace 'MI' and get the BigImage
   imgUrl = imgUrl.slice(0, -2) + 'BI';
-  var lang = this.lang.getLang();
   var embeddedImages = $('.embedded-image');
   var pswpElement = document.querySelectorAll('.pswp')[0];
   var items = [];
@@ -385,22 +399,46 @@ app.ViewDetailsController.prototype.openEmbeddedImage = function(imgUrl, imgId) 
 
   for (var i = 0; i <  embeddedImages.length;  i++) {
     var src = embeddedImages[i].src.slice(0, -2) + 'BI';
-    var caption = $(embeddedImages[i]).next().text();
     var id = parseInt($(embeddedImages[i]).attr('img-id'), 10);
 
     // add all the other images that are not the one you clicked on
     if (src !== imgUrl) {
-      var item = {html: app.utils.createSimpleImageSlide(src, caption, id, lang)};
+      var item = {html: app.utils.createPhotoswipeSlideHTML(src, id, '#embedded-')};
       items.push(item);
     } else {
-      var clickedImg = {html: app.utils.createSimpleImageSlide(imgUrl, caption, imgId, lang)};
+      var clickedImg = {html: app.utils.createPhotoswipeSlideHTML(imgUrl, imgId, '#embedded-')};
       items.push(clickedImg);
       index = i;
     }
   }
-                                                                                                                                                              // start slide at index
+
   var gallery = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default, items, {index: index});
   gallery.init();
+  this.compile_($('.image-infos-buttons').contents())(this.scope_);
+};
+
+
+/**
+ * get the clicked image detailed infos
+ * and compile them into the slide
+ * @param {number} id
+ * @private
+ */
+app.ViewDetailsController.prototype.getImageInfo_ = function(id) {
+  if ($('.showing-info').length > 0) {
+    $('.loading-infos').show();
+    $('.images-infos-container').hide();
+
+    this.api_.readDocument('images', id, this.lang.getLang()).then(function(res) {
+      var imgData = res.data;
+      var scope = this.scope_.$new(true);
+      angular.extend(scope, imgData);
+      this.compile_($('.image-infos'))(scope);
+      $('.loading-infos').hide();
+      $('.images-infos-container').show();
+
+    }.bind(this));
+  }
 };
 
 
@@ -414,5 +452,18 @@ app.ViewDetailsController.prototype.toggleOrientation = function(orientation, do
   // Do nothing
 };
 
+
+/**
+ * remove .showing-info if the container detects swipe/drag
+ * @private
+ */
+app.ViewDetailsController.prototype.watchPswpContainer_ = function() {
+  var observer = new MutationObserver(function() {
+    $('.showing-info').removeClass('showing-info');
+    this.compile_($('.image-infos-buttons').contents())(this.scope_);
+  }.bind(this));
+  var target = $('.pswp__container')[0];
+  observer.observe(target, {attributes: true, attributeFilter: ['style']});
+};
 
 app.module.controller('AppViewDetailsController', app.ViewDetailsController);

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -21,13 +21,14 @@ app.viewDetailsDirective = function() {
       }
       ctrl.loadImages_(initGalleries);
 
-      $('.pswp__button.info').on('touchend click', function() {
+      $('.pswp').on('click', '.image-infos-buttons', function (e) {
         $('.photoswipe-image-container .image-infos, .photoswipe-image-container img').toggleClass('showing-info');
       });
 
       $('.pswp__button--arrow--left, .pswp__button--arrow--right').click(function() {
         $('.showing-info').removeClass('showing-info');
-        ctrl.compile_($('.image-infos-buttons').contents())(ctrl.scope_); // recompile the protected-url-btn on each slide change
+        console.log('qwe')
+         // recompile the protected-url-btn on each slide change
       });
     }
   };
@@ -240,6 +241,7 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
       gallery = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default, items, options);
       gallery.init();
       this.compile_($('.image-infos-buttons').contents())(this.scope_);  // recompile the protected-url-btn on gallery open
+      $('.pswp__button.info').show();
 
     }.bind(this);
 
@@ -364,6 +366,41 @@ app.ViewDetailsController.prototype.loadImages_ = function(initGalleries) {
     this.compile_($('#' + id).contents())(scope);
   }
   initGalleries();
+};
+
+
+/**
+ * @param {string} imgUrl
+ * @param {number} imgId
+ * @export
+ */
+app.ViewDetailsController.prototype.openEmbeddedImage = function(imgUrl, imgId) {
+  // Replace 'MI' and get the BigImage
+  imgUrl = imgUrl.slice(0, -2) + 'BI';
+  var lang = this.lang.getLang();
+  var embeddedImages = $('.embedded-image');
+  var pswpElement = document.querySelectorAll('.pswp')[0];
+  var items = [];
+  var index;
+
+  for (var i = 0; i <  embeddedImages.length;  i++) {
+    var src = embeddedImages[i].src.slice(0, -2) + 'BI';
+    var caption = $(embeddedImages[i]).next().text();
+    var id = parseInt($(embeddedImages[i]).attr('img-id'), 10);
+
+    // add all the other images that are not the one you clicked on
+    if (src !== imgUrl) {
+      var item = {html: app.utils.createSimpleImageSlide(src, caption, id, lang)};
+      items.push(item);
+    } else {
+      var clickedImg = {html: app.utils.createSimpleImageSlide(imgUrl, caption, imgId, lang)};
+      items.push(clickedImg);
+      index = i;
+    }
+  }
+                                                                                                                                                              // start slide at index
+  var gallery = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default, items, {index: index});
+  gallery.init();
 };
 
 

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -27,7 +27,6 @@
           </p>
           <p ng-if="file.metadata.geo"><span class="glyphicon glyphicon-map-marker"></span><b>{{file.metadata.geo.label}}</b></p>
         </div>
-        <span class="glyphicon glyphicon-remove-circle remove-image-btn" type="button" ng-click="uplCtrl.deleteImage($index)" ng-show="file['processed']"></span>
       </div>
 
       <div class="img-data">
@@ -78,6 +77,13 @@
                 </div>
               </li>
             </ul>
+          </div>
+          <!-- REMOVE IMAGE-->
+          <div class="btn-group">
+            <button class="btn btn-default dropdown-toggle remove-image-btn" ng-click="uplCtrl.deleteImage($index)"
+                    type="button" class="btn btn-danger">
+              <span class="glyphicon glyphicon-trash"></span>
+            </button>
           </div>
 
         </div>

--- a/c2corg_ui/static/partials/slideinfo.html
+++ b/c2corg_ui/static/partials/slideinfo.html
@@ -1,11 +1,12 @@
-<div id="{{image_id}}-slide" class="ng-hide">
+<!--if you modify this template, please update utils.js createSimpleImageSlide()-->
+<div id="{{image_id}}-slide">
   <h2 class="image-title">{{locales[0].title}}</h2>
 
   <div class="image-infos">
-    <h2 translate>Infos</h2>
+    <h3 translate>Infos</h3>
 
     <p ng-show="date_time" class="date"><span class="glyphicon glyphicon-calendar"></span>{{date_time | amDateFormat:'Do MMMM YYYY'}}</p>
-    <p class="title"><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p>
+    <p ng-show="locales[0].title" class="title"><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p>
     <p ng-show="locales[0].description" class="description">{{locales[0].description}}</p>
     <p ng-show="image_type" class="image-type"><span class="glyphicon glyphicon-copyright-mark"></span><label x-translate>{{image_type}}</label></p>
 
@@ -34,18 +35,18 @@
         <li ng-show="width && height" uib-tooltip="{{'resolution' | translate}}">{{height}} x {{width}} <span translate>pixels</span></li>
       </ul>
     </div>
-
-    <div class="image-infos-buttons">
-      <button class="btn btn-default" uib-tooltip="{{'View details' | translate}}">
-        <a href="#" ng-href="{{view_url}}">
-          <span class="glyphicon glyphicon-eye-open"></span>
-        </a>
-      </button>
-      <button class="btn btn-default" protected-url-btn url="{{edit_url}}" uib-tooltip="{{'Edit' | translate}}">
-        <span class="glyphicon glyphicon-edit"></span>
-      </button>
-    </div>
-
   </div>
 
+  <div class="image-infos-buttons">
+    <button>
+      <a href="#" ng-href="{{view_url}}">
+        <span class="glyphicon glyphicon-eye-open"></span>
+      </a>
+    </button>
+    <button protected-url-btn url="{{edit_url}}">
+      <span class="glyphicon glyphicon-edit"></span>
+    </button>
+    <button class="pswp__button info glyphicon glyphicon-info-sign" img-id="{{image_id}}"></button>
+  </div>
 </div>
+

--- a/c2corg_ui/static/partials/slideinfo.html
+++ b/c2corg_ui/static/partials/slideinfo.html
@@ -1,48 +1,38 @@
 <!--if you modify this template, please update utils.js createSimpleImageSlide()-->
 <div id="{{image_id}}-slide">
-  <h2 class="image-title">{{locales[0].title}}</h2>
+  <h2 class="image-title" ng-bind="locales[0].title"></h2>
 
   <div class="image-infos">
     <h3 translate>Infos</h3>
+    <p class="loading-infos loading-gif-typehead"></p>
+    <div class="images-infos-container">
 
-    <p ng-show="date_time" class="date"><span class="glyphicon glyphicon-calendar"></span>{{date_time | amDateFormat:'Do MMMM YYYY'}}</p>
-    <p ng-show="locales[0].title" class="title"><span class="glyphicon glyphicon-tag"></span>{{locales[0].title}}</p>
-    <p ng-show="locales[0].description" class="description">{{locales[0].description}}</p>
-    <p ng-show="image_type" class="image-type"><span class="glyphicon glyphicon-copyright-mark"></span><label x-translate>{{image_type}}</label></p>
+      <p ng-show="date_time" class="date"><span class="glyphicon glyphicon-calendar"></span><span ng-bind="date_time | amDateFormat:'Do MMMM YYYY'"></span></p>
+      <p ng-show="locales[0].title" class="title"><span class="glyphicon glyphicon-tag"></span><span ng-bind="locales[0].title"></span></p>
+      <p ng-show="locales[0].description" class="description" ng-bind="locales[0].description"></p>
+      <p ng-show="image_type" class="image-type"><span class="glyphicon glyphicon-copyright-mark"></span><label x-translate ng-bind="image_type"></label></p>
 
-    <div ng-show="activities.length > 0" class="activities">
-      <label translate>activities</label>
-      <ul>
-        <li ng-repeat="activity in activities">{{activity | translate}}</li>
-      </ul>
-    </div>
-
-    <div ng-show="categories.length > 0" class="categories">
-      <label translate>categories</label>
-      <ul>
-        <li ng-repeat="category in categories">{{category | translate}}</li>
-      </ul>
-    </div>
-
-    <div ng-show="iso_speed || focal_length || exposure_time || camera_name" class="settings">
-      <label translate>Settings</label>
-      <ul>
-        <li ng-show="camera_name"><span>{{camera_name}}</span></li>
-        <li ng-show="exposure_time" uib-tooltip="{{'exposure_time' | translate}}"><span>1/{{exposure_time}}&nbsp;s</span></li>
-        <li ng-show="fnumber" uib-tooltip="{{'fnumber' | translate}}"><span>f/{{fnumber}}</span></li>
-        <li ng-show="focal_length" uib-tooltip="{{'focal_length' | translate}}"><span>{{focal_length}}&nbsp;mm</span></li>
-        <li ng-show="iso_speed" uib-tooltip="{{'iso_speed' | translate}}"><span>{{iso_speed}}&nbsp;ISO</span></li>
-        <li ng-show="width && height" uib-tooltip="{{'resolution' | translate}}">{{height}} x {{width}} <span translate>pixels</span></li>
-      </ul>
+      <div ng-show="iso_speed || focal_length || exposure_time || camera_name" class="settings">
+        <label translate>Settings</label>
+        <ul>
+          <li ng-show="camera_name"><span ng-bind="camera_name"></span></li>
+          <li ng-show="exposure_time" uib-tooltip="{{'exposure_time'| translate}}"><span ng-bind="exposure_time + 's'"></span></li>
+          <li ng-show="fnumber" uib-tooltip="{{'fnumber'| translate}}"><span ng-bind=" 'f/' + fnumber"></span></li>
+          <li ng-show="focal_length" uib-tooltip="{{'focal_length'| translate}}"><span ng-bind="focal_length + ' mm'"></span></li>
+          <li ng-show="iso_speed" uib-tooltip="{{'iso_speed'| translate}}"><span ng-bind="iso_speed + ' ISO'"></span></li>
+          <li ng-show="width && height" uib-tooltip="{{'resolution'| translate}}"><span ng-bind="height"></span> x <span ng-bind="width"></span> <span translate>pixels</span></li>
+        </ul>
+      </div>
     </div>
   </div>
 
   <div class="image-infos-buttons">
-    <button>
-      <a href="#" ng-href="{{view_url}}">
+
+    <a href="#" ng-href="{{view_url}}" class="view-details-btn">
+      <button>
         <span class="glyphicon glyphicon-eye-open"></span>
-      </a>
-    </button>
+      </button>
+    </a>
     <button protected-url-btn url="{{edit_url}}">
       <span class="glyphicon glyphicon-edit"></span>
     </button>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -683,7 +683,6 @@
 
           <button class="pswp__button pswp__button--close" title="{{'Close (Esc)' | translate}}"></button>
           <button class="pswp__button pswp__button--fs" title="{{'Toggle fullscreen' | translate}}"></button>
-          <button class="pswp__button info"><span class="glyphicon glyphicon-info-sign"></span></button>
 
           ## Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR
           ## element will get class pswp__preloader--active when preloader is running

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -453,16 +453,17 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
 
 
   .waypoint-type {
-    font-size: 2em;
+    font-size: 1.5em;
     color: @C2C-orange;
-    margin-right: 3px;
+    margin-right: 5px;
+    margin-top: 5px;
   }
   .route-activity {
-    font-size: 3.5em;
+    font-size: 3em;
     color: @C2C-orange;
     margin-bottom: 10px;
     @media @phone {
-      font-size: 3em;
+      font-size: 2.5em;
     }
   }
   /*list-item.*/

--- a/less/images.less
+++ b/less/images.less
@@ -4,7 +4,7 @@
   height: 100%;
   width: 100%;
   text-align: center;
-  padding-top: 25px;
+  padding: 25px;
 }
 .dragover {
   border: 5px dashed red;
@@ -86,6 +86,12 @@
       color: #333;
       white-space: nowrap;
     }
+    .remove-image-btn {
+      font-size: 12px;
+      .glyphicon-trash {
+        margin: 6px -3px auto auto;
+      }
+    }
   }
   .img-container {
     width:100%;
@@ -95,6 +101,7 @@
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
+    position: relative;
 
     &:hover {
       background-color: black;
@@ -116,14 +123,6 @@
   }
   .glyphicon {
     margin-right: 10px;
-  }
-  .remove-image-btn {
-    opacity: 0;
-    float: right;
-    margin-right: 10px;
-    top: -50px;
-    cursor: pointer;
-    font-size: 1.5em;
   }
 }
 .exif {
@@ -164,12 +163,18 @@
   height: 100%;
   display: flex;
   align-items: center;
+
+  @media @phone {
+    .calc(height, "100% - 45px");
+    margin-top: 45px;
+  }
   &:hover {
     .image-title {
       opacity: 1;
       transition: 0.3s;
     }
   }
+
   img {
     max-width: 100%;
     max-height: 100%;
@@ -209,8 +214,8 @@
       transition: 0.3s;
       background-color: #1D1D1D;
       @media @phone {
-        width: 50%;
-        padding: 30px;
+        width: 60%;
+        padding: 40px 10px 0 30px;
       }
     }
     .activities, .categories, .image-type, .image-infos-buttons, .settings,
@@ -221,18 +226,6 @@
       margin-right: 5px;
       color: gray;
     }
-    .image-infos-buttons button {
-      margin: 10px 10px 0 0;
-      float: left;
-      padding: 9px 5px 5px 5px;
-      width: 40px;
-      border-radius: 50%;
-      height: 40px;
-      font-size: 1.3em;
-      .glyphicon-edit, .glyphicon-eye-open {
-        margin-right: 0;
-      }
-    }
     .glyphicon-ok {
       color: white !important;
     }
@@ -241,14 +234,66 @@
     }
   }
 }
+
 .pswp__button.info {
   background: none !important;
   font-size: 19px;
-  margin-top: 2px;
+  color: #c3c7d0;
+  margin-top: -1px;
+  margin-left: 3px;
+  @media @phone {
+    margin-top: -3px;
+  }
+}
+
+.pswp__caption, .pswp__counter {
+  display: none;
+}
+
+.pswp__top-bar {
+  background-color: transparent;
+  pointer-events: none;
+}
+
+.pswp__button {
+  pointer-events: all;
+}
+
+.pswp__button, .image-infos-buttons button {
   .glyphicon {
     color: #CAD0D9;
   }
 }
-.pswp__caption, .pswp__counter {
-  display: none;
+
+.view-details-btn {
+  top: 1px;
+  position: relative;
+}
+.image-infos-buttons {
+  position: absolute;
+  .calc(right, "35px * 3");
+  top: -2px;
+
+  @media @phone {
+    top: 0;
+  }
+
+  button {
+    opacity: .8;
+    background-color: transparent;
+    border-color: transparent;
+    padding: 9px 5px 5px 5px;
+    width: 44px;
+    height: 44px;
+    font-size: 1.25em;
+    transition: .3s;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+    .glyphicon-edit, .glyphicon-eye-open {
+      margin-right: 0 !important;
+    }
+  }
 }

--- a/less/images.less
+++ b/less/images.less
@@ -59,6 +59,11 @@
     .flex();
     .btn-group {
       flex-grow: 1;
+      @media @phone {
+        .dropdown-toggle {
+          font-size: .8em;
+        }
+      }
     }
     .dropdown-toggle {
       padding-right: 0;
@@ -89,7 +94,8 @@
     .remove-image-btn {
       font-size: 12px;
       .glyphicon-trash {
-        margin: 6px -3px auto auto;
+        position: relative;
+        margin: 5px -3px auto auto;
       }
     }
   }
@@ -217,6 +223,11 @@
         width: 60%;
         padding: 40px 10px 0 30px;
       }
+    }
+    .loading-infos {
+      height: 20px;
+      width: 20px;
+      margin: 20px auto;
     }
     .activities, .categories, .image-type, .image-infos-buttons, .settings,
     .title, .date, .description {

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -169,6 +169,9 @@
         margin-left: 5px;
         margin-right: 5px;
       }
+      app-slide-info {
+        display: none;
+      }
     }
     .slick-prev, .slick-next {
       width: 40px;
@@ -747,9 +750,56 @@ app-add-association {
   h2 {
     margin-top: 10px;
   }
+
+  [class^='embedded_'] {
+    border: 1px solid #eee;
+    border-radius: 3px;
+    padding: 15px;
+    background-color: rgba(234, 234, 234, 0.37);
+    box-shadow: 0 3px 6px rgba(0,0,0,.25);
+    cursor: pointer;
+
+    @media @phone {
+      margin: 5px auto !important;
+      max-width: 285px;
+      float: none !important;
+
+      figcaption {
+        text-align: center;
+        margin-left: 0;
+        margin-top: 5px;
+      }
+      img {
+        margin: auto !important;
+      }
+    }
+    /*Big Image*/
+    &.BI  {
+      display: table-cell;
+      max-width: none;
+      margin-left: 10px;
+
+      figcaption, img {
+        max-width: 100% !important;
+      }
+    }
+    app-slide-info {
+      display: none;
+    }
+    figcaption {
+      max-width: 240px;
+      margin: 5px 10px -5px 10px;
+      color: dimgray;
+      font-size: 14px;
+    }
+    img {
+     margin: auto auto 0 auto;
+    }
+  }
+
   .embedded_center {
     margin: 10px auto;
-    display: block;
+    display: table;
   }
   .embedded_left {
     float: left;
@@ -759,11 +809,13 @@ app-add-association {
   .embedded_right {
     float: right;
     clear: right;
-    margin: 5px 0 10px 25px;
+    margin: 5px 0 10px 20px;
   }
   .embedded_inline {
-    margin: 5px 25px 10px 10px;
+    display: table;
+    margin: 5px 20px 10px 10px;
   }
+
   .important_message, .warning_message {
     clear: both;
     display: inline-block;


### PR DESCRIPTION
fixes #805 
related to #736

+ opens images in a gallery-like slideshow
+ you can navigate between the other images from the text
+ images in the text are styled
+ 'view details' and 'edit' buttons are directly visible next to the info, fullscreen and exit button.

![screenshot from 2016-11-09 14-24-07](https://cloud.githubusercontent.com/assets/7814311/20140551/14260cda-a68c-11e6-9262-c0a1c19092d5.png)
![screenshot from 2016-11-09 14-24-27](https://cloud.githubusercontent.com/assets/7814311/20140553/1555f35e-a68c-11e6-9064-10ca33ddf80d.png)
