### PR TITLE
Add list of followed users

### DIFF
--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -150,6 +150,7 @@ def main(global_config, **settings):
     config.add_route('account', '/account')
     config.add_route('preferences', '/preferences')
     config.add_route('mailinglists', '/mailinglists')
+    config.add_route('following', '/following')
 
     config.add_route('sitemap_index', '/sitemap.xml')
     config.add_route('sitemap', '/sitemaps/{doc_type:[a-z]{1}}/{i:\d+}.xml')

--- a/c2corg_ui/externs/appx.js
+++ b/c2corg_ui/externs/appx.js
@@ -85,12 +85,10 @@ appx.AlertMessage;
 appx.auth.RequestChangePassword;
 
 
-// TODO: extern for users + add it to associations
-
 /**
  * @typedef {{
  *   images: Array.<appx.Image>,
- *   users: ?Array.<Object>,
+ *   users: ?Array.<appx.User>,
  *   routes: ?Array.<appx.Route>,
  *   waypoints: ?Array.<appx.Waypoint>,
  *   waypoint_children: ?Array.<appx.Waypoint>,
@@ -105,7 +103,7 @@ appx.DocumentAssociations;
  * @typedef {{
  *   associations: appx.DocumentAssociations,
  *   locales: Array.<Object>,
- *   type : string,
+ *   type: string,
  *   quality: string,
  *   document_id: number
  * }}
@@ -117,7 +115,7 @@ appx.Document;
  * @typedef {{
  *   associations: appx.DocumentAssociations,
  *   locales: Array.<Object>,
- *   type : string,
+ *   type: string,
  *   quality: string,
  *   document_id: number,
  *
@@ -154,7 +152,7 @@ appx.Outing;
  * @typedef {{
  *   associations: appx.DocumentAssociations,
  *   locales: Array.<Object>,
- *   type : string,
+ *   type: string,
  *   quality: string,
  *   document_id: number,
  *
@@ -209,7 +207,7 @@ appx.Route;
  * @typedef {{
  *   associations: appx.DocumentAssociations,
  *   locales: Array.<Object>,
- *   type : string,
+ *   type: string,
  *   quality: string,
  *   document_id: number,
  *
@@ -265,8 +263,8 @@ appx.Waypoint;
  * @typedef {{
  *   associations: appx.DocumentAssociations,
  *   locales: Array.<Object>,
- *   type : string,
- *   document_id:number
+ *   type: string,
+ *   document_id: number
  * }}
  */
 appx.Image;
@@ -275,13 +273,29 @@ appx.Image;
 /**
  * @typedef {{
  *   locales: Array.<Object>,
- *   type : string,
+ *   type: string,
  *   area_type: string,
  *   quality: string,
- *   document_id:number
+ *   document_id: number
  * }}
  */
 appx.Area;
+
+
+/**
+ * @typedef {{
+ *   document_id: number,
+ *   type: string,
+ *   locales: Array.<Object>,
+ *   name: string,
+ *   forum_username: string,
+ *   areas: Array.<appx.Area>,
+ *   activities: Array.<string>,
+ *   categories: Array.<string>,
+ *   available_langs: Array.<string>
+ * }}
+ */
+appx.User;
 
 
 /**

--- a/c2corg_ui/static/js/following.js
+++ b/c2corg_ui/static/js/following.js
@@ -1,0 +1,107 @@
+goog.provide('app.FollowingController');
+goog.provide('app.followingDirective');
+
+goog.require('app');
+goog.require('app.Api');
+goog.require('app.Authentication');
+goog.require('app.utils');
+
+
+/**
+ * Directive managing the list of followed users.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.followingDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'appFollowingController',
+    controllerAs: 'flCtrl'
+  };
+};
+
+
+app.module.directive('appFollowing', app.followingDirective);
+
+/**
+ * @param {app.Authentication} appAuthentication
+ * @param {app.Api} appApi Api service.
+ * @param {string} authUrl Base URL of the authentication page.
+ * @constructor
+ * @ngInject
+ * @export
+ */
+app.FollowingController = function(appAuthentication, appApi, authUrl) {
+
+  /**
+   * @type {app.Api}
+   * @private
+   */
+  this.api_ = appApi;
+
+  /**
+   * @type {app.Authentication}
+   * @private
+   */
+  this.auth_ = appAuthentication;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.following = null;
+
+  /**
+   * @type {Array.<number>}
+   * @export
+   */
+  this.followingIds = [];
+
+  if (this.auth_.isAuthenticated()) {
+    this.api_.getFollowing().then(function(response) {
+      this.following = response['data']['following'];
+      this.followingIds = this.following.map(function(user) {
+        return user.document_id;
+      });
+    }.bind(this));
+  } else {
+    app.utils.redirectToLogin(authUrl);
+  }
+};
+
+
+/**
+ * @param {number} id Id of user to toggle.
+ * @export
+ */
+app.FollowingController.prototype.toggle = function(id) {
+  if (this.followingIds.indexOf(id) > -1) {
+    this.api_.unfollow(id).then(function(response) {
+      this.followingIds = this.followingIds.filter(function(i) {
+        return i != id;
+      });
+    }.bind(this));
+  } else {
+    this.api_.follow(id).then(function(response) {
+      this.followingIds.push(id);
+    }.bind(this));
+  }
+};
+
+
+/**
+ * @param {appx.User} user
+ * @export
+ */
+app.FollowingController.prototype.addUser = function(user) {
+  var id = user.document_id;
+  if (this.auth_.userData.id !== id) {
+    this.api_.follow(id).then(function(response) {
+      this.followingIds.push(id);
+      this.following.push(user);
+    }.bind(this));
+  }
+};
+
+
+app.module.controller('appFollowingController', app.FollowingController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -24,6 +24,7 @@ goog.require('app.diffMapDirective');
 goog.require('app.documentEditingDirective');
 goog.require('app.feedDirective');
 goog.require('app.followDirective');
+goog.require('app.followingDirective');
 goog.require('app.geolocationDirective');
 goog.require('app.gpxUploadDirective');
 goog.require('app.imageUploaderDirective');

--- a/c2corg_ui/static/js/urlservice.js
+++ b/c2corg_ui/static/js/urlservice.js
@@ -39,9 +39,8 @@ app.Url = function(slug) {
 app.Url.prototype.buildDocumentUrl = function(documentType, documentId, locale, lang) {
   lang = lang || locale['lang'];
 
-  if (documentType === 'profiles') {
-    return '/{type}/{id}/{lang}'
-    .replace('{type}', documentType)
+  if (documentType === 'profiles' || documentType === 'users') {
+    return '/profiles/{id}/{lang}'
     .replace('{id}', String(documentId))
     .replace('{lang}', lang);
   }

--- a/c2corg_ui/static/partials/cards/users.html
+++ b/c2corg_ui/static/partials/cards/users.html
@@ -1,0 +1,3 @@
+<a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
+  <span class="list-item-title">{{::doc.name}}</span>
+</a>

--- a/c2corg_ui/static/partials/user.html
+++ b/c2corg_ui/static/partials/user.html
@@ -14,6 +14,7 @@
     <li><a translate ng-href="/profiles/{{userCtrl.auth.userData.id}}">My profile</a></li>
     <li><a translate href="/account">My account</a></li>
     <li><a translate href="/preferences">My preferences</a></li>
+    <li><a translate href="/following">My followed users</a></li>
     <li><a translate href="/mailinglists">My mailing lists</a></li>
     <li><a translate ng-click="userCtrl.logout()" class="logout">Logout</a></li>
   </ul>

--- a/c2corg_ui/templates/following.html
+++ b/c2corg_ui/templates/following.html
@@ -1,0 +1,26 @@
+<%!
+from c2corg_common.attributes import mailinglists
+%>
+<%inherit file="base.html"/>
+<%namespace file="helpers/common.html" import="show_title"/>
+<%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Followed users')">${show_title('Followed users')}</title></%block>
+<%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
+
+<div class="following" app-loading>
+  <section app-following>
+    <h3 class="green-text" translate>Followed users</h3>
+    <p translate>Here is the list of users you are following and whose activity you will see in your personal feed.</p>
+    <app-simple-search app-select="flCtrl.addUser(doc)" dataset="u"></app-simple-search>
+    <div class="flex wrap-row areas" ng-show="flCtrl.following.length > 0">
+      <div class="list-item users" ng-repeat="user in flCtrl.following">
+        <app-card app-card-doc="user"></app-card>
+        <button class="btn orange-btn" ng-click="flCtrl.toggle(user.document_id)"
+                ng-show="flCtrl.followingIds.indexOf(user.document_id) > -1"
+                translate>Unfollow</button>
+        <button class="btn btn-success" ng-click="flCtrl.toggle(user.document_id)"
+                ng-hide="flCtrl.followingIds.indexOf(user.document_id) > -1"
+                translate>Follow</button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -47,6 +47,11 @@ class Pages(object):
         return self._get_page(
             'mailinglists', 'c2corg_ui:templates/mailinglists.html')
 
+    @view_config(route_name='following')
+    def following(self):
+        return self._get_page(
+            'following', 'c2corg_ui:templates/following.html')
+
     def _get_page(self, page_key, template, no_etag=False):
         return get_or_create_page(
             page_key,

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -447,7 +447,6 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
     }
   }/*list-item-info*/
 
-
   .waypoint-type {
     font-size: 1.5em;
     color: @C2C-orange;
@@ -539,6 +538,23 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   &.highlight a .list-item-title {
     color: teal;
     transition: 0.1s ease-in-out;
+  }
+  &.users {
+    margin-left: 3px;
+    margin-right: 3px;
+    @media @big {
+      width: 24%;
+    }
+    @media @desktop {
+      width: 32%;
+    }
+    @media @tablet {
+      width: 49%;
+    }
+    button {
+      float: right;
+      margin: 5px;
+    }
   }
 } /* list-item*/
 
@@ -934,7 +950,7 @@ app-alerts {
   }
 }
 
-.auth-form, .preferences, .mailinglists {
+.auth-form, .preferences, .mailinglists, .following {
   padding: 0 10% 0 10%;
   margin-top: 100px;
   margin-bottom: 20px;
@@ -1185,9 +1201,28 @@ ul {
   }
 }
 
-.preferences, .mailinglists {
+.preferences, .mailinglists, .following {
   h3 {
     margin: 15px 0;
+  }
+}
+
+.preferences, .following {
+  app-simple-search {
+    width: 50%;
+    margin-bottom: 10px;
+
+    .search {
+      width: 100% !important;
+    }
+  }
+  @media @phone {
+    app-simple-search {
+      width: 100%;
+    }
+    .list-item {
+      flex-basis: 100% !important;
+    }
   }
 }
 
@@ -1214,21 +1249,7 @@ ul {
     flex-basis: 33%;
     margin-right: 10px;
   }
-  app-simple-search {
-    width: 50%;
-    margin-bottom: 10px;
-
-    .search {
-      width: 100% !important;
-    }
-  }
   @media @phone {
-    app-simple-search {
-      width: 100%;
-    }
-    .list-item {
-      flex-basis: 100% !important;
-    }
     .route-activity {
       font-size: 4em;
     }


### PR DESCRIPTION
Close https://github.com/c2corg/v6_ui/issues/1013

<img width="1075" alt="capture d ecran 2016-12-04 a 01 02 34" src="https://cloud.githubusercontent.com/assets/1192331/20863039/c97bef48-b9bd-11e6-86c7-0ffceead4b56.png">

The list of cards is initially fed using the API ``users/following`` service. It is possible to add new followed users using the search tool. When clicking an "unfollow" button, the user card remains but the button is switched to "follow".

~~Perhaps a small bug to solve: even though the cards have ``app-card-disable-click="true"``, clicking on a user card sometimes reacts and opened a link that does not exist with ``undefined`` in it.~~ => I have finally made the card clickable, opening the user's profile.

Btw a question: we now have many templates (``account.html``, ``preferences.html``, etc.) and routes (``/account``, ``/preferences``, etc.) at the root of templates and URLs. Should we move them in a ``users`` directory (ie. ``users/account.html`` and ``/users/account``, etc.)? 