### PR TITLE
Do not show waypoints for outings

### DIFF
--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -133,7 +133,6 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
       </div>
       <section>
         ${show_associated_routes(outing)}
-        ${show_associated_waypoints(outing)}
         ${show_associated_articles(outing)}
       </section>
     </span>


### PR DESCRIPTION
Direct associations between outings and waypoints are not valid.

See also: https://github.com/c2corg/v6_api/pull/513