### PR TITLE
Add posibility to assoc. routes / outings from articles

### DIFF
--- a/c2corg_ui/static/js/addassociation.js
+++ b/c2corg_ui/static/js/addassociation.js
@@ -89,7 +89,8 @@ app.AddAssociationController.prototype.associate = function(doc) {
   // if the parent doc is an outing, inverse the IDs.
   if ((parentType === 'routes' && doc['type'] === 'w') ||
       parentType === 'outings' || parentType === 'images' ||
-      (parentType === 'articles' && doc['type'] === 'w') ||
+      (parentType === 'articles' && (doc['type'] === 'w' ||
+       doc['type'] === 'o' || doc['type'] === 'r' || doc['type'] === 'b')) ||
       (parentType === 'routes' && doc['type'] === 'b') ||
       (parentType === 'waypoints' && doc['type'] === 'b')) {
     childId = this.parentId;


### PR DESCRIPTION
Just a small addition to addassociation.js ... Assoc. are visible, links work correctly and articles are visible/working in other documents also.

Related to https://github.com/c2corg/v6_ui/issues/865