### PR TITLE
Disable history function in slideshow

### DIFF
--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -228,7 +228,8 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
           var pageYScroll = window.pageYOffset || document.documentElement.scrollTop;
           var rect = thumbnail.getBoundingClientRect();
           return {x: rect.left, y: rect.top + pageYScroll, w: rect.width};
-        }
+        },
+        history: false
       };
       // exit if index not found
       if (isNaN(options.index)) {


### PR DESCRIPTION
[PhotoSwipe](http://photoswipe.com/documentation/options.html) has a history function, that is it changes the URL for example to `/#&gid=1&pid=1`. The idea is that you share this URL and the slideshow will open with the right image.

Which is a good idea, but it does not work right now and it creates the problem described in https://github.com/c2corg/v6_ui/issues/1117 in build mode. I am proposing to disable the history function for now. 

Closes https://github.com/c2corg/v6_ui/issues/1117