### PR TITLE
Fix participants list when previewing a new outing

### DIFF
--- a/c2corg_ui/templates/outing/helpers/view.html
+++ b/c2corg_ui/templates/outing/helpers/view.html
@@ -139,7 +139,7 @@
   % endif
 </%def>
 
-<%def name="get_outing_participants(outing)">\
+<%def name="get_outing_participants(outing, preview=False)">\
   % if outing.get('participant_count') or outing['locales'][0].get('participants') or outing['associations']['users']:
     <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
       <h4><span translate>participants</span><span class="glyphicon glyphicon-menu-right"></span></h4>
@@ -156,11 +156,17 @@
           <p>
             % for user in outing['associations']['users']:
               <%
-                  user_id = user['document_id']
-                  user_lang = user['locales'][0]['lang']
                   is_last_participant = loop.last and not outing['locales'][0].get('participants')
               %>
-              <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
+              % if preview:
+                <a>${user['name']}</a>${'' if is_last_participant else ', '}
+              % else:
+                <%
+                    user_id = user['document_id']
+                    user_lang = user['locales'][0]['lang']
+                %>
+                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
+              % endif
             % endfor
             ${outing['locales'][0].get('participants') or ''}
           </p>

--- a/c2corg_ui/templates/outing/preview.html
+++ b/c2corg_ui/templates/outing/preview.html
@@ -32,7 +32,7 @@ ${show_preview_warning()}
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_outing_general(outing)}
-      ${get_outing_participants(outing)}
+      ${get_outing_participants(outing, True)}
       ${get_outing_heights(outing)}
       ${get_outing_access(outing)}
       ${get_outing_snow(outing)}


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/992#issuecomment-263082396

When creating a new outing, the creator's data are only partial => only the ``document_id`` and ``name``. But no ``locales``, with the ``lang`` attribute used in ``get_outing_participants`` to forge a link towards the user profiles.

To avoid this problem I have removed the user profile links when previewing the document, which will also prevent users from clicking on them... and lose the outing they were about to save (OK there is the same problem if the user has added links in their comments...). On the other hand it would help make sure the associated users are the good ones, by right clicking on the link to open the profile in another tab, but then again it's quite risky. Perhaps when an autosave system will be available?