### PR TITLE
Feed inner items styling

### DIFF
--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,12 +67,8 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div class="modal-body">
-      <div id="preview-container">
-        <div id="preview-container-content"></div>
-      </div>
-    </div>
-    <div class="modal-footer">
+    <div id="preview-container">
+      <div id="preview-container-content"></div>
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,8 +67,12 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div id="preview-container">
-      <div id="preview-container-content"></div>
+    <div class="modal-body">
+      <div id="preview-container">
+        <div id="preview-container-content"></div>
+      </div>
+    </div>
+    <div class="modal-footer">
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/less/feed.less
+++ b/less/feed.less
@@ -19,11 +19,12 @@
   }
   .images {
     height: 150px;
-    margin-bottom: 10px;
-    padding: 5px;
+    margin-bottom: 20px;
+    padding: 10px;
 
     .thumbnail {
       overflow: hidden;
+      border: 2px solid rgba(88, 150, 165, .2);
     }
 
     .image {
@@ -54,7 +55,7 @@
     }
   }
   .list-item {
-    margin-top: 0;
+    margin: 0 10px;
   }
   .feed-list {
     height: 100%;
@@ -79,6 +80,7 @@
     border-radius: 10px;
     width: 40%;
     padding-top: 13px;
+    padding-bottom: 13px;
     transition: .3s;
 
     /*left triangle*/


### PR DESCRIPTION
* same border for images and outings/waypoints/other cards
* add margin around boxes

Before:
![before](https://cloud.githubusercontent.com/assets/2234024/20629866/f5cf0ac6-b32d-11e6-883d-b048541cfcb8.png)
After:
![after](https://cloud.githubusercontent.com/assets/2234024/20629865/f5cd6c20-b32d-11e6-8ee5-5ffe765808a0.png)
