### PR TITLE
Add styles for ng-cloak to the base.html to apply them correctly

### DIFF
--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -38,6 +38,11 @@ closure_library_path = settings.get('closure_library_path')
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build.css')}">
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build-print.css')}" media="print">
 % else:
+    <style>
+      [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+        display: none !important;
+      };
+    </style>
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/deps.css')}">
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build.min.css')}">
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build-print.min.css')}" media="print">

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -8,7 +8,7 @@ closure_library_path = settings.get('closure_library_path')
 %>\
 <%namespace file="helpers/common.html" import="show_title"/>\
 <!DOCTYPE html>
-<html <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl">
+<html ng-cloak <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl">
   <head>
     <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Home')">${show_title('Home')}</title></%block>
     <meta charset="utf-8">


### PR DESCRIPTION
I was wondering what is the problem with loading and showing some angular variables like `{{resCounter}} {{filtersCtrl...}}`, some DIVs appear and then disappear (they are visible to moderators, etc.). This should be probably hidden. We already use `Ng-cloak` ([docs](https://docs.angularjs.org/api/ng/directive/ngCloak)) in the code for that elements, but for some reason, the styles for it are not applied (they are contained inside in angular js files which are loaded after the page loads???).

I added the styles to base.html so they are loaded immediately and now pages are loading correctly (but it should be probably added somewhere else? I didn't find any angular related .less style files).

Sometimes this feature like it is now can be actually useful for debugging (it works with `?debug` URL now, but that is not available on demo for testers), so feel free to discuss / merge.

Before:
![image](https://cloud.githubusercontent.com/assets/6165660/20423877/3726004e-ad73-11e6-92b4-edad0ca17448.png)

After:
![image](https://cloud.githubusercontent.com/assets/6165660/20424334/99645e52-ad75-11e6-8915-0284d9b91bb0.png)


