### PR TITLE
Fix assoc. card links problems with title / title-prefix for route

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -165,7 +165,11 @@
       % for doc in documents:
         <%
             locale = doc['locales'][0]
-            title = locale['title_prefix'] + ' : ' if doctype == 'routes' and locale['title_prefix'] is not None else ''
+            if 'title' in locale:
+                title = locale['title_prefix'] + ' : ' if doctype == 'routes' and locale['title_prefix'] is not None else ''
+            else:
+                locale['title_prefix'] = ''
+                locale['title'] = ''
             title += locale['title']
             slug = get_slug(locale, is_route=doctype == 'routes')
         %>


### PR DESCRIPTION
Now documents where associated routes miss `title/title_prefix` are visible and broken routes can be easily identified. It is not possible to view detail of route this route (201889) because it requires adjusting many things on UI to see it. It is probably better to fix them in DB than using UI.

Close https://github.com/c2corg/v6_ui/issues/1099