### PR TITLE
Show article author/participants on the view page

### DIFF
--- a/c2corg_ui/templates/article/helpers/view.html
+++ b/c2corg_ui/templates/article/helpers/view.html
@@ -31,7 +31,7 @@
       <p><span class="value-title" translate>article_type</span>: <span class="value" x-translate>${article['article_type']}</span></p>
     % endif
 
-    % if article.get('author') and article['article_type'] != 'collab':
+    % if article.get('author') and article['article_type'] != 'collab' and article['author']['user_id'] != article['associations']['users'][0]['document_id']:
       <%
           user_id = article['author']['user_id']
           user_lang = article['locales'][0]['lang']
@@ -48,8 +48,8 @@
 </div>
 </%def>
 
-<%def name="get_article_participants(article)">\
-  % if article.get('participant_count') or article['locales'][0].get('participants') or article['associations']['users']:
+<%def name="get_article_associated_users(article)">\
+  % if article['associations']['users']:
     % if len(article['associations']['users']) > 1 or not article['associations']['users'][0]['document_id'] == article['author']['user_id']:
       <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
         <h4><span translate>associated users</span><span class="glyphicon glyphicon-menu-right"></span></h4>
@@ -64,11 +64,10 @@
                 <%
                     user_id = user['document_id']
                     user_lang = user['locales'][0]['lang']
-                    is_last_participant = loop.last and not article['locales'][0].get('participants')
+                    is_last_associated_user = loop.last
                 %>
-                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
+                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_associated_user else ', '}
               % endfor
-              ${article['locales'][0].get('participants') or ''}
             </p>
           % endif
 

--- a/c2corg_ui/templates/article/helpers/view.html
+++ b/c2corg_ui/templates/article/helpers/view.html
@@ -31,7 +31,7 @@
       <p><span class="value-title" translate>article_type</span>: <span class="value" x-translate>${article['article_type']}</span></p>
     % endif
 
-    % if article.get('author'):
+    % if article.get('author') and article['article_type'] != 'collab':
       <%
           user_id = article['author']['user_id']
           user_lang = article['locales'][0]['lang']
@@ -50,28 +50,30 @@
 
 <%def name="get_article_participants(article)">\
   % if article.get('participant_count') or article['locales'][0].get('participants') or article['associations']['users']:
-    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
-      <h4><span translate>participants</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-      <div class="name-icon">
-        <span class="icon-user"></span>
-        <p translate>participants</p>
-      </div>
-      <span class="detail-text accordion">
-        % if article.get('associations').get('users'):
-          <p>
-            % for user in article['associations']['users']:
-              <%
-                  user_id = user['document_id']
-                  user_lang = user['locales'][0]['lang']
-                  is_last_participant = loop.last and not article['locales'][0].get('participants')
-              %>
-              <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
-            % endfor
-            ${article['locales'][0].get('participants') or ''}
-          </p>
-        % endif
+    % if len(article['associations']['users']) > 1 or not article['associations']['users'][0]['document_id'] == article['author']['user_id']:
+      <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+        <h4><span translate>associated users</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+        <div class="name-icon">
+          <span class="icon-user"></span>
+          <p translate>associated users</p>
+        </div>
+        <span class="detail-text accordion">
+          % if article.get('associations').get('users'):
+            <p>
+              % for user in article['associations']['users']:
+                <%
+                    user_id = user['document_id']
+                    user_lang = user['locales'][0]['lang']
+                    is_last_participant = loop.last and not article['locales'][0].get('participants')
+                %>
+                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
+              % endfor
+              ${article['locales'][0].get('participants') or ''}
+            </p>
+          % endif
 
-      </span>
-    </div>
+        </span>
+      </div>
+    % endif
   % endif
 </%def>

--- a/c2corg_ui/templates/article/helpers/view.html
+++ b/c2corg_ui/templates/article/helpers/view.html
@@ -31,6 +31,15 @@
       <p><span class="value-title" translate>article_type</span>: <span class="value" x-translate>${article['article_type']}</span></p>
     % endif
 
+    % if article.get('author'):
+      <%
+          user_id = article['author']['user_id']
+          user_lang = article['locales'][0]['lang']
+      %>
+      <p><span class="value-title" translate>author</span>:
+        <a class="value" href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}" >${article['author']['name']}</a>
+    % endif
+
     % if article.get('quality'):
       <p><span class="value-title" translate>quality</span>: <span class="value" x-translate>${article['quality']}</span></p>
     % endif

--- a/c2corg_ui/templates/article/helpers/view.html
+++ b/c2corg_ui/templates/article/helpers/view.html
@@ -47,3 +47,31 @@
     </span>
 </div>
 </%def>
+
+<%def name="get_article_participants(article)">\
+  % if article.get('participant_count') or article['locales'][0].get('participants') or article['associations']['users']:
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>participants</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="icon-user"></span>
+        <p translate>participants</p>
+      </div>
+      <span class="detail-text accordion">
+        % if article.get('associations').get('users'):
+          <p>
+            % for user in article['associations']['users']:
+              <%
+                  user_id = user['document_id']
+                  user_lang = user['locales'][0]['lang']
+                  is_last_participant = loop.last and not article['locales'][0].get('participants')
+              %>
+              <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_participant else ', '}
+            % endfor
+            ${article['locales'][0].get('participants') or ''}
+          </p>
+        % endif
+
+      </span>
+    </div>
+  % endif
+</%def>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -11,7 +11,7 @@ from json import dumps
   show_associated_waypoints, show_associated_outings, show_associated_routes,
   show_associated_articles, show_associated_books,
   delete_association_confirmation_modal, associated_images_featurelist, show_badge, get_licence"/>
-<%namespace file="helpers/view.html" import="get_article_general"/>
+<%namespace file="helpers/view.html" import="get_article_general, get_article_participants"/>
 
 <%
 article_id = article['document_id']
@@ -66,6 +66,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_article_general(article)}
+      ${get_article_participants(article)}
       ${get_licence(article)}
     </section>
   </div>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -11,7 +11,7 @@ from json import dumps
   show_associated_waypoints, show_associated_outings, show_associated_routes,
   show_associated_articles, show_associated_books,
   delete_association_confirmation_modal, associated_images_featurelist, show_badge, get_licence"/>
-<%namespace file="helpers/view.html" import="get_article_general, get_article_participants"/>
+<%namespace file="helpers/view.html" import="get_article_general, get_article_associated_users"/>
 
 <%
 article_id = article['document_id']
@@ -66,7 +66,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
     </h3>
     <section id="document-informations" class="collapse in">
       ${get_article_general(article)}
-      ${get_article_participants(article)}
+      ${get_article_associated_users(article)}
       ${get_licence(article)}
     </section>
   </div>


### PR DESCRIPTION
On API of articles, we have author field. I think it is useful to show it directly in information window so that user can quickly know who is the origin author/owner of copyrights (and he can get to his page with more similar articles) without making an additional request on the history of the current document.

I am not sure about participants field -
In articles, there are sometimes more participants (f.e. here API http://localhost:6548/articles/147444 UI http://localhost:6558/articles/147444/fr/l-esprit-des-fetes-par-jean-pierre-banville) and it can be also useful to list them on the view page. But when there is only one author (and the same person as associated user), it can be redundant to show both fields.

![image](https://cloud.githubusercontent.com/assets/6165660/20923505/0a81daa2-bbad-11e6-983b-f5d099a1f415.png)

I am not sure if adding new user associations to articles should be possible only on creation or editing or not at all. I think we miss both cases now and NO association user-article is now not created when an article is created.