### PR TITLE
Layout columns

### DIFF
--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -93,6 +93,12 @@ app.CardController = function(gettextCatalog, appUrl, imageUrl) {
   this.doc;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.remainingActivities = false;
+
+  /**
    * @type {string}
    * @public
    */
@@ -131,7 +137,7 @@ app.CardController.prototype.translate = function(str) {
 app.CardController.prototype.createURL = function() {
   var loc = window.location.pathname;
   // Don't create links on edit and add pages.
-  if (loc.indexOf('edit') === -1 && loc.indexOf('add') === -1) {
+  if (loc.indexOf('/edit/') === -1 && loc.indexOf('/add/') === -1) {
     return this.url_.buildDocumentUrl(
       this.type, this.doc['document_id'], this.doc['locales'][0]);
   }

--- a/c2corg_ui/static/partials/cards/areas.html
+++ b/c2corg_ui/static/partials/cards/areas.html
@@ -1,10 +1,14 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title">{{::locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-  <br>
-  <div class="list-item-info flex baseline-align">
+  <div class="list-item-info">
+
+    <div class="list-item-title-lang">
+      <span class="list-item-title">{{::locale.title}}</span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    </div>
+
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
          uib-tooltip="{{'quality' | translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
-    {{::doc['area_type'] | translate}}
+    <span class="area-type">{{::doc['area_type'] | translate}}</span>
+
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/articles.html
+++ b/c2corg_ui/static/partials/cards/articles.html
@@ -1,21 +1,35 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="list-item-info">
 
-    <span class="list-item-title">{{::locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-    <div class="value">{{::doc['article_type'] | translate }}</div>
+    <div class="list-item-title-lang">
+      <span class="list-item-title">{{::locale.title}}</span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    </div>
+
+    <b class="article-type margin-t-sm margin-b-sm"><span class="green-text glyphicon glyphicon-tag margin-r-sm"></span>{{::doc['article_type']| translate }}</b>
 
     <div class="article-categories">
-      <span ng-repeat="category in ::doc.categories" class="value">{{::category | translate }}{{$last ? '' : ', '}}</span>
+      <b ng-repeat="category in ::doc.categories" class="value">{{::category | translate }}{{$last ? '' : ', '}}</b>
     </div>
 
-    <div class="article-activities">
-      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
+    <div class="activities flex wrap-row margin-t-sm">
+      <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
+            uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+
+      <span class="flex flexend-align show-more-activities"
+            ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
+            ng-click="$event.preventDefault(); cardCtrl.remainingActivities = true">
+        ...(+ {{::doc.activities.length - 4}})
+      </span>
+
+      <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
+            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+      </span>
     </div>
 
-    <br>
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+    </div>
+
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/books.html
+++ b/c2corg_ui/static/partials/cards/books.html
@@ -1,20 +1,27 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="list-item-info">
 
-    <span class="list-item-title">{{::locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-    <span ng-if="::doc['author']" class="value">{{::doc['author']}}</span>
-
-    <div class="article-categories">
-      <span ng-repeat="book_type in ::doc['book_types']" class="value">{{::book_type | translate }}{{$last ? '' : ', '}}</span>
+    <div class="list-item-title-lang">
+      <span class="list-item-title">{{::locale.title}}</span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <div class="book-activities">
-      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity) }}"></span>
+    <div class="article-categories">
+      <span ng-repeat="book_type in ::doc['book_types']" class="value book-type">{{::book_type | translate }}{{$last ? '' : ', '}}</span>
+    </div>
+
+    <div class="activities">
+      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
+            uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
          uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+
+    <div class="author margin-t-sm" ng-if="::doc['author']">
+      <span class="glyphicon glyphicon-pencil"></span>
+      <span ng-if="::doc['author']" class="value">{{::doc['author']}}</span>
+    </div>
+
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/images.html
+++ b/c2corg_ui/static/partials/cards/images.html
@@ -1,16 +1,15 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <img ng-src="{{cardCtrl.createImg()}}" alt="{{::locale['title']}}">
+  <div class="image margin-b-sm"
+       style="background-image: url({{cardCtrl.createImg()}});" ng-style="{'height': !locale.title ? '100%' : '150px'}"></div>
   <div class="list-item-info">
+
+    <div class="list-item-title-lang" ng-if="locale.title">
+      <span class="list-item-title"><p translate>{{::locale.title}}</p></span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    </div>
+
     <div class="outing-date">{{ ::doc['date_time'] | date: 'dd/MM/yyyy'}}</div>
     <div ng-if="doc['author']"><span class="value-title" translate>author</span>: <span class="value">{{::doc['author']}}</span></div>
 
-    <span class="list-item-title">{{::locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-    <br>
-
-    <div class="route-activities">
-      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity)}}" tooltip-placement="top"></span>
-    </div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -7,14 +7,14 @@
     </div>
 
     <div class="flex wrap-row">
+      <span class="date margin-r-sm">
+        <span class="value-title glyphicon glyphicon-time"></span>
+        <span class="value">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</span>
+      </span>
+
       <span class="elevation" ng-if="::doc.elevation_max" uib-tooltip="{{'elevation_max' | translate}}">
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
-      </span>
-
-      <span class="date">
-        <span class="value-title glyphicon glyphicon-time"></span>
-        <span class="value">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</span>
       </span>
     </div>
 
@@ -24,7 +24,7 @@
     </div>
 
     <div class="outing-author flex baseline-align" ng-if="!feed">
-      <span class="glyphicon glyphicon-user"></span>
+      <span class="icon-user"></span>
       <span class="author-name">{{::doc['author']['name']}}</span>
     </div>
 

--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -1,26 +1,36 @@
-<a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <div class="outing-author text-center">
-    <div class="outing-date">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</div>
-    <span class="icon-user"></span><br>
-    <b class="author-name">{{::doc['author']['name']}}</b>
-  </div>
+<a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;" class="flex">
+
   <div class="list-item-info">
-
-    <span class="list-item-title">{{::locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-    <br>
-    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+    <div class="list-item-title-lang margin-b-sm">
+      <span class="list-item-title"><p>{{::locale.title}}</p></span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <span class="elevation-max"  uib-tooltip="{{'elevation_max' | translate}}">
-      <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
-      <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
-    </span>
+    <div class="flex wrap-row">
+      <span class="elevation" ng-if="::doc.elevation_max" uib-tooltip="{{'elevation_max' | translate}}">
+        <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
+      </span>
 
-    <div class="route-activities">
-      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}"
-            uib-tooltip="{{ ::cardCtrl.translate(activity) }}"></span>
+      <span class="date">
+        <span class="value-title glyphicon glyphicon-time"></span>
+        <span class="value">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</span>
+      </span>
+    </div>
+
+    <div class="activities">
+      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
+            uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
+    </div>
+
+    <div class="outing-author flex baseline-align" ng-if="!feed">
+      <span class="glyphicon glyphicon-user"></span>
+      <span class="author-name">{{::doc['author']['name']}}</span>
+    </div>
+
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality' | translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
     </div>
   </div>
+
 </a>

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -1,10 +1,13 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title"><span ng-if="::locale.title_prefix">{{::locale.title_prefix}}&nbsp;: </span>{{::locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-  <br>
   <div class="list-item-info">
+
+    <div class="list-item-title-lang">
+      <span class="list-item-title"><p><span ng-if="::locale.title_prefix">{{::locale.title_prefix}}&nbsp;: </span>{{::locale.title}}</p></span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    </div>
+
     <div class="flex wrap-row">
-      <span class="elevation-max" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
+      <span class="elevation-max margin-r-sm" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
@@ -28,22 +31,23 @@
       </div>
     </div>
 
-    <div class="global-rating flex flexend-align" ng-init="globalRatings = cardCtrl.getGlobalRatings()" ng-show="::globalRatings">
+    <div class="global-rating flex flexend-align margin-b-sm" ng-init="globalRatings = cardCtrl.getGlobalRatings()" ng-show="::globalRatings">
       <span class="icon-rating"></span>
       <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr | translate}}" ng-if="::val">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
-    <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()">
+    <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()" ng-if="fullRatings">
       <span class="icon-rating"></span>
       <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr | translate}}" class="rating">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
-    <div class="route-activities">
-      <span ng-repeat="activity in ::doc.activities" class="route-activity icon-{{::activity}}" uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
+    <div class="activities">
+      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}" uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
     </div>
+
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/users.html
+++ b/c2corg_ui/static/partials/cards/users.html
@@ -1,3 +1,6 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title">{{::doc.name}}</span>
+  <div class="list-item-info text-center">
+    <span class="icon-user margin-b-sm"></span>
+    <span class="list-item-title">{{::doc.name}}</span>
+  </div>
 </a>

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -1,16 +1,18 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <span class="list-item-title">{{::locale.title}}</span>
-  <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-  <br>
 
-  <div class="list-item-info flex baseline-align">
+  <div class="list-item-info">
+    <div class="list-item-title-lang">
+      <span class="list-item-title"><p>{{::locale.title}}</p></span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+    </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
 
-    <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type"
-          uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type']) }}"></span>
-    <p ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}}&nbsp;m</span></p>
+    <div class="waypoint-type-elevation">
+      <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type" uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type'])}}"></span>
+      <span ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}}&nbsp;m</span></span>
+    </div>
   </div>
 
 </a>

--- a/c2corg_ui/static/partials/cards/xreports.html
+++ b/c2corg_ui/static/partials/cards/xreports.html
@@ -1,23 +1,36 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="list-item-info">
 
-    <span class="list-item-title">{{::locale.title}}</span>
-    <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
-
-    <div class="categories">
-      <span class="value" ng-repeat="type in doc['event_type']">{{type | translate }}{{$last ? '' : ', '}}</span>
+    <div class="list-item-title-lang">
+      <span class="list-item-title">{{::locale.title}}</span>
+      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <div class="value" ng-if="::doc['date']">{{::doc['date'] | amDateFormat:'Do MMMM YYYY' }}</div>
-    <div class="value" ng-if="::doc['elevation']">{{::doc['elevation']}} m</div>
+    <div class="categories margin-t-sm margin-b-sm">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      <b class="value" ng-repeat="type in doc['event_type']">{{type | translate}}{{$last ? '' : ', '}}</b>
+    </div>
+
+    <div class="flex wrap-row">
+      <span class="elevation">
+        <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span class="value" ng-if="::doc['elevation']">{{::doc['elevation']}}&nbsp;m</span>
+      </span>
+
+      <span class="date">
+        <span class="value-title glyphicon glyphicon-time"></span>
+        <span class="value" ng-if="::doc['date']">{{::doc['date'] | date: 'dd/MM/yyyy'}}</span>
+      </span>
+    </div>
 
     <div class="activities">
-      <span ng-repeat="activity in doc.activities" class="route-activity icon-{{activity}}"
+      <span ng-repeat="activity in doc.activities" class="activity icon-{{activity}}"
             uib-tooltip="{{ ::cardCtrl.translate(activity) }}"></span>
     </div>
 
-    <br>
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+    </div>
+
   </div>
 </a>

--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -39,7 +39,6 @@
         <b><a ng-href="/profiles/{{::doc['user']['document_id']}}/{{::doc['user']['locales'][0]['lang']}}">{{::doc['user']['name']}}</a></b>
         {{feedCtrl.createActionLine(doc) | translate}}
       </span>
-      <br>
       <span class="action date">
         <span class=" glyphicon glyphicon-time"></span>
         <span>{{::doc.time | amUtc | amLocal | amTimeAgo }}</span>
@@ -61,7 +60,7 @@
       </a>
     </div>
 
-    <div class="list-item {{::type}}s">
+    <div class="list-item {{::type}}s" ng-init="feed = true">
       <app-card app-card-doc="::doc['document']"></app-card>
     </div>
   </article>

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -6,12 +6,12 @@
   <section ng-show="${model}.associations.${type}.length > 0" class="associated-section">
     <label translate>Associated waypoints</label>
     <article class="associated-documents">
-      <div class="list-item"
+      <div class="list-item waypoints ${'to-route' if model == 'route' else ''}"
            ng-repeat="wp in ${model}.associations.${type} | orderBy: 'waypoint_type'"
            ng-class="{'main-waypoint': ${model}.main_waypoint_id === wp.document_id, 'new-item': wp['new']}">
         <app-card app-card-doc="wp" app-card-disable-click="true"></app-card>
         % if model == 'route':
-          <div class="set-main-waypoint" ng-if="${model}.main_waypoint_id === wp.document_id" ng-init="${model}.main_waypoint_title = wp.locales[0].title" translate>main waypoint</div>
+          <b class="set-main-waypoint green-text" ng-if="${model}.main_waypoint_id === wp.document_id" ng-init="${model}.main_waypoint_title = wp.locales[0].title" translate>main waypoint</b>
           <button class="btn btn-sm btn-default set-main-waypoint" translate
                   ng-click="${model}.main_waypoint_id = wp.document_id; ${model}.main_waypoint_title = wp.locales[0].title"
                   ng-if="${model}.main_waypoint_id != wp.document_id">

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -304,7 +304,7 @@
           </div>
         % endif
         % if document['doctype'] == 'waypoints':
-          <div class="list-item vertical-align" protected-url-btn
+          <div class="list-item vertical-align new-route" protected-url-btn
                url="${request.route_path('routes_add') + '#w=' + str(document['document_id'])}">
             <a>
               <button class="btn orange-btn" translate>add a new route to this waypoint</button>
@@ -377,7 +377,7 @@
       </h3>
       <div class="associated-documents collapse in" id="associated-outings">
         % if document['doctype'] == 'routes':
-          <div class="list-item vertical-align" protected-url-btn
+          <div class="list-item vertical-align new-outing" protected-url-btn
                url="${request.route_path('outings_add') + '#r=' + str(document['document_id'])}">
             <a>
               <button class="btn orange-btn" translate>add a new outing to this document</button>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -476,15 +476,8 @@ updating_doc = outing_id and outing_lang
                                    app-select="editCtrl.documentService.pushToAssociations(doc, 'users')" dataset="u"></app-simple-search>
                 <section class="associated-section flex wrap-row">
                   <h5 translate ng-show="outing.associations.users.length == 0">You can look up for users that were with you during the outing.</h5>
-                  <div class="list-item outings new-item" ng-repeat="user in outing.associations.users">
-                    <a>
-                      <div class="outing-author text-center">
-                        <span class="icon-user"></span><br>
-                      </div>
-                      <div class="list-item-info">
-                        <span class="list-item-title outing">{{user.name}}</span>
-                      </div>
-                    </a>
+                  <div class="list-item users new-item" ng-repeat="user in outing.associations.users track by user.name">
+                    <app-card app-card-doc="{'name': user['name'], 'type': 'u', 'locales': [] }"></app-card>
                     <span class="glyphicon glyphicon-trash"
                           ng-click="editCtrl.documentService.removeAssociation(user.document_id, 'users', $event)"
                           ng-show="outing.associations.users.length > 1"></span>

--- a/less/activities.less
+++ b/less/activities.less
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-[class^="route-activity icon-"], .activity>div>div {
+[class^="route-activity icon-"], [class^="activity icon-"], .activity>div>div {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'icomoon' !important;
   speak: none;

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -2,6 +2,7 @@
 @import "../node_modules/bootstrap/less/bootstrap.less";
 @icon-font-path: "bootstrap_fonts/";
 @import "simplesearch.less";
+@import "lists.less";
 @import "diff.less";
 @import "sidemenu.less";
 @import "feed.less";
@@ -315,249 +316,6 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   }
 }
 
-.list {
-  width:100%;
-  padding: 1% 2% 2% 2%;
-  -webkit-column-count: 3;
-  -moz-column-count: 3;
-  column-count: 3;
-
-  @media @tablet {
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
-    column-count: 2;
-  }
-  @media (max-width: @screen-sm-min) {
-    -webkit-column-count: 1;
-    -moz-column-count: 1;
-    column-count: 1;
-    padding-bottom: 50px;
-  }
-  .list-item {
-    -webkit-column-break-inside:avoid;
-    -moz-column-break-inside:avoid;
-    -o-column-break-inside:avoid;
-    -ms-column-break-inside:avoid;
-    column-break-inside:avoid;
-  }
-  & + .no-results {
-    display: none;
-  }
-}
-
-.list-item {
-  position: relative;
-  cursor: pointer;
-  background-color: white;
-  margin-top: 10px;
-  outline: none;
-  border-radius: 7px;
-  min-height: 80px;
-  -moz-border-radius: 7px;
-  -webkit-border-radius: 7px;
-  transition: .2s ease-in-out;
-  border: 2px solid rgba(88, 150, 165, 0.2);
-
-  &:active {
-    -webkit-box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
-    -moz-box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
-    box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
-    -webkit-transition: .2s ease-in-out;
-    transition: 0.2s ease-in-out;
-    outline: none;
-  }
-  &:hover, &.highlight {
-    background-color: #EFEFEF;
-    transition: 0.1s ease-in-out;
-  }
-  @media @tablet {
-    border-width: 1px;
-  }
-  @media @phone {
-    border-width: 1px;
-    font-size: 1.2em;
-  }
-
-  .list-item-title {
-    font-weight: bold;
-    color: graytext;
-    line-height: 5px;
-
-    @media @tablet {
-      font-size: 1em;
-    }
-  }
-
-  .list-item-info {
-    margin: auto;
-    width: 100%;
-    text-decoration: none;
-    color: #919191;
-    font-weight: normal;
-
-    .quality, .orientations {
-      white-space: nowrap;
-      .glyphicon {
-        margin-right: 3px;
-      }
-    }
-    .elevation-max, .height-diff, .height-diff-difficulties, .orientations {
-      margin-right: 8px;
-    }
-    .icon-rating {
-      font-size: 1.4em;
-      margin-left: -2px;
-    }
-    .rating {
-      margin-right: 8px;
-    }
-    .orientations, .height-diff, .height-diff-difficulties, .elevation-max {
-      white-space: nowrap;
-      @media (max-width: @phone-max) {
-        display: none;
-      }
-    }
-    .global-rating {
-      margin-bottom: 5px;
-      @media (min-width: @phone-max) {
-        display: none;
-      }
-    }
-    .full-rating {
-      margin-bottom: 5px;
-      margin-top: 5px;
-      flex-wrap: wrap;
-      .glyphicon {
-        font-size: 1.3em;
-        margin-left: -3px;
-        margin-right: 3px !important;
-      }
-      .value {
-        transition: .2s;
-        &:hover {
-          color: gold;
-        }
-      }
-      @media (max-width: @phone-max) {
-        display: none;
-      }
-    }
-    .glyphicon, [class*="icon-"]:not(.route-activity):not(.waypoint-type) {
-      color: @bright-green;
-    }
-  }/*list-item-info*/
-
-  .waypoint-type {
-    font-size: 1.5em;
-    color: @C2C-orange;
-    margin-right: 5px;
-    margin-top: 5px;
-  }
-  .route-activity {
-    font-size: 3em;
-    color: @C2C-orange;
-    margin-bottom: 10px;
-    @media @phone {
-      font-size: 2.5em;
-    }
-  }
-  /*list-item.*/
-  &.main-waypoint {
-    border: 2px solid @bright-green;
-  }
-  &.images {
-    img {
-      width: 100%;
-    }
-  }
-  &.outings {
-    min-height: 80px;
-    .quality {
-      display: block;
-    }
-    .elevation-max {
-      display: block !important;
-    }
-    a {
-      .flex() !important;
-      height: 100%;
-    }
-    .outing-author, .outing-date {
-      font-size: 0.9em;
-    }
-    .list-item-info {
-      margin-left: 10px;
-    }
-    .outing-author {
-      width: 33%;
-      color: gray;
-      margin-top: auto;
-      margin-bottom: auto;
-
-      .icon-user {
-        font-size: 3em;
-      }
-    }
-    .glyphicon-trash {
-      .calc(top, "100% - 60px");
-    }
-  }
-  .set-main-waypoint {
-    margin: -10px 0 10px 10px;
-  }
-  a {
-    display: block;
-    transition: 0.2s;
-    font-weight: normal;
-    word-wrap: break-word;
-    color: #767676;
-    padding: 10px;
-
-    .list-item-lang {
-      opacity: 0.9;
-      color: graytext;
-      font-weight: normal;
-    }
-
-    &:hover {
-      text-decoration: none;
-    }
-
-    &:hover .list-item-title {
-      color: teal;
-      transition: 0.1s ease-in-out;
-    }
-    &:focus {
-      text-decoration: none;
-      outline: none;
-    }
-    @media @phone {
-      font-size: .8em;
-    }
-  } /*list-item a*/
-  &.highlight a .list-item-title {
-    color: teal;
-    transition: 0.1s ease-in-out;
-  }
-  &.users {
-    margin-left: 3px;
-    margin-right: 3px;
-    @media @big {
-      width: 24%;
-    }
-    @media @desktop {
-      width: 32%;
-    }
-    @media @tablet {
-      width: 49%;
-    }
-    button {
-      float: right;
-      margin: 5px;
-    }
-  }
-} /* list-item*/
-
 .line-separator{
   height:1px;
   background:#717171;
@@ -590,42 +348,6 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
     }
     @media screen and (max-height: 330px) {
       height: 73vh !important;
-    }
-  }
-}
-
-.documents-list-section-container {
-  position: relative;
-  &.no-map .documents-list-section, &.no-map .page-main-title {
-    width: 100%;
-  }
-}
-.documents-list-section, .not-found-section, .map-right .map {
-  margin-top: @page-main-title-height;
-  .calc(height, "100vh - @{page-header-height} - @{page-main-title-height}");
-}
-
-.documents-list-section, .not-found-section {
-  float: left;
-  background-color: @lightgrey;
-  position: relative;
-  width: @list-width;
-  overflow: auto;
-
-  @media @phone {
-    width: 100%;
-    float:none;
-    padding-top: 35px;
-    .calc(height, "100vh - 92px");
-  }
-  .show-documents-filters-phone {
-    display: none;
-    height: 33px;
-    margin-right: 5px;
-    float: right;
-
-    @media @phone {
-      display: block;
     }
   }
 }
@@ -1123,6 +845,19 @@ ul {
     }
     @media @phone {
       width: 100%;
+    }
+
+    &.new-outing a, &.new-route a {
+      .flex();
+      align-items: center;
+    }
+    &.waypoints  {
+      &.to-route {
+        min-height: 115px;
+      }
+      a {
+        height: auto;
+      }
     }
   }
   app-add-association, .associated-section {

--- a/less/feed.less
+++ b/less/feed.less
@@ -84,7 +84,7 @@
     }
     /*left triangle*/
     &:before {
-      border-width: 8px 25px 9px 10px;
+      border-width: 13px 31px 11px 23px;
       border-color: transparent #fbfbfb transparent transparent;
       content: '';
       position: relative;
@@ -143,15 +143,20 @@
       color: #A9D361;
     }
     .action-line {
-      padding-top: 7px;
-      margin-bottom: -4px;
+      padding: 7px 5px 0 5px;
+      margin-bottom: -8px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
     }
     .action {
-      margin-bottom: 5px;
       display: block;
       color: slategray;
       a {
         color: slategray;
+      }
+      b:hover {
+        cursor: pointer;
       }
     }
   }

--- a/less/feed.less
+++ b/less/feed.less
@@ -147,6 +147,8 @@
       margin-bottom: -4px;
     }
     .action {
+      margin-bottom: 5px;
+      display: block;
       color: slategray;
       a {
         color: slategray;

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -332,6 +332,22 @@ p {
   .flex();
 }
 
+.margin-r-sm {
+  margin-right: 5px;
+}
+
+.margin-l-sm {
+  margin-left: 5px;
+}
+
+.margin-t-sm {
+  margin-top: 5px;
+}
+
+.margin-b-sm {
+  margin-bottom: 5px;
+}
+
 .wrap-row {
   flex-flow: wrap row;
 }

--- a/less/homepage.less
+++ b/less/homepage.less
@@ -79,13 +79,13 @@
         width: 100%;
       }
       a {
-        color: @C2C-orange;
         &:hover, &:focus {
           text-decoration: none;
           outline: none;
         }
       }
       .activity {
+        color: @C2C-orange;
         background-color: white;
         border-radius: 50%;
         border: 1px solid #eee;

--- a/less/lists.less
+++ b/less/lists.less
@@ -1,0 +1,377 @@
+
+.list {
+  width:100%;
+  padding: 1% 2% 2% 2%;
+  .flex();
+  justify-content: space-around;
+  flex-flow: wrap row;
+
+  @media @tablet {
+    -webkit-column-count: 2;
+    -moz-column-count: 2;
+    column-count: 2;
+  }
+  @media (max-width: @screen-sm-min) {
+    -webkit-column-count: 1;
+    -moz-column-count: 1;
+    column-count: 1;
+    padding-bottom: 50px;
+  }
+  .list-item {
+    flex-basis: 32%;
+    @media (max-width: 1200px){
+      flex-basis: 48%;
+    }
+    @media (max-width: 730px) {
+      flex-basis: 100%;
+    }
+  }
+  & + .no-results {
+    display: none;
+  }
+}
+
+.list-item {
+  position: relative;
+  cursor: pointer;
+  background-color: white;
+  margin-top: 10px;
+  outline: none;
+  border-radius: 7px;
+  min-height: 90px;
+  -moz-border-radius: 7px;
+  -webkit-border-radius: 7px;
+  transition: .2s ease-in-out;
+  border: 2px solid rgba(88, 150, 165, 0.2);
+
+
+  &:active {
+    -webkit-box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
+    -moz-box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
+    box-shadow: inset 1px 1px 8px -3px rgba(0,0,0,.75);
+    -webkit-transition: .2s ease-in-out;
+    transition: 0.2s ease-in-out;
+    outline: none;
+  }
+  &:hover, &.highlight {
+    background-color: #EFEFEF;
+    transition: 0.1s ease-in-out;
+    cursor: pointer;
+  }
+
+  @media @tablet {
+    border-width: 1px;
+  }
+  @media @phone {
+    border-width: 1px;
+    font-size: 1.2em;
+  }
+
+
+  a {
+    display: block;
+    transition: 0.2s;
+    font-weight: normal;
+    height: 100%;
+    word-wrap: break-word;
+    color: #767676;
+    padding: 10px;
+
+    @media @phone {
+      font-size: .8em;
+      padding: 7px;
+    }
+
+    &:hover .list-item-title {
+      color: teal;
+      transition: 0.1s ease-in-out;
+    }
+
+    &:focus, &:hover {
+      text-decoration: none;
+      outline: none;
+    }
+  } /*list-item a*/
+
+  .list-item-lang {
+    opacity: 0.9;
+    color: graytext;
+    font-weight: normal;
+  }
+
+  .list-item-title {
+    font-weight: bold;
+    color: graytext;
+    font-size: 14px;
+    margin-right: 5px;
+    p {
+      line-height: normal;
+      display: block;
+      margin: 0;
+    }
+  }
+
+  .list-item-title-lang {
+    .flex();
+    align-items: center;
+  }
+
+  .list-item-info {
+    margin: auto;
+    height: 100%;
+    width: 100%;
+    text-decoration: none;
+    color: #919191;
+    font-weight: normal;
+    .flex();
+    flex-direction: column;
+    -webkit-flex-direction: column;
+    justify-content: space-between;
+
+    .quality, .orientations, .date,  .height-diff, .height-diff-difficulties, .elevation {
+      white-space: nowrap;
+      .glyphicon {
+        margin-right: 3px;
+      }
+    }
+    .elevation, .height-diff, .height-diff-difficulties, .orientations {
+      margin-right: 8px;
+    }
+    .icon-rating {
+      font-size: 1.4em;
+      margin-left: -2px;
+    }
+    .rating {
+      margin-right: 8px;
+    }
+    .orientations, .height-diff, .height-diff-difficulties, .elevation {
+      @media (max-width: @phone-max) {
+        display: none;
+      }
+    }
+    .global-rating {
+      @media (min-width: @phone-max) {
+        display: none;
+      }
+    }
+    .full-rating {
+      margin-bottom: 5px;
+      margin-top: 5px;
+      flex-wrap: wrap;
+      .glyphicon {
+        font-size: 1.3em;
+        margin-left: -3px;
+        margin-right: 3px !important;
+      }
+      .value {
+        transition: .2s;
+        &:hover {
+          color: gold;
+        }
+      }
+      @media (max-width: @phone-max) {
+        display: none;
+      }
+    }
+    .glyphicon, [class*="icon-"]:not(.activity):not(.waypoint-type) {
+      color: @bright-green;
+    }
+  }/*list-item-info*/
+  .show-more-activities:hover {
+    color: teal;
+  }
+  .activities .activity {
+    font-size: 3em;
+    color: @C2C-orange;
+    @media @phone {
+      font-size: 2.5em;
+    }
+  }
+  .set-main-waypoint {
+    margin: 0 0 10px 10px;
+  }
+  .outing-author, .article-activities {
+    .calc(width, "100% - 40px");
+  }
+  // .list-item.waypoints
+  &.waypoints {
+    max-height : 100px;
+
+    .waypoint-type {
+      font-size: 2em;
+      color: @C2C-orange;
+      margin-right: 10px;
+    }
+
+    .waypoint-type-elevation {
+      display: inherit;
+      align-items: flex-end;
+    }
+  }
+  // .list-item.routes
+  &.routes .activities {
+    margin-bottom: -5px;
+  }
+  // .list-item.books
+  &.books {
+    .author {
+      line-height: normal;
+      font-size: 13px;
+      .calc(width, "100% - 30px");
+    }
+    .glyphicon-pencil {
+      color: #a9a9a9 !important;
+    }
+    .book-type {
+      color: @bright-green;
+    }
+  }
+  // .list-item.main-waypoint
+  &.main-waypoint {
+    border: 2px solid @bright-green;
+  }
+  // .list-item.images
+  &.images  {
+    min-height: 170px;
+    a {
+      .flex();
+      flex-flow: wrap;
+    }
+    .list-item-info {
+      align-self: flex-start;
+    }
+    .image {
+      width: 100%;
+      height: 150px;
+      background-position: 50% 40%;
+      background-repeat: no-repeat;
+    }
+  }
+  // .list-item.outings
+  &.outings {
+    max-height: inherit;
+
+    .glyphicon-user {
+      padding-right: 5px;
+      float: left;
+      font-size: 19px;
+      color: #b2bcc4 !important;
+    }
+    .activities {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+    .author-name {
+      font-weight: bold;
+    }
+    .glyphicon-time {
+      font-size: 14px;
+    }
+    .list-item-info {
+      margin: inherit;
+    }
+    .outing-author {
+      color: gray;
+
+      .icon-user {
+        font-size: 3em;
+      }
+    }
+    .glyphicon-trash {
+      .calc(top, "100% - 60px");
+    }
+
+    @media @phone {
+      max-height: 115px;
+
+      .list-item-info {
+        padding-left: 25%;
+      }
+      .outing-author {
+        top: 35%;
+        left: 10px;
+        width: 20%;
+        text-align: center;
+        display: initial;
+        position: absolute;
+
+        .glyphicon-user {
+          float: none;
+          width: 100%;
+        }
+      }
+      .activities {
+        margin-bottom: 0;
+        margin-top: 3px;
+      }
+    }
+  } // end outing cards
+
+  // .list-item.highlight
+  &.highlight a .list-item-title {
+    color: teal;
+    transition: 0.1s ease-in-out;
+  }
+  // .list-item.users
+  &.users {
+    margin-left: 3px;
+    margin-right: 3px;
+    @media @big {
+      flex-basis: 24%;
+    }
+    @media @desktop {
+      flex-basis: 32%;
+    }
+    @media @tablet {
+      flex-basis: 49%;
+    }
+    .list-item-info {
+      justify-content: center;
+    }
+    .icon-user {
+      font-size: 2.5em;
+      color: gray !important;
+    }
+    button {
+      float: right;
+      margin: 5px;
+    }
+  }
+} /* list-item*/
+
+
+.documents-list-section-container {
+  position: relative;
+  &.no-map .documents-list-section, &.no-map .page-main-title {
+    width: 100%;
+  }
+}
+.documents-list-section, .not-found-section, .map-right .map {
+  margin-top: @page-main-title-height;
+  .calc(height, "100vh - @{page-header-height} - @{page-main-title-height}");
+}
+
+.documents-list-section, .not-found-section {
+  float: left;
+  background-color: @lightgrey;
+  position: relative;
+  width: @list-width;
+  overflow: auto;
+
+  @media @phone {
+    width: 100%;
+    float:none;
+    padding-top: 35px;
+    .calc(height, "100vh - 92px");
+  }
+  .show-documents-filters-phone {
+    display: none;
+    height: 33px;
+    margin-right: 5px;
+    float: right;
+
+    @media @phone {
+      display: block;
+    }
+  }
+}

--- a/less/lists.less
+++ b/less/lists.less
@@ -1,4 +1,3 @@
-
 .list {
   width:100%;
   padding: 1% 2% 2% 2%;
@@ -6,15 +5,7 @@
   justify-content: space-around;
   flex-flow: wrap row;
 
-  @media @tablet {
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
-    column-count: 2;
-  }
   @media (max-width: @screen-sm-min) {
-    -webkit-column-count: 1;
-    -moz-column-count: 1;
-    column-count: 1;
     padding-bottom: 50px;
   }
   .list-item {
@@ -67,7 +58,6 @@
     font-size: 1.2em;
   }
 
-
   a {
     display: block;
     transition: 0.2s;
@@ -96,6 +86,7 @@
   .list-item-lang {
     opacity: 0.9;
     color: graytext;
+    white-space: nowrap;
     font-weight: normal;
   }
 
@@ -249,12 +240,13 @@
   }
   // .list-item.outings
   &.outings {
-    max-height: inherit;
+    max-height: inherit !important;
 
-    .glyphicon-user {
+    .icon-user {
+      font-size: 3em;
       padding-right: 5px;
       float: left;
-      font-size: 19px;
+      font-size: 25px;
       color: #b2bcc4 !important;
     }
     .activities {
@@ -272,17 +264,14 @@
     }
     .outing-author {
       color: gray;
-
-      .icon-user {
-        font-size: 3em;
-      }
+      align-items: flex-end;
+      .flex();
     }
     .glyphicon-trash {
       .calc(top, "100% - 60px");
     }
 
     @media @phone {
-      max-height: 115px;
 
       .list-item-info {
         padding-left: 25%;
@@ -295,7 +284,7 @@
         display: initial;
         position: absolute;
 
-        .glyphicon-user {
+        .icon-user {
           float: none;
           width: 100%;
         }
@@ -372,6 +361,77 @@
 
     @media @phone {
       display: block;
+    }
+  }
+}
+
+.section.associations .list-item, .view-details-section .list-item {
+  margin-right: .5%;
+  margin-left: .5%;
+  width: 49%;
+
+  @media @big {
+    width: 32%;
+  }
+  @media @phone {
+    width: 100%;
+  }
+
+  &.new-outing a, &.new-route a {
+    .flex();
+    align-items: center;
+  }
+  &.waypoints  {
+    &.to-route {
+      min-height: 115px;
+    }
+    a {
+      height: auto;
+    }
+  }
+}
+
+#feed .list-item {
+  .list-item-info {
+    min-height: 60px;
+  }
+  &.outings {
+    .list-item-info {
+      padding-left: 30%;
+    }
+    .activities {
+      margin-bottom: 0;
+    }
+    .icon-user {
+      margin-bottom: 5px;
+      width: 100%;
+      font-size: 30px;
+      text-align: center;
+    }
+    .outing-author, .date {
+      left: 10px;
+      width: 25%;
+      position: absolute;
+      justify-content: center;
+      .flex();
+    }
+    .outing-author {
+      top: 33%;
+      flex-flow: wrap;
+      align-content: flex-start;
+      justify-content: center;
+    }
+    .author-name {
+      line-height: normal;
+      word-break: break-all;
+      word-break: break-word; // non-standard for webkit
+      text-align: center;
+    }
+    .date {
+      top: 13%;
+      .glyphicon {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
related to #690 
related to #1138 
related to #1139

After a few unsuccessful attempts to work with `columns` and `ellipsis` (= hide a text too long and replace last letters with"..." -> we're in 2016 and it's impossible to do it for more than a single line with pure CSS!! -.- only chrome supports a special property to do it, how surprising...), I decided to go back again to `flexbox` which we had at the beginning and that we decided to throw away because all the cards had the same height per row of cards, and often it looked weird with one card full and the next one nearly empty.

Now I came back to this solution and time has passed, the cards have more data and it doesn't look that bad. However, I had to make a lot of adaptations and the cards have changed the layout, hopefully for the best:

**outings** when in the feed, the author info is redundant with "xxx has created an outing"
![screenshot from 2016-12-07 09-24-35](https://cloud.githubusercontent.com/assets/7814311/20968792/6d044316-bc86-11e6-926b-349f47a5e95c.png)

**articles** you can show the last activities if more than 4 (anyway always showing them all was unreadable...). Could totally be used for outings, routes and others too, but i have never seen more than 3 activities.
![screenshot from 2016-12-07 13-46-00](https://cloud.githubusercontent.com/assets/7814311/20968817/81db8b32-bc86-11e6-9173-ec34f1932387.png)


**routes**
![screenshot from 2016-12-07 09-23-39](https://cloud.githubusercontent.com/assets/7814311/20968841/9c49605c-bc86-11e6-933b-4e631da7a057.png)

**areas**
![screenshot from 2016-12-07 09-25-43](https://cloud.githubusercontent.com/assets/7814311/20968868/b1cbdaf4-bc86-11e6-8540-1b36e5547145.png)

**xreports**
![screenshot from 2016-12-07 14-10-17](https://cloud.githubusercontent.com/assets/7814311/20968908/e9d73bc8-bc86-11e6-8f59-041212023dc9.png)

**waypoints**
![screenshot from 2016-12-07 09-25-01](https://cloud.githubusercontent.com/assets/7814311/20968920/f55c8458-bc86-11e6-9f29-25e200d213cb.png)

**books**
![screenshot from 2016-12-07 09-25-23](https://cloud.githubusercontent.com/assets/7814311/20968960/1a44976a-bc87-11e6-8aeb-27346f7e68d1.png)

**users** in outing editing
![screenshot from 2016-12-07 14-18-04](https://cloud.githubusercontent.com/assets/7814311/20969136/00a944c6-bc88-11e6-8c5a-574c68948528.png)


All in all, the cards look good IMHO and are sorted from left to right.
I didn't test the Images because they don't load at all and I can't upload, but it should be ok, there is very little to be shown.

Still looking for typos, it may happen after editing 19 files :P
