### PR TITLE
Float icons mobile dropdown

### DIFF
--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,12 +67,8 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div class="modal-body">
-      <div id="preview-container">
-        <div id="preview-container-content"></div>
-      </div>
-    </div>
-    <div class="modal-footer">
+    <div id="preview-container">
+      <div id="preview-container-content"></div>
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,8 +67,12 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div id="preview-container">
-      <div id="preview-container-content"></div>
+    <div class="modal-body">
+      <div id="preview-container">
+        <div id="preview-container-content"></div>
+      </div>
+    </div>
+    <div class="modal-footer">
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/less/floatbuttons.less
+++ b/less/floatbuttons.less
@@ -134,8 +134,8 @@
     margin-top: -55px;
 
     @media @phone{
-      left: unset;
-      top: unset;
+      left: initial;
+      top: initial;
       right: 0;
       bottom: 55px;
       position: absolute;

--- a/less/floatbuttons.less
+++ b/less/floatbuttons.less
@@ -135,7 +135,7 @@
 
     @media @phone{
       left: unset;
-      top: unset
+      top: unset;
       right: 0;
       bottom: 55px;
       position: absolute;

--- a/less/floatbuttons.less
+++ b/less/floatbuttons.less
@@ -134,9 +134,11 @@
     margin-top: -55px;
 
     @media @phone{
-      left: -165px;
+      left: unset;
+      top: unset
+      right: 0;
+      bottom: 55px;
       position: absolute;
-      top: -80px;
     }
   }
 }


### PR DESCRIPTION
Currently position looks a bit strange

![before](https://cloud.githubusercontent.com/assets/2234024/20626491/5d4cf230-b31a-11e6-819a-0ff112a096bd.png)

This PR changes it to the following (never mind the second `versions` item, it was for debugging - also ignore the tooltip, it's not relevant):

![after](https://cloud.githubusercontent.com/assets/2234024/20626489/598579e2-b31a-11e6-981e-5fb6bc2f6252.png)



Note: this is OK only if we always have the plus button on the right.