### PR TITLE
Associated data design

### DIFF
--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,12 +67,8 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div class="modal-body">
-      <div id="preview-container">
-        <div id="preview-container-content"></div>
-      </div>
-    </div>
-    <div class="modal-footer">
+    <div id="preview-container">
+      <div id="preview-container-content"></div>
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -67,8 +67,12 @@
 
 <%def name="show_preview_container()">\
   <div class="ng-hide">
-    <div id="preview-container">
-      <div id="preview-container-content"></div>
+    <div class="modal-body">
+      <div id="preview-container">
+        <div id="preview-container-content"></div>
+      </div>
+    </div>
+    <div class="modal-footer">
       <button class="btn btn-warning" type="button" ng-click="previewModalCtrl.close()" translate>Close</button>
     </div>
   </div>

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -325,8 +325,6 @@
     .associated-documents {
       max-height: 600px;
       overflow-y: auto;
-      border: 1px solid #eee;
-      padding-bottom: 10px;
       margin-bottom: 5px;
     }
   }


### PR DESCRIPTION
References #966 

Now, with simple inner card and scrollable content:
![after](https://cloud.githubusercontent.com/assets/2234024/20640312/66572fc4-b3da-11e6-9791-1b9332265461.png)

(and of course, collapses nicely now)
