### PR TITLE
Add missing translation for height_diff

### DIFF
--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -440,3 +440,4 @@
 ## misc
 <span translate>see more results</span>
 <span translate>Associated waypoint_children</span>
+<span translate>height_diff</span>


### PR DESCRIPTION
``height_diff`` is not translated in route and outing detail views (OK in editing because the editing use 2 distinct attributes for diff up and diff down).

In fact it uses a pretty special helper that concatenates the up and down attributes using the base of the attribute name.

See https://github.com/c2corg/v6_ui/blob/c23e0402fa84a3250855e6d09aa7333988ae2c30/c2corg_ui/templates/outing/helpers/view.html#L198
https://github.com/c2corg/v6_ui/blob/f349f2c0bed61d6ea09a5809e6f5cf84ef3d16ab/c2corg_ui/templates/route/helpers/view.html#L164
https://github.com/c2corg/v6_ui/blob/7977d467f561002ceb318cc92e9fc8935f983646/c2corg_ui/templates/helpers/view.html#L534