### PR TITLE
Add a route creation button in waypoint detail views

### DIFF
--- a/c2corg_ui/static/js/documentediting.js
+++ b/c2corg_ui/static/js/documentediting.js
@@ -78,12 +78,6 @@ app.DocumentEditingController = function($scope, $element, $attrs, $http,
   this.documentService = appDocument;
 
   /**
-   * @type {ngeo.Location}
-   * @private
-   */
-  this.ngeoLocation_ = ngeoLocation;
-
-  /**
    * @type {string}
    * @private
    */

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -9,9 +9,10 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.AccountController');
-goog.require('app.OutingEditingController');
 goog.require('app.ImageEditingController');
+goog.require('app.OutingEditingController');
 goog.require('app.OutingFiltersController');
+goog.require('app.RouteEditingController');
 goog.require('app.addAssociationDirective');
 goog.require('app.advancedSearchDirective');
 goog.require('app.alertsDirective');

--- a/c2corg_ui/static/js/outingediting.js
+++ b/c2corg_ui/static/js/outingediting.js
@@ -69,15 +69,15 @@ app.OutingEditingController = function($scope, $element, $attrs, $http,
    */
   this.differentDates;
 
-  // allow association only for a new outing to existing route
-  if (ngeoLocation.hasFragmentParam('r')) {
-    var routeId = parseInt(ngeoLocation.getFragmentParam('r'), 10);
-    appApi.getDocumentByIdAndDoctype(routeId, 'r', appLang.getLang()).then(function(doc) {
-      this.documentService.pushToAssociations(doc.data['routes'].documents[0], 'routes', true);
-    }.bind(this));
-  }
-
   if (this.auth.isAuthenticated()) {
+    // allow association only for a new outing to existing route
+    if (ngeoLocation.hasFragmentParam('r')) {
+      var routeId = parseInt(ngeoLocation.getFragmentParam('r'), 10);
+      appApi.getDocumentByIdAndDoctype(routeId, 'r', appLang.getLang()).then(function(doc) {
+        this.documentService.pushToAssociations(doc.data['routes'].documents[0], 'routes', true);
+      }.bind(this));
+    }
+
     this.scope[this.modelName]['associations']['users'].push({
       'document_id': this.auth.userData.id,
       'name': this.auth.userData.name

--- a/c2corg_ui/static/js/routeediting.js
+++ b/c2corg_ui/static/js/routeediting.js
@@ -1,0 +1,52 @@
+goog.provide('app.RouteEditingController');
+
+goog.require('app');
+goog.require('app.DocumentEditingController');
+goog.require('app.Alerts');
+goog.require('app.Document');
+goog.require('app.Lang');
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.Attributes} $attrs Attributes.
+ * @param {angular.$http} $http
+ * @param {Object} $uibModal modal from angular bootstrap.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {app.Lang} appLang Lang service.
+ * @param {app.Authentication} appAuthentication
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {app.Alerts} appAlerts
+ * @param {app.Api} appApi Api service.
+ * @param {string} authUrl Base URL of the authentication page.
+ * @param {app.Document} appDocument
+ * @param {app.Url} appUrl URL service.
+ * @param {!string} imageUrl URL to the image backend.
+ * @constructor
+ * @extends {app.DocumentEditingController}
+ * @ngInject
+ * @export
+ */
+app.RouteEditingController = function($scope, $element, $attrs, $http,
+    $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+    appApi, authUrl, appDocument, appUrl, imageUrl) {
+
+  goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
+    appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
+    appDocument, appUrl, imageUrl);
+
+  if (this.auth.isAuthenticated()) {
+    // allow association only for a new route to existing waypoint
+    if (ngeoLocation.hasFragmentParam('w')) {
+      var waypointId = parseInt(ngeoLocation.getFragmentParam('w'), 10);
+      appApi.getDocumentByIdAndDoctype(waypointId, 'w', appLang.getLang()).then(function(doc) {
+        this.documentService.pushToAssociations(doc.data['waypoints'].documents[0], 'waypoints', true);
+      }.bind(this));
+    }
+  }
+};
+goog.inherits(app.RouteEditingController, app.DocumentEditingController);
+
+
+app.module.controller('appRouteEditingController', app.RouteEditingController);

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -251,7 +251,11 @@
     associations += 'all_routes.documents' if type == 'all_routes' else 'routes'
   %>
     ${add_seo_association_links(routes, 'routes')}
-    <section ng-show="${associations}.length > 0">
+    <section
+      % if document['doctype'] != 'waypoints':
+        ng-show="${associations}.length > 0"
+      % endif
+    >
       <h3 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#associated-routes">
         <span class="glyphicon glyphicon-map-marker"></span>
         <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
@@ -274,6 +278,14 @@
           %>
           <div class="list-item vertical-align" onclick="window.location='${request.route_path('routes_index')}#${fragment}';">
             <button class="gray-btn btn show-more" translate>show more</button>
+          </div>
+        % endif
+        % if document['doctype'] == 'waypoints':
+          <div class="list-item vertical-align" protected-url-btn
+               url="${request.route_path('routes_add') + '#w=' + str(document['document_id'])}">
+            <a>
+              <button class="btn orange-btn" translate>add a new route to this waypoint</button>
+            </a>
           </div>
         % endif
       </div>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -24,7 +24,7 @@ updating_doc = route_id and route_lang
   <h1 ng-cloak ng-init="id=${route_id if route_id else 0}" ng-bind="id ? ('Editing a route' | translate) : ('Creating a route' | translate)" class="text-center"></h1>
 
   <form app-loading app-document-editing="routes" app-document-editing-model="route"
-    app-document-editing-controller-name="appDocumentEditingController"
+    app-document-editing-controller-name="appRouteEditingController"
   % if updating_doc:
     app-document-editing-id="${route_id}" app-document-editing-lang="${route_lang}"
   % endif

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -142,7 +142,7 @@ geometry4326 = geometry
 
   ## ASSOCIATIONS
   % if not version:
-    <div class="view-details-associations col-xs-12  associations">
+    <div class="view-details-associations col-xs-12 associations">
       <span class="lead">
         <section>
           <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
@@ -154,7 +154,7 @@ geometry4326 = geometry
         </section>
       </span>
     </div>
-    <div class="view-details-associations col-xs-12  associations" ng-if="detailsCtrl.documentService.document.associations.all_routes.total > 0">
+    <div class="view-details-associations col-xs-12 associations">
       <span class="lead">
         <section>
           ${show_associated_routes(waypoint, 'all_routes')}

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -162,17 +162,17 @@ geometry4326 = geometry
       </span>
     </div>
 
-    % if 'recent_outings' in waypoint['associations'] and waypoint['associations']['recent_outings']['total'] > 0:
-      <div class="view-details-associations col-xs-12  associations">
-        <span class="lead">
-          <section>
-            ${show_associated_articles(waypoint)}
-            ${show_associated_books(waypoint)}
-            ${show_associated_outings(waypoint)}
-          </section>
-        </span>
-      </div>
-    % endif
+    <div class="view-details-associations col-xs-12 associations"
+         ng-init="associations = detailsCtrl.documentService.document.associations"
+         ng-show="associations.recent_outings.total || associations.articles.length || associations.books.length">
+      <span class="lead">
+        <section>
+          ${show_associated_articles(waypoint)}
+          ${show_associated_books(waypoint)}
+          ${show_associated_outings(waypoint)}
+        </section>
+      </span>
+    </div>
   % endif
 
   ${get_comments()}

--- a/c2corg_ui/tests/views/data/waypoint.json
+++ b/c2corg_ui/tests/views/data/waypoint.json
@@ -53,6 +53,7 @@
 			"available_langs": ["fr"]
 		}],
 		"images": [],
+		"books": [],
 		"all_routes": {
 			"total": 0,
 			"documents": []


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/198 and https://github.com/c2corg/v6_ui/issues/945

For waypoint detail view pages (not other pages that have an associated-routes section):
* the associated-routes section is always visible, even though there is no associated route yet
* an "add a route to this WP" button is added at the end of the associated routes list
* when the button is clicked, the route addition form is open with the source WP already associated

![sans titre](https://cloud.githubusercontent.com/assets/1192331/20806672/2a09b5ac-b7fc-11e6-865d-9c9a1a229542.png)
![sans titre2](https://cloud.githubusercontent.com/assets/1192331/20806673/2a1b5f78-b7fc-11e6-961e-7696d3afa864.png)

No change for other document types.
