### PR TITLE
Use one-time-bindings

### DIFF
--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -26,7 +26,7 @@ app.cardDirective = function($compile, $templateCache) {
     controllerAs: 'cardCtrl',
     bindToController: true,
     scope: {
-      'doc': '=appCardDoc'
+      'doc': '<appCardDoc'
     },
     link: function(scope, element, attrs, ctrl) {
       element.html(template(ctrl.type));

--- a/c2corg_ui/static/partials/advancedsearch.html
+++ b/c2corg_ui/static/partials/advancedsearch.html
@@ -1,8 +1,8 @@
 <div class="list" app-loading>
-  <div id="card{{doc.document_id}}" class="list-item" ng-class="[searchCtrl.doctype, {'highlight': doc.document_id === searchCtrl.highlightId}]" ng-repeat="doc in searchCtrl.documents">
+  <div id="card{{doc.document_id}}" class="list-item" ng-class="[searchCtrl.doctype, {'highlight': doc.document_id === searchCtrl.highlightId}]"
+       ng-repeat="doc in searchCtrl.documents track by doc.document_id">
     <app-card app-card-doc="doc" ng-mouseenter="searchCtrl.onMouseEnter(doc.document_id)"
               ng-mouseleave="searchCtrl.onMouseLeave(doc.document_id)"></app-card>
   </div>
 </div>
 <p translate class="text-warning text-center no-results" ng-class="{'show': searchCtrl.noResults}">No results</p>
-

--- a/c2corg_ui/static/partials/advancedsearch.html
+++ b/c2corg_ui/static/partials/advancedsearch.html
@@ -1,7 +1,7 @@
 <div class="list" app-loading>
   <div id="card{{doc.document_id}}" class="list-item" ng-class="[searchCtrl.doctype, {'highlight': doc.document_id === searchCtrl.highlightId}]"
        ng-repeat="doc in searchCtrl.documents track by doc.document_id">
-    <app-card app-card-doc="doc" ng-mouseenter="searchCtrl.onMouseEnter(doc.document_id)"
+    <app-card app-card-doc="::doc" ng-mouseenter="searchCtrl.onMouseEnter(doc.document_id)"
               ng-mouseleave="searchCtrl.onMouseLeave(doc.document_id)"></app-card>
   </div>
 </div>

--- a/c2corg_ui/static/partials/cards/areas.html
+++ b/c2corg_ui/static/partials/cards/areas.html
@@ -1,10 +1,10 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title">{{locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
+  <span class="list-item-title">{{::locale.title}}</span>
+  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
   <br>
   <div class="list-item-info flex baseline-align">
-    <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-         uib-tooltip="{{'quality' | translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
-    {{doc['area_type'] | translate}}
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality' | translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+    {{::doc['area_type'] | translate}}
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/articles.html
+++ b/c2corg_ui/static/partials/cards/articles.html
@@ -1,21 +1,21 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="list-item-info">
 
-    <span class="list-item-title">{{locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
-    <div class="value">{{doc['article_type'] | translate }}</div>
+    <span class="list-item-title">{{::locale.title}}</span>
+    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    <div class="value">{{::doc['article_type'] | translate }}</div>
 
     <div class="article-categories">
-      <span ng-repeat="category in doc.categories" class="value">{{category | translate }}{{$last ? '' : ', '}}</span>
+      <span ng-repeat="category in ::doc.categories" class="value">{{::category | translate }}{{$last ? '' : ', '}}</span>
     </div>
 
     <div class="article-activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}"
+      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
             uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
     </div>
 
     <br>
-    <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/books.html
+++ b/c2corg_ui/static/partials/cards/books.html
@@ -1,21 +1,21 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="list-item-info">
 
-    <span class="list-item-title">{{locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
-    <span ng-if="doc['author']" class="value">{{doc['author']}}</span>
+    <span class="list-item-title">{{::locale.title}}</span>
+    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    <span ng-if="::doc['author']" class="value">{{::doc['author']}}</span>
 
     <div class="article-categories">
-      <span ng-repeat="book_type in doc['book_types']" class="value">{{book_type | translate }}{{$last ? '' : ', '}}</span>
+      <span ng-repeat="book_type in ::doc['book_types']" class="value">{{::book_type | translate }}{{$last ? '' : ', '}}</span>
     </div>
 
     <div class="book-activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}"
+      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
             uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
     </div>
 
     <br>
-    <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/images.html
+++ b/c2corg_ui/static/partials/cards/images.html
@@ -1,15 +1,15 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <img ng-src="{{cardCtrl.createImg()}}" alt="{{locale['title']}}">
+  <img ng-src="{{cardCtrl.createImg()}}" alt="{{::locale['title']}}">
   <div class="list-item-info">
-    <div class="outing-date">{{ doc['date_time'] | date: 'dd/MM/yyyy'}}</div>
-    <div ng-if="doc['author']"><span class="value-title" translate>author</span>: <span class="value">{{doc['author']}}</span></div>
+    <div class="outing-date">{{ ::doc['date_time'] | date: 'dd/MM/yyyy'}}</div>
+    <div ng-if="doc['author']"><span class="value-title" translate>author</span>: <span class="value">{{::doc['author']}}</span></div>
 
-    <span class="list-item-title">{{locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
+    <span class="list-item-title">{{::locale.title}}</span>
+    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     <br>
 
     <div class="route-activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}"
+      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
             uib-tooltip="{{ cardCtrl.translate(activity)}}" tooltip-placement="top"></span>
     </div>
   </div>

--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -1,25 +1,25 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="outing-author text-center">
-    <div class="outing-date">{{ doc['date_end'] | date: 'dd/MM/yyyy'}}</div>
+    <div class="outing-date">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</div>
     <span class="icon-user"></span><br>
-    <b class="author-name">{{doc['author']['name']}}</b>
+    <b class="author-name">{{::doc['author']['name']}}</b>
   </div>
   <div class="list-item-info">
 
-    <span class="list-item-title">{{locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
+    <span class="list-item-title">{{::locale.title}}</span>
+    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     <br>
-    <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
 
-    <span class="elevation-max" ng-if="doc['elevation_max']" uib-tooltip="{{'elevation_max' | translate}}">
+    <span class="elevation-max" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max' | translate}}">
       <span translate class="value-title glyphicon glyphicon-sort-by-attributes"></span>
-      <span class="value">{{doc['elevation_max']}}&nbsp;m</span>
+      <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
     </span>
 
     <div class="route-activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
+      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
+            uib-tooltip="{{ ::cardCtrl.translate(activity) }}"></span>
     </div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -1,49 +1,49 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title"><span ng-if="locale.title_prefix">{{locale.title_prefix}}&nbsp;: </span>{{locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
+  <span class="list-item-title"><span ng-if="::locale.title_prefix">{{::locale.title_prefix}}&nbsp;: </span>{{::locale.title}}</span>
+  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
   <br>
   <div class="list-item-info">
     <div class="flex wrap-row">
-      <span class="elevation-max" ng-if="doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
+      <span class="elevation-max" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
         <span translate class="value-title glyphicon glyphicon-sort-by-attributes"></span>
-        <span class="value">{{doc['elevation_max']}}&nbsp;m</span>
+        <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
 
-      <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-           uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
+      <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+           uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
 
-      <span class="height-diff" ng-if="doc['height_diff']">
+      <span class="height-diff" ng-if="::doc['height_diff']">
         <span translate class="value-title">height_diff</span> :
-        <span class="value">{{doc['height_diff']}}&n&nbsp;m</span>
+        <span class="value">{{::doc['height_diff']}}&n&nbsp;m</span>
       </span>
 
-      <span class="height-diff-difficulties" ng-if="doc['height_diff_difficulties']" uib-tooltip="{{'height_diff_difficulties'| translate}}">
+      <span class="height-diff-difficulties" ng-if="::doc['height_diff_difficulties']" uib-tooltip="{{'height_diff_difficulties'| translate}}">
         <span translate class="value-title icon-height_diff"></span>
-        <span class="value">{{doc['height_diff_difficulties']}}&nbsp;m</span>
+        <span class="value">{{::doc['height_diff_difficulties']}}&nbsp;m</span>
       </span>
 
-      <div ng-if="doc['orientations']" class="orientations" uib-tooltip="{{'orientations'| translate}}">
+      <div ng-if="::doc['orientations']" class="orientations" uib-tooltip="{{'orientations'| translate}}">
         <span class="glyphicon glyphicon-fullscreen"></span>
-        <span ng-repeat="o in doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
+        <span ng-repeat="o in ::doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
       </div>
     </div>
 
-    <div class="global-rating flex flexend-align" ng-init="globalRatings = cardCtrl.getGlobalRatings()" ng-show="globalRatings">
+    <div class="global-rating flex flexend-align" ng-init="globalRatings = cardCtrl.getGlobalRatings()" ng-show="::globalRatings">
       <span class="icon-rating"></span>
-      <div ng-repeat="(attr, val) in globalRatings" class="rating" uib-tooltip="{{attr | translate}}" ng-if="val">
-        <span class="value">{{val}}</span>
+      <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr | translate}}" ng-if="::val">
+        <span class="value">{{::val}}</span>
       </div>
     </div>
 
     <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()">
       <span class="icon-rating"></span>
-      <div ng-repeat="(attr, val) in fullRatings" uib-tooltip="{{attr | translate}}" class="rating">
-        <span class="value">{{val}}</span>
+      <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr | translate}}" class="rating">
+        <span class="value">{{::val}}</span>
       </div>
     </div>
 
     <div class="route-activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}" uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
     </div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -1,16 +1,16 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title">{{locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{locale.lang}})</span>
+  <span class="list-item-title">{{::locale.title}}</span>
+  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
   <br>
 
   <div class="list-item-info flex baseline-align">
 
-    <div class="quality" ng-if="doc['quality']" ng-class="doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left"></div>
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
 
     <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type"
-          uib-tooltip="{{ cardCtrl.translate(doc['waypoint_type']) }}"></span>
-    <p ng-if="doc['elevation']"><span class="value">{{doc['elevation']}} m</span></p>
+          uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type']) }}"></span>
+    <p ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}} m</span></p>
   </div>
 
 </a>

--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -29,7 +29,7 @@
     </div>
   </article>
 
-  <article class="feed-list-item" ng-repeat="doc in feedCtrl.documents"
+  <article class="feed-list-item" ng-repeat="doc in feedCtrl.documents track by doc.id"
            ng-init="type = feedCtrl.documentType(doc.document.type);">
 
     <div class="timeline-bullet icon-{{type}}s" uib-tooltip="{{type | translate}}" tooltip-placement="left"></div>

--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -32,37 +32,37 @@
   <article class="feed-list-item" ng-repeat="doc in feedCtrl.documents track by doc.id"
            ng-init="type = feedCtrl.documentType(doc.document.type);">
 
-    <div class="timeline-bullet icon-{{type}}s" uib-tooltip="{{type | translate}}" tooltip-placement="left"></div>
+    <div class="timeline-bullet icon-{{::type}}s" uib-tooltip="{{::type | translate}}" tooltip-placement="left"></div>
 
     <p class="action-line">
       <span class="action" ng-cloak>
-        <b><a ng-href="/profiles/{{doc['user']['document_id']}}/{{doc['user']['locales'][0]['lang']}}">{{doc['user']['name']}}</a></b>
+        <b><a ng-href="/profiles/{{::doc['user']['document_id']}}/{{::doc['user']['locales'][0]['lang']}}">{{::doc['user']['name']}}</a></b>
         {{feedCtrl.createActionLine(doc) | translate}}
       </span>
       <br>
       <span class="action date">
         <span class=" glyphicon glyphicon-time"></span>
-        <span am-time-ago="doc.time"></span>
+        <span am-time-ago="::doc.time"></span>
       </span>
     </p>
 
     <div ng-if="doc.change_type == 'added_photos'" class="images">
-      <a class="big-image thumbnail flex" ng-href="/images/{{doc.image1.document_id}}/{{doc.image1.locales[0].lang}}"
+      <a class="big-image thumbnail flex" ng-href="/images/{{::doc.image1.document_id}}/{{::doc.image1.locales[0].lang}}"
          ng-style="(!doc.image2 && !doc.image3) && {'width': '100%'}">
         <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image1.filename, 'MI')}})"></span>
       </a>
-      <a class="small-image thumbnail flex" ng-href="/images/{{doc.image2.document_id}}/{{doc.image2.locales[0].lang}}"
-       ng-if="doc.image2">
+      <a class="small-image thumbnail flex" ng-href="/images/{{::doc.image2.document_id}}/{{::doc.image2.locales[0].lang}}"
+       ng-if="::doc.image2">
         <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image2.filename, 'MI')}})"></span>
       </a>
-      <a class="small-image thumbnail flex" ng-href="/images/{{doc.image3.document_id}}/{{doc.image3.locales[0].lang}}"
-        ng-if="doc.image3">
+      <a class="small-image thumbnail flex" ng-href="/images/{{::doc.image3.document_id}}/{{::doc.image3.locales[0].lang}}"
+        ng-if="::doc.image3">
         <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image3.filename, 'MI')}})"></span>
       </a>
     </div>
 
-    <div class="list-item {{type}}s">
-      <app-card app-card-doc="doc['document']"></app-card>
+    <div class="list-item {{::type}}s">
+      <app-card app-card-doc="::doc['document']"></app-card>
     </div>
   </article>
   <h4 class="text-center text-danger" translate ng-show="feedCtrl.error">Sorry, there was an error while getting the feed.</h4>

--- a/c2corg_ui/static/partials/suggestions/outings.html
+++ b/c2corg_ui/static/partials/suggestions/outings.html
@@ -1,10 +1,10 @@
   <span class="suggestion-text"> 
     <span class="suggestion-title"> 
       <span ng-bind-html="highlight(label, _query)"></span> 
-      <span ng-if="date_end">&nbsp;({{::date_end}})</span> 
+      <span ng-if="::date_end">&nbsp;({{::date_end}})</span>
     </span><br> 
     <span class="suggestion-info"> 
-      <span ng-if="elevation_max">{{::elevation_max}}m</span> 
+      <span ng-if="::elevation_max">{{::elevation_max}}m</span>
     </span> 
   </span> 
   <span class="icon-container" ng-bind-html="::activitiesHtml"></span>

--- a/c2corg_ui/static/partials/suggestions/routes.html
+++ b/c2corg_ui/static/partials/suggestions/routes.html
@@ -3,7 +3,7 @@
       <span ng-bind-html="highlight(label, _query)"></span> 
     </span><br> 
     <span class="suggestion-info"> 
-      <span ng-if="elevation_max">{{elevation_max}}m</span> 
+      <span ng-if="::elevation_max">{{::elevation_max}}m</span>
     </span> 
   </span> 
   <span class="icon-container" ng-bind-html="::activitiesHtml"></span>

--- a/c2corg_ui/static/partials/suggestions/waypoints.html
+++ b/c2corg_ui/static/partials/suggestions/waypoints.html
@@ -3,7 +3,7 @@
       <span ng-bind-html="highlight(label, _query)"></span> 
     </span><br> 
     <span class="suggestion-info"> 
-      <span ng-if="elevation">{{::elevation}}m</span> 
+      <span ng-if="::elevation">{{::elevation}}m</span>
     </span> 
   </span> 
   <span class="icon-container"> 


### PR DESCRIPTION
To reduce the number of Angular watchers, this PR proposes to use one-time-bindings. I didn't check all partials, I focused on the card partials because they are used intensively in the advanced search and the feed.

For more information about one-time-bindings, see here: https://www.binpress.com/tutorial/speeding-up-angular-js-with-simple-optimizations/135

The last commit uses [track by](https://docs.angularjs.org/api/ng/directive/ngRepeat#tracking-and-duplicates) for the `ng-repeat` in the advanced search and the feed. See also: http://www.codelord.net/2014/04/15/improving-ng-repeat-performance-with-track-by/