### PR TITLE
Use same color for map controls

### DIFF
--- a/less/map.less
+++ b/less/map.less
@@ -114,3 +114,11 @@ app-map-search {
 .ol-zoom {
   top: 10px;
 }
+
+.ol-control button {
+  background-color: @btn-primary-bg;
+
+  &:hover, &:focus {
+    background-color: fadeout(@btn-primary-bg, 10%);
+  }
+}


### PR DESCRIPTION
Use the same color for the standard ol controls as for the other controls in the map.

Before:
![c2corg-map-tools-before](https://cloud.githubusercontent.com/assets/266474/20445959/9490fa5e-add7-11e6-8e1a-2ad3775df19c.png)


After:
![c2corg-map-tools-after](https://cloud.githubusercontent.com/assets/266474/20445962/98953dc2-add7-11e6-9000-0c354afdc05c.png)

