### PR TITLE
Improve perceived performance of advanced search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ LIBS_JS_FILES += \
     c2corg_ui/static/lib/angular-bootstrap/ui-bootstrap-custom-tpls-1.3.2.min.js \
     node_modules/angular-gettext/dist/angular-gettext.min.js \
     node_modules/angular-ui-date/dist/date.js \
+    node_modules/angular-debounce/angular-debounce.js \
     node_modules/angular-messages/angular-messages.min.js \
     node_modules/angular-cookies/angular-cookies.min.js \
     node_modules/typeahead.js/dist/typeahead.bundle.min.js \

--- a/build.json
+++ b/build.json
@@ -22,6 +22,7 @@
       "c2corg_ui/externs/angular-1.5.js",
       "c2corg_ui/externs/angular-1.5-q_templated.js",
       "c2corg_ui/externs/angular-1.5-http-promise_templated.js",
+      "c2corg_ui/externs/debounce.js",
       "node_modules/openlayers/externs/bingmaps.js",
       "node_modules/openlayers/externs/closure-compiler.js",
       "node_modules/openlayers/externs/esrijson.js",

--- a/c2corg_ui/externs/debounce.js
+++ b/c2corg_ui/externs/debounce.js
@@ -1,0 +1,7 @@
+
+/**
+ * @typedef {
+ *  function(function(), number)
+ * }
+ */
+var debounce;

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -21,5 +21,6 @@ app.module = angular.module('app', [
   'ngFileUpload',
   'slug',
   'vcRecaptcha',
-  'infinite-scroll'
+  'infinite-scroll',
+  'debounce'
 ]);

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -15,9 +15,19 @@ goog.require('app.Url');
  * @ngInject
  */
 app.cardDirective = function($compile, $templateCache) {
-  var template = function(doctype) {
+  var cardElementCache = {};
+
+  var getCardElement = function(doctype) {
+    if (cardElementCache[doctype] !== undefined) {
+      return cardElementCache[doctype];
+    }
     var path = '/static/partials/cards/' + doctype + '.html';
-    return app.utils.getTemplate(path, $templateCache);
+    var template = app.utils.getTemplate(path, $templateCache);
+
+    var element = angular.element(template);
+    cardElementCache[doctype] = $compile(element);
+
+    return cardElementCache[doctype];
   };
 
   return {
@@ -29,8 +39,10 @@ app.cardDirective = function($compile, $templateCache) {
       'doc': '=appCardDoc'
     },
     link: function(scope, element, attrs, ctrl) {
-      element.html(template(ctrl.type));
-      $compile(element.contents())(scope);
+      var cardElementFn = getCardElement(ctrl.type);
+      cardElementFn(scope, function(clone) {
+        element.append(clone);
+      });
     }
   };
 };

--- a/c2corg_ui/static/js/search/advancedsearch.js
+++ b/c2corg_ui/static/js/search/advancedsearch.js
@@ -39,13 +39,14 @@ app.module.directive('appAdvancedSearch', app.advancedSearchDirective);
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {angular.$q} $q Angular promises/deferred service.
+ * @param {debounce} debounce debounce.
  * @constructor
  * @struct
  * @export
  * @ngInject
  */
 app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
-    gettextCatalog, $q) {
+    gettextCatalog, $q, debounce) {
 
   /**
    * @type {angular.Scope}
@@ -131,7 +132,8 @@ app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
     app.utils.detectDocumentIdFilter(this.location_);
 
   // Refresh the results when pagination or criterias have changed:
-  this.scope_.$root.$on('searchFilterChange', this.getResults_.bind(this));
+  this.scope_.$root.$on(
+      'searchFilterChange', debounce(this.getResults_.bind(this), 700));
 
   // Get the initial results when loading the page unless a map is used.
   // In that case wait to get the map extent before triggering the request.
@@ -140,7 +142,7 @@ app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
   }
 
   if (this.useMap) {
-    // Hilight matching cards when a map feature is hovered
+    // Highlight matching cards when a map feature is hovered
     this.scope_.$root.$on('mapFeatureHover', function(event, id) {
       this.onMapFeatureHover_(id);
     }.bind(this));

--- a/c2corg_ui/static/js/search/suggestion.js
+++ b/c2corg_ui/static/js/search/suggestion.js
@@ -11,9 +11,19 @@ goog.require('app.utils');
  * @ngInject
  */
 app.suggestionDirective = function($compile, $sce, $templateCache) {
-  var template = function(doctype) {
+  var cardElementCache = {};
+
+  var getCardElement = function(doctype) {
+    if (cardElementCache[doctype] !== undefined) {
+      return cardElementCache[doctype];
+    }
     var path = '/static/partials/suggestions/' + doctype + '.html';
-    return app.utils.getTemplate(path, $templateCache);
+    var template = app.utils.getTemplate(path, $templateCache);
+
+    var element = angular.element(template);
+    cardElementCache[doctype] = $compile(element);
+
+    return cardElementCache[doctype];
   };
 
   return {
@@ -41,8 +51,10 @@ app.suggestionDirective = function($compile, $sce, $templateCache) {
         scope.$parent['activitiesHtml'] = $sce.trustAsHtml(activitiesHtml);
       }
 
-      element.html(template(document['documentType']));
-      $compile(element.contents())(scope);
+      var cardElementFn = getCardElement(document['documentType']);
+      cardElementFn(scope, function(clone) {
+        element.append(clone);
+      });
       scope.$apply();
     }
   };

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -107,6 +107,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_path('%s/slug/slug.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/floatthead/dist/jquery.floatThead.min.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-float-thead/angular-floatThead.js' % node_modules_path)}"></script>
+    <script src="${request.static_path('%s/angular-debounce/angular-debounce.js' % node_modules_path)}"></script>
     <script src="${request.route_path('deps.js')}"></script>
     <script src="${request.static_path('c2corg_ui:static/js/main.js')}"></script>
 % else:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "angular": "1.5.8",
     "angular-cookies": "1.5.8",
+    "angular-debounce": "git://github.com/shahata/angular-debounce#0c67aca",
     "angular-float-thead": "0.1.2",
     "angular-gettext": "2.3.4",
     "angular-gettext-tools": "2.2.3",


### PR DESCRIPTION
When navigating around in the map, new results are constantly queried. While the request itself is asynchronously, updating the DOM (showing the results) is blocking. During that time you can not navigate the map, which feels disturbing.

The aim of this PR is to improve the performance of updating the DOM, and to reduce the number of DOM updates. This is done by:

- Caching the compiled elements for the cards.
- Canceling previous XHR requests, when a new request is made.
- Debouncing the requests. A request is only made if the filters/bbox have not changed in the last 700ms.

This is still not perfect, but it improves the perceived performance.