### PR TITLE
Hide overflowing text in map search

### DIFF
--- a/less/map.less
+++ b/less/map.less
@@ -102,6 +102,7 @@ app-map-search {
       background-clip: padding-box; /* for IE9+, Firefox 4+, Opera, Chrome */
       padding-left: 5px !important;
       white-space: pre;
+      overflow: hidden;
       .flex();
 
       &:extend(.dropdown-menu > li > a);


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1019

![c2corg-map-search-overflow](https://cloud.githubusercontent.com/assets/266474/20766719/c4afd160-b737-11e6-8e25-e4d9d25241e5.png)
