### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_install:
   fi
 
 install:
+- jdk_switcher use openjdk8
+- java -version
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 - npm -version
 - make -f config/travis .build/dev-requirements.timestamp


### PR DESCRIPTION
Because of a problem with the Travis container Java was no longer available (see https://github.com/travis-ci/travis-ci/issues/6959).