### PR TITLE
Associations permissions

### DIFF
--- a/c2corg_ui/static/js/auth/authservice.js
+++ b/c2corg_ui/static/js/auth/authservice.js
@@ -112,17 +112,16 @@ app.Authentication.prototype.hasEditRights = function(doctype, options) {
   if (this.isModerator()) {
     return true;
   }
-
   if (doctype === 'outings') {
     return this.hasEditRightsOuting_(options['users']);
-  }
-
-  if (doctype === 'images') {
+  } else if (doctype === 'images') {
     return this.hasEditRightsImage_(options['imageType'], options['imageCreator']);
-  }
-
-  if (doctype === 'profiles') {
+  } else if (doctype === 'profiles') {
     return this.userData.id === options['user_id'];
+  } else if (doctype === 'articles') {
+    return this.hasEditRightsArticle_(options['articleType'], options['authorId']);
+  } else if (doctype === 'xreports') {
+    return false;
   }
 
   return true;
@@ -131,20 +130,16 @@ app.Authentication.prototype.hasEditRights = function(doctype, options) {
 
 /**
  * Checks if the current user has rights to access/edit the outing.
- * @param {!Array<string> | !string} users
+ * @param {string | Array<string>} users
  * @return {boolean}
  * @private
  */
 app.Authentication.prototype.hasEditRightsOuting_ = function(users) {
-  var userid = this.userData.id;
-  var u;
+  var u = typeof users === 'string' ? JSON.parse(users) : users;
 
-  if (typeof users === 'string') {
-    u = JSON.parse(users);
-  }
   if (u) {
     for (var i = 0; i < u.length; i++) {
-      if (userid === u[i].document_id) {
+      if (this.userData.id === u[i].document_id) {
         return true;
       }
     }
@@ -164,6 +159,22 @@ app.Authentication.prototype.hasEditRightsImage_ = function(imageType, creator) 
     return true;
   } else {
     return this.userData.id === creator;
+  }
+};
+
+
+/**
+ * Checks if the current user has rights to access/edit the article.
+ * @param {string} articleType
+ * @param {string} authorId
+ * @return {boolean}
+ * @private
+ */
+app.Authentication.prototype.hasEditRightsArticle_ = function(articleType, authorId) {
+  if (articleType === 'collab') {
+    return true;
+  } else {
+    return this.userData.id === parseInt(authorId, 10);
   }
 };
 

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -458,12 +458,14 @@ app.ViewDetailsController.prototype.toggleOrientation = function(orientation, do
  * @private
  */
 app.ViewDetailsController.prototype.watchPswpContainer_ = function() {
-  var observer = new MutationObserver(function() {
-    $('.showing-info').removeClass('showing-info');
-    this.compile_($('.image-infos-buttons').contents())(this.scope_);
-  }.bind(this));
   var target = $('.pswp__container')[0];
-  observer.observe(target, {attributes: true, attributeFilter: ['style']});
+  if (target) {
+    var observer = new MutationObserver(function() {
+      $('.showing-info').removeClass('showing-info');
+      this.compile_($('.image-infos-buttons').contents())(this.scope_);
+    }.bind(this));
+    observer.observe(target, {attributes: true, attributeFilter: ['style']});
+  }
 };
 
 app.module.controller('AppViewDetailsController', app.ViewDetailsController);

--- a/c2corg_ui/static/partials/cards/books.html
+++ b/c2corg_ui/static/partials/cards/books.html
@@ -14,7 +14,6 @@
             uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
     </div>
 
-    <br>
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
          uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
   </div>

--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -125,7 +125,7 @@ area['doctype'] = 'areas'
   % if not version:
     ${show_other_langs_links('areas', area, other_langs)}
     ${show_missing_langs_links('areas', area, missing_langs)}
-    ${show_float_buttons(None, 'areas', area_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(area, lang, other_langs, missing_langs)}
   % endif
 </section>
 

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
+from c2corg_ui.templates.utils import get_lang_lists, has_associations
 from json import dumps
 %>
 
@@ -55,7 +55,6 @@ other_langs, missing_langs = get_lang_lists(article, lang)
     ${show_archive_data('articles', article, locale, version)}
   % endif
 
-
   ## IMAGES
   % if not version:
     ${get_image_gallery()}
@@ -78,16 +77,16 @@ other_langs, missing_langs = get_lang_lists(article, lang)
   ## ASSOCIATIONS
   % if not version:
     <div class="view-details-associations col-xs-12 associations"
-      % if not check_if_any_associations(article):
-         ng-show="userCtrl.hasEditRights( 'articles', { 'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']} })"
+      % if not has_associations(article):
+         ng-show="userCtrl.hasEditRights('articles', {'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']}})"
       % endif
-      >
+    >
       <span class="lead">
         <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()
           % if article['article_type'] == 'personal':
-              && userCtrl.hasEditRights( 'articles', { 'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']} })
+            && userCtrl.hasEditRights('articles', {'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']}})
           % endif
-           ">
+        ">
           <label translate>Add association</label>
           <app-add-association parent-doctype="articles" parent-id="${article_id}" dataset="wrocb"></app-add-association>
         </div>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists
+from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
 from json import dumps
 %>
 
@@ -77,9 +77,17 @@ other_langs, missing_langs = get_lang_lists(article, lang)
 
   ## ASSOCIATIONS
   % if not version:
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations"
+      % if not check_if_any_associations(article):
+         ng-show="userCtrl.hasEditRights( 'articles', { 'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']} })"
+      % endif
+      >
       <span class="lead">
-        <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+        <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()
+          % if article['article_type'] == 'personal':
+              && userCtrl.hasEditRights( 'articles', { 'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']} })
+          % endif
+           ">
           <label translate>Add association</label>
           <app-add-association parent-doctype="articles" parent-id="${article_id}" dataset="wrocb"></app-add-association>
         </div>
@@ -100,7 +108,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
   % if not version:
     ${show_other_langs_links('articles', article, other_langs)}
     ${show_missing_langs_links('articles', article, missing_langs)}
-    ${show_float_buttons(article['associations']['users'], 'articles', article_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(article, lang, other_langs, missing_langs)}
   % endif
 </section>
 

--- a/c2corg_ui/templates/book/helpers/view.html
+++ b/c2corg_ui/templates/book/helpers/view.html
@@ -22,7 +22,7 @@
 
     % if book.get('book_types'):
       <article class="value-title">
-          <span translate class="value-title">book_types</span><br>
+          <span translate class="value-title">book_types</span>: 
         % for book_type in book.get('book_types') :
           <span x-translate class="value">${book_type}</span>${'' if loop.last else ', '}
         % endfor

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -111,7 +111,7 @@ other_langs, missing_langs = get_lang_lists(book, lang)
   % if not version:
     ${show_other_langs_links('books', book, other_langs)}
     ${show_missing_langs_links('books', book, missing_langs)}
-    ${show_float_buttons(None, 'books', book_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(book, lang, other_langs, missing_langs)}
   % endif
 
 </section>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -1,38 +1,16 @@
 <%!
-    from c2corg_ui.templates.utils import get_attr
+    from c2corg_ui.templates.utils import get_attr, is_collaborative, is_personal, get_doc_type
     from json import dumps, loads
     from shapely.geometry import asShape
     from math import floor
-    from c2corg_ui.views.document import get_slug, is_collaborative
+    from c2corg_ui.views.document import get_slug
 %>
 
 <%def name="get_licence(doc)">\
   <%
-      doctype = doc['type']
-      collaborative = False
-      personal = False
-      copyright = False
-
-      if doctype == 'o' or doctype == 'u' or doctype == 'x':
-          personal = True
-      elif doctype == 'w' or doctype == 'r' or doctype == 'b' or doctype == 'a':
-          collaborative = True
-
-      elif doctype == 'c':
-          if doc['article_type'] == 'personal':
-              personal = True
-          else:
-              collaborative = True
-
-      elif doctype == 'i':
-          if doc['image_type'] == 'personal':
-              personal = True
-          elif doc['image_type'] == 'copyright':
-              copyright = True
-          else:
-              collaborative = True
+      personal = is_personal(doc)
+      collaborative = is_collaborative(doc) if not personal else False
   %>
-
   <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
     <h4><span translate>Licence</span><span class="glyphicon glyphicon-menu-right"></span></h4>
     <div class="name-icon">
@@ -68,14 +46,6 @@
       </article>
     </span>
   </div>
-</%def>
-
-<%def name="show_attr(obj, key, parse=True)">\
-  <%
-      attr = get_attr(obj, key, md=parse, bb=parse)
-      attr = attr if attr else ''
-  %>
-  ${attr | n}\
 </%def>
 
 <%def name="show_attr(obj, key, parse=True)">\
@@ -207,11 +177,30 @@
   % endif
 </%def>
 
+<%def name="test_association_rights(document)">\
+  % if is_collaborative(document):
+    userCtrl.auth.isAuthenticated()
+    && userCtrl.auth.isModerator()
+  % elif is_personal(document):
+    userCtrl.hasEditRights(
+        '${get_doc_type(document['type'])}',
+        {'users': ${dumps(document['associations']['users'])},
+      % if document['type'] == 'c':
+        'articleType': '${document['article_type']}',
+        'authorId': '${document['author']['user_id']}'
+      % elif document['type'] == 'i':
+        'imageType': '${document['image_type']}',
+        'imageCreator': '${document['creator']['user_id']}',
+      % endif
+    })
+  % endif
+</%def>
+
+
 <%def name="show_associated_articles(document, type='articles')">\
   <%
     articles = document['associations']['articles']
     associations = 'detailsCtrl.documentService.document.associations.' + type
-    isCollaborative = is_collaborative(document)
   %>
    ${add_seo_association_links(articles, 'articles')}
     <section ng-show="${associations}.length > 0">
@@ -223,12 +212,8 @@
         <div class="list-item" ng-repeat="doc in ${associations}" ng-class="{'new-item': doc['new']}">
           <app-card app-card-doc="doc"></app-card>
           % if type == 'articles':
-            <app-delete-association child-doctype="articles" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.auth.isAuthenticated()
-              % if isCollaborative:
-                && userCtrl.auth.isModerator()
-              % endif
-              "></app-delete-association>
+              <app-delete-association child-doctype="articles" parent-id="${document['document_id']}" child-id="doc.document_id"
+                ng-if="${test_association_rights(document)}"></app-delete-association>
           % endif
         </div>
       </div>
@@ -240,7 +225,6 @@
   <%
     books = document['associations']['books']
     associations = 'detailsCtrl.documentService.document.associations.' + type
-    isCollaborative = is_collaborative(document)
   %>
    ${add_seo_association_links(books, 'books')}
     <section ng-show="${associations}.length > 0">
@@ -252,11 +236,8 @@
         <div class="list-item" ng-repeat="doc in ${associations}" ng-class="{'new-item': doc['new']}">
           <app-card app-card-doc="doc"></app-card>
           % if type == 'books':
-            <app-delete-association child-doctype="books" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
-          % endif
-          % if isCollaborative:
-            && userCtrl.auth.isModerator()
+              <app-delete-association child-doctype="books" parent-id="${document['document_id']}" child-id="doc.document_id"
+                ng-if="${test_association_rights(document)}"></app-delete-association>
           % endif
         </div>
       </div>
@@ -269,7 +250,6 @@
     routes = document['associations']['all_routes']['documents'] if type == 'all_routes' else document['associations']['routes']
     associations = 'detailsCtrl.documentService.document.associations.'
     associations += 'all_routes.documents' if type == 'all_routes' else 'routes'
-    isCollaborative = is_collaborative(document)
   %>
     ${add_seo_association_links(routes, 'routes')}
     <section ng-show="${associations}.length > 0">
@@ -282,15 +262,11 @@
           <app-card app-card-doc="doc"></app-card>
           % if type == 'routes':
             <app-delete-association child-doctype="routes" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.auth.isAuthenticated()
+              ng-if="${test_association_rights(document)}
               % if document['type'] == 'o':
-                && userCtrl.hasEditRights('outings', ${ {"users": dumps(document['associations']['users']) }})
-                && ${associations}.length > 1
+                  && ${associations}.length > 1
               % endif
-              % if isCollaborative:
-                && userCtrl.auth.isModerator()
-              % endif
-              "></app-delete-association>
+            "></app-delete-association>
           % endif
         </div>
         % if type == 'all_routes' and document['associations']['all_routes']['total'] > len(routes):
@@ -308,7 +284,6 @@
 <%def name="show_associated_waypoints(document, type='waypoints', showDelete=True)">\
   ## Possible values for type: waypoints, waypoint_children
   <%
-      isCollaborative = is_collaborative(document)
       associations = 'detailsCtrl.documentService.document.associations.' + type
   %>
   ${add_seo_association_links(document['associations'][type], 'waypoints')}
@@ -328,15 +303,12 @@
            ng-repeat="doc in ${associations} | orderBy: 'waypoint_type'">
            <app-card app-card-doc="doc"></app-card>
         % if showDelete:
-        <app-delete-association child-doctype="${type}" parent-id="${document['document_id']}" child-id="doc.document_id"
-          ng-if="userCtrl.auth.isAuthenticated()
-          % if document['doctype'] == 'routes':
-              && ${associations}.length > 1
-          % endif
-          % if isCollaborative:
-            && userCtrl.auth.isModerator()
-          % endif
-        "></app-delete-association>
+            <app-delete-association child-doctype="${type}" parent-id="${document['document_id']}" child-id="doc.document_id"
+              ng-if="${test_association_rights(document)}
+              % if document['doctype'] == 'routes':
+                  && ${associations}.length > 1
+              % endif
+            "></app-delete-association>
         % endif
       </div>
     </div>
@@ -380,13 +352,8 @@
         % endif
         <div class="list-item outings" ng-repeat="doc in detailsCtrl.documentService.document.associations.${'recent_outings.documents' if isRecentOutings else 'outings'}">
           <app-card app-card-doc="doc"></app-card>
-          % if not isRecentOutings and document['doctype'] == 'images':
-            <%
-                options = {"imageType": document["image_type"], "imageCreator": document["creator"]["user_id"]}
-            %>
             <app-delete-association child-doctype="o" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.hasEditRights('outings', ${options})"></app-delete-association>
-          % endif
+              ng-if="${test_association_rights(document)}"></app-delete-association>
         </div>
         % if isRecentOutings and total > len(outings) :
           <%
@@ -493,12 +460,18 @@
   % endif
 </%def>
 
-<%def name="show_float_buttons(associatedUsers, doctype, doc_id, doc_lang, other_langs, missing_langs, image = None)">\
+<%def name="show_float_buttons(doc, doc_lang, other_langs, missing_langs)">\
   <%
-      if image:
+      doctype = get_doc_type(doc['type'])
+      doc_id = doc['document_id']
+      users = dumps(doc['associations']['users']) if 'users' in doc['associations'] else None
+
+      if doctype == 'images':
           options = {"imageType": image["image_type"], "imageCreator": image["creator"]["user_id"]}
+      elif doctype == 'articles':
+          options = {"articleType": doc['article_type'], "authorId": doc['author']['user_id']}
       else:
-          options = {"users": dumps(associatedUsers) }
+          options = {"users": users}
   %>
   <div class="float-buttons">
       <div ng-if="userCtrl.hasEditRights('${doctype}', ${options})"

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -3,7 +3,7 @@
     from json import dumps, loads
     from shapely.geometry import asShape
     from math import floor
-    from c2corg_ui.views.document import get_slug
+    from c2corg_ui.views.document import get_slug, is_collaborative
 %>
 
 <%def name="get_licence(doc)">\
@@ -70,6 +70,13 @@
   </div>
 </%def>
 
+<%def name="show_attr(obj, key, parse=True)">\
+  <%
+      attr = get_attr(obj, key, md=parse, bb=parse)
+      attr = attr if attr else ''
+  %>
+  ${attr | n}\
+</%def>
 
 <%def name="show_attr(obj, key, parse=True)">\
   <%
@@ -204,6 +211,7 @@
   <%
     articles = document['associations']['articles']
     associations = 'detailsCtrl.documentService.document.associations.' + type
+    isCollaborative = is_collaborative(document)
   %>
    ${add_seo_association_links(articles, 'articles')}
     <section ng-show="${associations}.length > 0">
@@ -216,7 +224,11 @@
           <app-card app-card-doc="doc"></app-card>
           % if type == 'articles':
             <app-delete-association child-doctype="articles" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
+              ng-if="userCtrl.auth.isAuthenticated()
+              % if isCollaborative:
+                && userCtrl.auth.isModerator()
+              % endif
+              "></app-delete-association>
           % endif
         </div>
       </div>
@@ -228,6 +240,7 @@
   <%
     books = document['associations']['books']
     associations = 'detailsCtrl.documentService.document.associations.' + type
+    isCollaborative = is_collaborative(document)
   %>
    ${add_seo_association_links(books, 'books')}
     <section ng-show="${associations}.length > 0">
@@ -242,6 +255,9 @@
             <app-delete-association child-doctype="books" parent-id="${document['document_id']}" child-id="doc.document_id"
               ng-if="userCtrl.auth.isAuthenticated()"></app-delete-association>
           % endif
+          % if isCollaborative:
+            && userCtrl.auth.isModerator()
+          % endif
         </div>
       </div>
     </section>
@@ -253,6 +269,7 @@
     routes = document['associations']['all_routes']['documents'] if type == 'all_routes' else document['associations']['routes']
     associations = 'detailsCtrl.documentService.document.associations.'
     associations += 'all_routes.documents' if type == 'all_routes' else 'routes'
+    isCollaborative = is_collaborative(document)
   %>
     ${add_seo_association_links(routes, 'routes')}
     <section ng-show="${associations}.length > 0">
@@ -269,6 +286,9 @@
               % if document['type'] == 'o':
                 && userCtrl.hasEditRights('outings', ${ {"users": dumps(document['associations']['users']) }})
                 && ${associations}.length > 1
+              % endif
+              % if isCollaborative:
+                && userCtrl.auth.isModerator()
               % endif
               "></app-delete-association>
           % endif
@@ -288,6 +308,7 @@
 <%def name="show_associated_waypoints(document, type='waypoints', showDelete=True)">\
   ## Possible values for type: waypoints, waypoint_children
   <%
+      isCollaborative = is_collaborative(document)
       associations = 'detailsCtrl.documentService.document.associations.' + type
   %>
   ${add_seo_association_links(document['associations'][type], 'waypoints')}
@@ -311,6 +332,9 @@
           ng-if="userCtrl.auth.isAuthenticated()
           % if document['doctype'] == 'routes':
               && ${associations}.length > 1
+          % endif
+          % if isCollaborative:
+            && userCtrl.auth.isModerator()
           % endif
         "></app-delete-association>
         % endif
@@ -361,7 +385,7 @@
                 options = {"imageType": document["image_type"], "imageCreator": document["creator"]["user_id"]}
             %>
             <app-delete-association child-doctype="o" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="userCtrl.hasEditRights('images', ${options})"></app-delete-association>
+              ng-if="userCtrl.hasEditRights('outings', ${options})"></app-delete-association>
           % endif
         </div>
         % if isRecentOutings and total > len(outings) :

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -179,8 +179,7 @@
 
 <%def name="test_association_rights(document)">\
   % if is_collaborative(document):
-    userCtrl.auth.isAuthenticated()
-    && userCtrl.auth.isModerator()
+    userCtrl.auth.isAuthenticated() && userCtrl.auth.isModerator()
   % elif is_personal(document):
     userCtrl.hasEditRights(
         '${get_doc_type(document['type'])}',

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
+from c2corg_ui.templates.utils import get_lang_lists, has_associations
 from json import dumps
 %>
 
@@ -115,14 +115,14 @@ from json import dumps
   ## ASSOCIATIONS
   % if not version:
   <div class="view-details-associations col-xs-12 associations"
-       % if not check_if_any_associations(image):
-          ng-if="userCtrl.hasEditRights( 'images', { 'imageType': '${image['image_type']}', 'imageCreator': ${image['creator']['user_id']} })"
-       % endif
-    >
+    % if not has_associations(image):
+       ng-if="userCtrl.hasEditRights('images', {'imageType': '${image['image_type']}', 'imageCreator': ${image['creator']['user_id']}})"
+    % endif
+  >
     <span class="lead">
       <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()
         % if image['image_type'] == 'personal':
-            && userCtrl.hasEditRights('images', {'imageType': 'personal', 'imageCreator': ${image['creator']['user_id']} })
+          && userCtrl.hasEditRights('images', {'imageType': 'personal', 'imageCreator': ${image['creator']['user_id']}})
         % endif
       ">
         <label translate>Add association</label>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists
+from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
 from json import dumps
 %>
 
@@ -114,9 +114,17 @@ from json import dumps
 
   ## ASSOCIATIONS
   % if not version:
-  <div class="view-details-associations col-xs-12 associations">
+  <div class="view-details-associations col-xs-12 associations"
+       % if not check_if_any_associations(image):
+          ng-if="userCtrl.hasEditRights( 'images', { 'imageType': '${image['image_type']}', 'imageCreator': ${image['creator']['user_id']} })"
+       % endif
+    >
     <span class="lead">
-      <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+      <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()
+        % if image['image_type'] == 'personal':
+            && userCtrl.hasEditRights('images', {'imageType': 'personal', 'imageCreator': ${image['creator']['user_id']} })
+        % endif
+      ">
         <label translate>Add association</label>
         <app-add-association parent-doctype="images" parent-id="${image_id}" dataset="wrcb"></app-add-association>
       </div>
@@ -135,7 +143,7 @@ from json import dumps
   ## OTHER BUTTON contents
     ${show_other_langs_links('images', image, other_langs)}
     ${show_missing_langs_links('images', image, missing_langs)}
-    ${show_float_buttons(image['associations']['users'], 'images', image_id, lang, other_langs, missing_langs, image)}
+    ${show_float_buttons(image, lang, other_langs, missing_langs)}
   % endif
 </section>
 

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -127,7 +127,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   % if not version:
   <div class="view-details-associations col-xs-12  associations">
     <span class="lead">
-      <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+      <div ng-show="userCtrl.auth.isAuthenticated() && userCtrl.hasEditRights('outings', ${ {"users": dumps(outing['associations']['users']) }})">
         <label translate>Add association</label>
         <app-add-association parent-doctype="outings" parent-id="${outing_id}" dataset="r"></app-add-association>
       </div>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
+from c2corg_ui.templates.utils import get_lang_lists, has_associations
 from json import dumps
 %>
 
@@ -125,13 +125,13 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   ## ASSOCIATIONS
   % if not version:
-  <div class="view-details-associations col-xs-12  associations"
-       % if not check_if_any_associations(outing):
-            ng-if="userCtrl.hasEditRights('outings', ${ {'users': dumps(outing['associations']['users']) } } )"
-       % endif
-      >
+  <div class="view-details-associations col-xs-12 associations"
+     % if not has_associations(outing):
+       ng-if="userCtrl.hasEditRights('outings', {'users': ${dumps(outing['associations']['users'])}})"
+     % endif
+  >
     <span class="lead">
-      <div ng-show="userCtrl.auth.isAuthenticated() && userCtrl.hasEditRights('outings', ${ {'users': dumps(outing['associations']['users']) } })">
+      <div ng-show="userCtrl.auth.isAuthenticated() && userCtrl.hasEditRights('outings', {'users': ${dumps(outing['associations']['users'])}})">
         <label translate>Add association</label>
         <app-add-association parent-doctype="outings" parent-id="${outing_id}" dataset="r"></app-add-association>
       </div>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -1,6 +1,6 @@
 <%!
 from c2corg_common.attributes import activities, image_categories, image_types
-from c2corg_ui.templates.utils import get_lang_lists
+from c2corg_ui.templates.utils import get_lang_lists, check_if_any_associations
 from json import dumps
 %>
 
@@ -125,9 +125,13 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   ## ASSOCIATIONS
   % if not version:
-  <div class="view-details-associations col-xs-12  associations">
+  <div class="view-details-associations col-xs-12  associations"
+       % if not check_if_any_associations(outing):
+            ng-if="userCtrl.hasEditRights('outings', ${ {'users': dumps(outing['associations']['users']) } } )"
+       % endif
+      >
     <span class="lead">
-      <div ng-show="userCtrl.auth.isAuthenticated() && userCtrl.hasEditRights('outings', ${ {"users": dumps(outing['associations']['users']) }})">
+      <div ng-show="userCtrl.auth.isAuthenticated() && userCtrl.hasEditRights('outings', ${ {'users': dumps(outing['associations']['users']) } })">
         <label translate>Add association</label>
         <app-add-association parent-doctype="outings" parent-id="${outing_id}" dataset="r"></app-add-association>
       </div>
@@ -143,7 +147,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
   ## OTHER BUTTON contents
     ${show_other_langs_links('outings', outing, other_langs)}
     ${show_missing_langs_links('outings', outing, missing_langs)}
-    ${show_float_buttons(outing['associations']['users'], 'outings', outing_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(outing, lang, other_langs, missing_langs)}
   % endif
 </section>
 

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -174,7 +174,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   ## OTHER BUTTON contents
     ${show_other_langs_links('routes', route, other_langs)}
     ${show_missing_langs_links('routes', route, missing_langs)}
-    ${show_float_buttons(None, 'routes', route_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(route, lang, other_langs, missing_langs)}
   % endif
 
 </section>

--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -75,10 +75,10 @@ def get_doc_type(type):
         return 'xreports'
 
 
-def check_if_any_associations(doc):
+def has_associations(doc):
     a = doc['associations']
 
-    if a.get('xreports') or a.get('books') or a.get('routes') or \
-       a.get('all_routes') or a.get('waypoints') or a.get('recent_outings') \
-       or a.get('outings') or a.get('articles') or a.get('waypoints_children'):
-            return True
+    return a.get('waypoints') or a.get('waypoints_children') or \
+        a.get('all_routes') or a.get('routes') or \
+        a.get('recent_outings') or a.get('outings') or \
+        a.get('articles') or a.get('xreports') or a.get('books')

--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -26,3 +26,59 @@ def get_attr(obj, key, md=True, bb=True):
         attr = sanitize(attr)
         attr = parse_code(attr, md, bb) if md or bb else attr
     return attr
+
+
+def is_collaborative(doc):
+    type = doc['type']
+
+    if type == 'r' or type == 'w' or type == 'a' or type == 'b':
+        return True
+    elif type == 'c':
+        return doc['article_type'] == 'collab'
+    elif type == 'i':
+        return doc['image_type'] == 'collaborative'
+
+    return False
+
+
+def is_personal(doc):
+    doctype = doc['type']
+
+    if doctype == 'o' or doctype == 'u' or doctype == 'x':
+        return True
+    elif doctype == 'c':
+        return doc['article_type'] == 'personal'
+    elif doctype == 'i':
+        return doc['image_type'] == 'personal'
+
+    return False
+
+
+def get_doc_type(type):
+    if type == 'w':
+        return 'waypoints'
+    if type == 'r':
+        return 'routes'
+    if type == 'o':
+        return 'outings'
+    if type == 'u':
+        return 'users'
+    if type == 'c':
+        return 'articles'
+    if type == 'i':
+        return 'images'
+    if type == 'a':
+        return 'areas'
+    if type == 'b':
+        return 'books'
+    if type == 'x':
+        return 'xreports'
+
+
+def check_if_any_associations(doc):
+    a = doc['associations']
+
+    if a.get('xreports') or a.get('books') or a.get('routes') or \
+       a.get('all_routes') or a.get('waypoints') or a.get('recent_outings') \
+       or a.get('outings') or a.get('articles') or a.get('waypoints_children'):
+            return True

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -181,7 +181,7 @@ geometry4326 = geometry
   % if not version:
     ${show_other_langs_links('waypoints', waypoint, other_langs)}
     ${show_missing_langs_links('waypoints', waypoint, missing_langs)}
-    ${show_float_buttons(None, 'waypoints', waypoint_id, lang, other_langs, missing_langs)}
+    ${show_float_buttons(waypoint, lang, other_langs, missing_langs)}
   % endif
 </section>
 

--- a/c2corg_ui/tests/views/data/article.json
+++ b/c2corg_ui/tests/views/data/article.json
@@ -10,6 +10,10 @@
     "en",
     "de"
   ],
+  "author": {
+    "user_id": 710777,
+    "name": "ginold"
+  },
   "document_id": 716071,
   "article_type": "personal",
   "locales": [

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -500,7 +500,7 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
       }
     }
     .glyphicon-trash {
-      top: 65% !important;
+      .calc(top, "100% - 60px");
     }
   }
   .set-main-waypoint {
@@ -1139,7 +1139,7 @@ ul {
 .glyphicon-trash:not(app-delete-association) {
   position: absolute;
   color: red;
-  font-size: 1.3em;
+  font-size: 1.2em;
   right: 10px;
   top: calc(~"100% - 30px");
 }

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -279,9 +279,6 @@
         flex-grow: 1;
       }
     }
-    .add-association {
-      float: left;
-    }
     .add-outing {
       float: right;
       background: #CACACA;


### PR DESCRIPTION
related to #836

+ hide the association tool if user is not associated to the outing or isn't moderator
+ don't let the user delete an association from a collaborative document, unless he's a moderator

So for example you cannot delete any association from waypoints, routes, books, collaborative articles and collaborative images. Only if you are moderator - it is allowed.

Still few unclear questions: 

+ Outing is a **non collaborative** document - therefore the associated articles could be deleted -> should it be the case? (i think not)
+ If i'm the author or participant of an outing should I be able to delete any associations I want?
+ what about associations in personal/non-collaborative articles and images?
+ others?

please test and tell me if it's going in the right direction! I think it's pretty confusing with all the exceptions we have to handle in the same time in multiple places.

