### PR TITLE
Useless details icon width on mobile

### DIFF
--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -57,6 +57,9 @@
       .title {
         max-width: 70%;
         margin-right: 10px;
+        @media @phone {
+          max-width: none;
+        }
       }
       .icons-header {
         font-size: 1.5em;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -63,7 +63,6 @@
         margin-right: 10px;
         @media @phone {
           margin-right: 5px;
-          width: 150px;
         }
       }
     }


### PR DESCRIPTION
I don't know why this rule exists. Whether when viewing a document or previewing an edit, it produces useless space between icon and title. Simply removing it is IMHO the best options