### PR TITLE
Do not show field access_period when editing a climbing_outdoor waypoint

### DIFF
--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -747,7 +747,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             </div>
 
             ## ACCESS PERIOD
-            <div id="access-period" class="form-group data full" ng-if="['access', 'local_product', 'hut', 'gite', 'camp_site', 'climbing_outdoor'].indexOf(type) > -1">
+            <div id="access-period" class="form-group data full" ng-if="['access', 'local_product', 'hut', 'gite', 'camp_site'].indexOf(type) > -1">
               <label translate ng-if="type == 'access'">access_period</label>
               <label translate ng-if="type == 'hut' || type == 'gite' || type == 'camp_site'">opening_periods</label>
               <label translate ng-if="type == 'local_product'">opening_hours</label>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/705#issuecomment-261408302

> in WP/site, the field after "Accès" should have a title in edition mode, and the title in display mode should be changed with a new Transifex label (access_period is used with another sense)

Actually climbing_outdoor WP already have a ``best_periods`` attribute (a list of checkboxes with months). Then a text-field for ``access_period`` is redundant => this PR makes sure it is not shown for climbing_outdoor WP.
Nothing to do in the detail view page: if not set, the attribute is not displayed.