### PR TITLE
Resize too big images before uploading them

### DIFF
--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -387,6 +387,23 @@ app.ImageUploaderController.prototype.selectOption = function(object, property, 
 };
 
 
+/**
+ * @param {Object} file
+ * @param {number} width Width of uploaded image.
+ * @param {number} height Height of uploaded image.
+ * @return {boolean}
+ * @export
+ */
+app.ImageUploaderController.prototype.resizeIf = function(
+    file, width, height) {
+  if (file.type === 'image/jpeg' || file.type === 'image/png') {
+    return file.size > 2 * 1024 * 1024 /** 2 MB */ ||
+      width > 4096 || height > 2048;
+  }
+  return false;
+};
+
+
 app.module.controller('AppImageUploaderController', app.ImageUploaderController);
 
 

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -153,52 +153,6 @@ app.ImageUploaderController = function($scope, $uibModal, $compile, $q, appAlert
 
 
 /**
- * We have to use a secondary controller for the modal so that we can inject
- * uibModalInstance which is not available from the first level controller.
- * @param {Object} $uibModalInstance modal from angular bootstrap
- * @constructor
- * @ngInject
- * @returns {app.ImageUploaderModalController}
- */
-app.ImageUploaderModalController = function($scope, $uibModalInstance) {
-
-  /**
-   * @type {!angular.Scope}
-   * @private
-   */
-  this.scope_ = $scope;
-
-  /**
-   * @type {Object} $uibModalInstance angular bootstrap
-   * @private
-   */
-  this.modalInstance_ = $uibModalInstance;
-
-  $scope.$on('modal.closing', function(event, reason, closed) {
-    this.scope_['uplCtrl'].abortAllUploads();
-  }.bind(this));
-};
-
-
-/**
- * @export
- */
-app.ImageUploaderModalController.prototype.close = function() {
-  this.modalInstance_.close();
-};
-
-
-/**
- * @export
- */
-app.ImageUploaderModalController.prototype.save = function() {
-  this.scope_['uplCtrl'].save().then(function() {
-    this.modalInstance_.close();
-  }.bind(this));
-};
-
-
-/**
  * @private
  */
 app.ImageUploaderController.prototype.upload_ = function() {
@@ -434,4 +388,52 @@ app.ImageUploaderController.prototype.selectOption = function(object, property, 
 
 
 app.module.controller('AppImageUploaderController', app.ImageUploaderController);
+
+
+/**
+ * We have to use a secondary controller for the modal so that we can inject
+ * uibModalInstance which is not available from the first level controller.
+ * @param {Object} $uibModalInstance modal from angular bootstrap
+ * @constructor
+ * @ngInject
+ * @returns {app.ImageUploaderModalController}
+ */
+app.ImageUploaderModalController = function($scope, $uibModalInstance) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {Object} $uibModalInstance angular bootstrap
+   * @private
+   */
+  this.modalInstance_ = $uibModalInstance;
+
+  $scope.$on('modal.closing', function(event, reason, closed) {
+    this.scope_['uplCtrl'].abortAllUploads();
+  }.bind(this));
+};
+
+
+/**
+ * @export
+ */
+app.ImageUploaderModalController.prototype.close = function() {
+  this.modalInstance_.close();
+};
+
+
+/**
+ * @export
+ */
+app.ImageUploaderModalController.prototype.save = function() {
+  this.scope_['uplCtrl'].save().then(function() {
+    this.modalInstance_.close();
+  }.bind(this));
+};
+
+
 app.module.controller('AppImageUploaderModalController', app.ImageUploaderModalController);

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -8,6 +8,8 @@
        ngf-keep="'distinct'"
        ngf-fix-orientation="true"
        ngf-allow-dir="true"
+       ngf-resize-if="uplCtrl.resizeIf($file, $width, $height)"
+       ngf-resize="{width: 4096, height: 2048, quality: 1.0}"
        accept="image/*"
        ngf-pattern="'image/*'">
     <span translate>Drop images here or click to upload</span>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jquery": "2.2.4",
     "less": "2.7.1",
     "less-plugin-clean-css": "1.5.1",
-    "ng-file-upload": "12.0.4",
+    "ng-file-upload": "12.2.13",
     "ngeo": "git://github.com/camptocamp/ngeo#1db20a5",
     "nomnom": "1.8.1",
     "openlayers": "3.19.1",


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1046

In v5, client-side resizing is managed at https://github.com/c2corg/camptocamp.org/blob/72e777075f2e6260b1d2ef563ab0f90c383038ba/web/static/js/plupload.wrapper.js#L135-L144

* png and jpg images <2M will get resized only if they exceed c2c limits (8192x2048)
* images >2M will be resized to max 4096x1024
* svg and gifs won't be resized anyway

I have not fully succeeded in completing such a complicated pattern but the current PR at least adds the support of a simpler condition that might be already quite enough (at least as a first version?). Perhaps the resized dimensions should be confirmed. @lbesson @fbunoz @mgerbaux what do you think? See a962e23

It seems possible to pass as ``ngf-resize`` a function "returning a promise which resolves into the options" (see https://github.com/danialfarid/ng-file-upload#file-select-and-drop) that could probably be used to switch among resized dimensions depending on the file size but I have not figured out how to write such a promise function. Here is a piece of code that could be used as base:
```
/**
 * @param {Object} file
 * @return {Object}
 * @export
 */
app.ImageUploaderController.prototype.resizeOptions = function(file) {
  if (file.size > app.ImageUploaderController.MAX_IMAGE_SIZE) {
    return {'width': 4096, 'height': 1024, 'quality': 1.0};
  } else {
    return {'width': 8192, 'height': 2048, 'quality': 1.0};
  }
};
```
See also https://github.com/danialfarid/ng-file-upload/blob/052ea1942dfbe5cb9cb14b2caeb35fec15c3040d/src/model.js#L82-L99