### PR TITLE
"No result" buttons in simple search suggestions

### DIFF
--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -295,10 +295,11 @@ app.SimpleSearchController.prototype.createDataset_ = function(type) {
  * @private
  */
 app.SimpleSearchController.prototype.createAndInitBloodhound_ = function(type) {
+  var limit = 7;
   var url = this.apiUrl_ + '/search?q=%QUERY';
 
   var bloodhound = new Bloodhound(/** @type {BloodhoundOptions} */({
-    limit: 7,
+    limit: limit,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     datumTokenizer: Bloodhound.tokenizers.obj.whitespace('label'),
     remote: {
@@ -308,6 +309,7 @@ app.SimpleSearchController.prototype.createAndInitBloodhound_ = function(type) {
       prepare: (function(query, settings) {
 
         var url = settings['url'] + '&pl=' + this.gettextCatalog_.currentLanguage;
+        url += '&limit=' + limit;
 
         if (this.datasetLimit_) {
           // add the Auth header if searching for users

--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -252,7 +252,8 @@ app.SimpleSearchController.prototype.createDataset_ = function(type) {
     templates: {
       header: (function() {
         var typeUpperCase = type.charAt(0).toUpperCase() + type.substr(1);
-        return '<div class="header" dataset="' + type + '">' +  this.gettextCatalog_.getString(typeUpperCase) + '</div>';
+        return '<div class="header" dataset="' + type + '">' +
+          this.gettextCatalog_.getString(typeUpperCase) + '</div>';
       }).bind(this),
       footer: function(doc) {
         if (!this.associationContext_) {
@@ -267,14 +268,20 @@ app.SimpleSearchController.prototype.createDataset_ = function(type) {
       suggestion: function(doc) {
         if (doc) {
           this.scope_['doc'] = doc;
-          return this.compile_('<app-suggestion class="tt-suggestion"></app-suggestion>')(this.scope_);
+          return this.compile_(
+            '<app-suggestion class="tt-suggestion"></app-suggestion>'
+          )(this.scope_);
         } else {
           return '<div class="ng-hide"></div>';
         }
       }.bind(this),
       empty: function(res) {
         if ($('.header.empty').length === 0) {
-          return this.compile_(this.templatecache_.get('/static/partials/suggestions/empty.html'))(this.scope_);
+          var partialFile = this.associationContext_ ? 'empty' : 'create';
+          return this.compile_(
+            this.templatecache_.get(
+              '/static/partials/suggestions/' + partialFile + '.html')
+          )(this.scope_);
         }
       }.bind(this)
     }

--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -2,6 +2,7 @@ goog.provide('app.SimpleSearchController');
 goog.provide('app.simpleSearchDirective');
 
 goog.require('app');
+goog.require('app.utils');
 goog.require('app.Document');
 goog.require('app.Url');
 /** @suppress {extraRequire} */
@@ -278,10 +279,10 @@ app.SimpleSearchController.prototype.createDataset_ = function(type) {
       empty: function(res) {
         if ($('.header.empty').length === 0) {
           var partialFile = this.associationContext_ ? 'empty' : 'create';
-          return this.compile_(
-            this.templatecache_.get(
-              '/static/partials/suggestions/' + partialFile + '.html')
-          )(this.scope_);
+          var template = app.utils.getTemplate(
+              '/static/partials/suggestions/' + partialFile + '.html',
+              this.templatecache_);
+          return this.compile_(template)(this.scope_);
         }
       }.bind(this)
     }

--- a/c2corg_ui/static/partials/suggestions/create.html
+++ b/c2corg_ui/static/partials/suggestions/create.html
@@ -1,0 +1,5 @@
+<div class="header empty" translate>No match?</div>
+<p class="tt-suggestion" protected-url-btn url="/waypoints/add"><span class="suggestion-text" translate>Create a new waypoint</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
+<p class="tt-suggestion" protected-url-btn url="/routes/add"><span class="suggestion-text" translate>Create a new route</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
+<p class="tt-suggestion" protected-url-btn url="/articles/add"><span class="suggestion-text" translate>Create a new article</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
+<p class="tt-suggestion" protected-url-btn url="/books/add"><span class="suggestion-text" translate>Create a new book</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>

--- a/c2corg_ui/static/partials/suggestions/empty.html
+++ b/c2corg_ui/static/partials/suggestions/empty.html
@@ -1,6 +1,5 @@
-<div class="header empty" translate>No results</div>
+<div class="header empty" translate>No match?</div>
 <p class="tt-suggestion" protected-url-btn url="/waypoints/add"><span class="suggestion-text" translate>Create a new waypoint</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
 <p class="tt-suggestion" protected-url-btn url="/routes/add"><span class="suggestion-text" translate>Create a new route</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
-<p class="tt-suggestion" protected-url-btn url="/outings/add"><span class="suggestion-text" translate>Create a new outing</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
 <p class="tt-suggestion" protected-url-btn url="/articles/add"><span class="suggestion-text" translate>Create a new article</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
 <p class="tt-suggestion" protected-url-btn url="/books/add"><span class="suggestion-text" translate>Create a new book</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>

--- a/c2corg_ui/static/partials/suggestions/empty.html
+++ b/c2corg_ui/static/partials/suggestions/empty.html
@@ -1,5 +1,1 @@
-<div class="header empty" translate>No match?</div>
-<p class="tt-suggestion" protected-url-btn url="/waypoints/add"><span class="suggestion-text" translate>Create a new waypoint</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
-<p class="tt-suggestion" protected-url-btn url="/routes/add"><span class="suggestion-text" translate>Create a new route</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
-<p class="tt-suggestion" protected-url-btn url="/articles/add"><span class="suggestion-text" translate>Create a new article</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
-<p class="tt-suggestion" protected-url-btn url="/books/add"><span class="suggestion-text" translate>Create a new book</span><span class="glyphicon glyphicon-plus-sign text-right"></span></p>
+<div class="empty" translate>No results</div>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/849

* [x] No need for outings and xreports creation buttons in simple search
* [x] "empty" title is renamed to "No match?" (because it appears also when there are results). Remains "no results" in association context to at least gives a feedback (see next point).
* [x] Show creation buttons only in the simple search context, not in an association context. This would make sense but would require much more work and we don't have time before golive.
* [ ] Article results should appear before the "no match?" section.

The last point is still open. I have not figure out why articles appear AFTER the "no match" section:
<img width="650" alt="capture d ecran 2016-12-03 a 17 31 40" src="https://cloud.githubusercontent.com/assets/1192331/20860693/94b5f324-b97e-11e6-81e2-ab0d32a1d0fd.png">

Anyone has a tip?