### PR TITLE
Make sure slug redirects use the current scheme

### DIFF
--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -353,12 +353,15 @@ class Document(object):
             key_v1, key_v2, caching.CACHE_VERSION)
 
     def _redirect(self, id, lang, slug=None, is_lang_set=False):
+        scheme = self.request.scheme
         if slug is None:
-            location = self.request.route_path(
-                self._API_ROUTE + '_view_id_lang', id=id, lang=lang)
+            location = self.request.route_url(
+                self._API_ROUTE + '_view_id_lang',
+                id=id, lang=lang, _scheme=scheme)
         else:
-            location = self.request.route_path(
-                self._API_ROUTE + '_view', id=id, lang=lang, slug=slug)
+            location = self.request.route_url(
+                self._API_ROUTE + '_view',
+                id=id, lang=lang, slug=slug, _scheme=scheme)
         if is_lang_set:
             raise HTTPMovedPermanently(location=location)
         else:


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/981

It works with my localhost (in http - at least ``scheme`` is correctly detected) but I have no https instance for testing. I wonder if it is possible to write some unit tests for this? 