### PR TITLE
add padding to discourse comments + fix cut sidemenu tooltips

### DIFF
--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -14,7 +14,6 @@
   height: 100%;
   font-size: 1em;
   transition: 0.3s;
-  overflow-y: auto;
 
   @media (max-width: @tablet-max) {
     width: @menu-width-tablet;
@@ -48,6 +47,8 @@
   }
 
   @media (max-height: 400px){
+    overflow-y: auto;
+
     ul li {
       font-size: 0.9em;
       >a{

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -574,11 +574,12 @@
 
     #discourse-comments {
       text-align: center;
+      padding: 20px;
+      background-color: #fbfaf6;
 
       .no-thread {
         display: inline-block;
         background: #CACACA;
-        margin: 10px;
         padding: .5%;
         color: white;
         border-radius: 5px;


### PR DESCRIPTION
Adds a little padding around the comments and hides the iframe with glichy discourse menu when no comments.
![screenshot from 2016-11-29 12-26-14](https://cloud.githubusercontent.com/assets/7814311/20708330/aa18b99c-b62f-11e6-85d8-a0d8696bb83d.png)
