### PR TITLE
Card attributes updated

### DIFF
--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -10,10 +10,11 @@
     <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     <br>
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+    </div>
 
-    <span class="elevation-max" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max' | translate}}">
-      <span translate class="value-title glyphicon glyphicon-sort-by-attributes"></span>
+    <span class="elevation-max"  uib-tooltip="{{'elevation_max' | translate}}">
+      <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
       <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
     </span>
 

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -5,20 +5,20 @@
   <div class="list-item-info">
     <div class="flex wrap-row">
       <span class="elevation-max" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
-        <span translate class="value-title glyphicon glyphicon-sort-by-attributes"></span>
+        <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
 
       <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
            uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
 
-      <span class="height-diff" ng-if="::doc['height_diff']">
-        <span translate class="value-title">height_diff</span> :
-        <span class="value">{{::doc['height_diff']}}&n&nbsp;m</span>
+      <span class="height-diff" ng-if="::doc['height_diff_up']" uib-tooltip="{{'height_diff_up'| translate}}">
+        <span class="icon-height_diff"></span>
+        <span class="value">{{::doc['height_diff_up']}}&nbsp;m</span>
       </span>
 
       <span class="height-diff-difficulties" ng-if="::doc['height_diff_difficulties']" uib-tooltip="{{'height_diff_difficulties'| translate}}">
-        <span translate class="value-title icon-height_diff"></span>
+        <span class="value-title glyphicon glyphicon-resize-vertical"></span>
         <span class="value">{{::doc['height_diff_difficulties']}}&nbsp;m</span>
       </span>
 

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -10,7 +10,7 @@
 
     <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type"
           uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type']) }}"></span>
-    <p ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}} m</span></p>
+    <p ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}}&nbsp;m</span></p>
   </div>
 
 </a>

--- a/c2corg_ui/static/partials/suggestions/outings.html
+++ b/c2corg_ui/static/partials/suggestions/outings.html
@@ -1,10 +1,15 @@
-  <span class="suggestion-text"> 
-    <span class="suggestion-title"> 
-      <span ng-bind-html="highlight(label, _query)"></span> 
+  <span class="suggestion-text">
+    <span class="suggestion-title">
+      <span ng-bind-html="highlight(label, _query)"></span>
       <span ng-if="::date_end">&nbsp;({{::date_end}})</span>
-    </span><br> 
-    <span class="suggestion-info"> 
-      <span ng-if="::elevation_max">{{::elevation_max}}m</span>
-    </span> 
-  </span> 
+    </span><br>
+
+    <div class="suggestion-info flex">
+      <div uib-tooltip="{{'elevation_max' | translate}}" ng-if="::elevation_max">
+        <span class="glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span>{{::elevation_max}}&nbsp;m</span>
+      </div>
+    </div>
+
+  </span>
   <span class="icon-container" ng-bind-html="::activitiesHtml"></span>

--- a/c2corg_ui/static/partials/suggestions/routes.html
+++ b/c2corg_ui/static/partials/suggestions/routes.html
@@ -1,9 +1,19 @@
-  <span class="suggestion-text"> 
-    <span class="suggestion-title"> 
-      <span ng-bind-html="highlight(label, _query)"></span> 
-    </span><br> 
-    <span class="suggestion-info"> 
-      <span ng-if="::elevation_max">{{::elevation_max}}m</span>
-    </span> 
-  </span> 
+  <span class="suggestion-text">
+    <span class="suggestion-title">
+      <span ng-bind-html="highlight(label, _query)"></span>
+    </span><br>
+    <div class="suggestion-info flex">
+
+      <div uib-tooltip="{{'elevation_max' | translate}}"  ng-if="::elevation_max" class="elevation_max">
+        <span class="glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span>{{::elevation_max}}&nbsp;m</span>
+      </div>
+
+      <span ng-if="::height_diff_up" uib-tooltip="{{'height_diff_up'| translate}}">
+        <span class="icon-height_diff"></span>
+        <span>{{::height_diff_up}}&nbsp;m</span>
+      </span>
+
+    </div>
+  </span>
   <span class="icon-container" ng-bind-html="::activitiesHtml"></span>

--- a/c2corg_ui/static/partials/suggestions/waypoints.html
+++ b/c2corg_ui/static/partials/suggestions/waypoints.html
@@ -1,11 +1,16 @@
-  <span class="suggestion-text"> 
-    <span class="suggestion-title"> 
-      <span ng-bind-html="highlight(label, _query)"></span> 
-    </span><br> 
-    <span class="suggestion-info"> 
-      <span ng-if="::elevation">{{::elevation}}m</span>
-    </span> 
-  </span> 
-  <span class="icon-container"> 
-    <span class="icon-{{::waypoint_type}}"></span> 
+  <span class="suggestion-text">
+    <span class="suggestion-title">
+      <span ng-bind-html="highlight(label, _query)"></span>
+    </span><br>
+
+    <div class="suggestion-info flex" ng-if="::elevation">
+      <div uib-tooltip="{{'elevation' | translate}}">
+        <span class="glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span>{{::elevation}}m</span>
+      </div>
+    </div>
+
+  </span>
+  <span class="icon-container">
+    <span class="icon-{{::waypoint_type}}"></span>
   </span>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -401,11 +401,8 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
         margin-right: 3px;
       }
     }
-    .elevation-max .glyphicon {
-      transform: rotateX(180deg);
-    }
     .elevation-max, .height-diff, .height-diff-difficulties, .orientations {
-      margin-right: 5px;
+      margin-right: 8px;
     }
     .icon-rating {
       font-size: 1.4em;
@@ -447,7 +444,6 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
     }
     .glyphicon, [class*="icon-"]:not(.route-activity):not(.waypoint-type) {
       color: @bright-green;
-      margin-right: 5px;
     }
   }/*list-item-info*/
 
@@ -477,6 +473,12 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   }
   &.outings {
     min-height: 80px;
+    .quality {
+      display: block;
+    }
+    .elevation-max {
+      display: block !important;
+    }
     a {
       .flex() !important;
       height: 100%;

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -367,3 +367,7 @@ p {
     background-position: -96px;
   }
 }
+
+.rotate-180 {
+  transform: rotateX(180deg);
+}

--- a/less/simplesearch.less
+++ b/less/simplesearch.less
@@ -85,13 +85,24 @@ app-simple-search span.twitter-typeahead {
     &:hover, &:focus {
       &:extend(.dropdown-menu > .active > a);
       cursor: pointer;
-      .suggestion-title {
+      .suggestion-title, .suggestion-info{
         color: white;
       }
     }
     .suggestion-info {
       font-size: .9em;
       color: gray;
+
+      .glyphicon,  [class^="icon-"] {
+        color: @bright-green;
+        float: left;
+        margin-right: 5px;
+        margin-left: 0;
+      }
+
+      .elevation_max {
+        margin-right: 10px;
+      }
     }
     .suggestion-title {
       white-space: normal !important;


### PR DESCRIPTION
related to #398

+ added icons for the elevations/diffs 


Associated cards:
+ add outing quality
~~remove outing elevation from associated cards -> show only in the home feed~~ outing's elevation max everywhere
+ add route height_diff_difficulties (=  difficulties denivelation?)
+ add route height_diff_up (= denivelation?)

Search suggestions:
+ add 'height_diff_up' for routes


- Outing Search: Mobile: max elevation should already be available

@loicperrin, @shortoland please tell me if when the above attributes are added if there is still something missing.
