### PR TITLE
Show username in account form

### DIFF
--- a/c2corg_ui/templates/account.html
+++ b/c2corg_ui/templates/account.html
@@ -7,6 +7,12 @@
     <div ng-controller="appAccountController as accountCtrl">
       <h1 translate>Change account parameters</h1>
       <form name="accountForm" novalidate ng-submit="accountCtrl.save()">
+
+        <div class="form-group">
+          <label translate>Username</label>
+          <input type="text" ng-value="userCtrl.auth.userData.username" class="form-control" disabled />
+        </div>
+
         <div id="account-currentpassword-group" class="form-group" ng-class="{ 'has-error': accountForm.currentpassword.$invalid }">
           <label translate>Current password</label>
           <input type="password" minlength="3" name="currentpassword" ng-model="account.currentpassword" class="form-control" required />


### PR DESCRIPTION
Many people in the association are confused because of all those names (username, name, forum_username), the changes done in forum_usernames, the fact that v6 no longer accepts the whatever-the-case username as login (as in v5).

The username is available in the user menu in the page header but:
* it might change in the future, see https://github.com/c2corg/v6_ui/issues/889
* using small caps does not help figuring out what is the case of the username

Having the username reminded in the account form (as in v5) would greatly help:
![sans titre](https://cloud.githubusercontent.com/assets/1192331/20808231/1d9ba4f0-b802-11e6-8286-69fbccc0c217.png)
