### PR TITLE
Do not redirect after logout from Discourse

### DIFF
--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -81,7 +81,6 @@ app.UserController = function(appAuthentication, ngeoLocation,
   if (this.ngeoLocation_.hasParam('logout')) {
     // Logout from API by removing User data
     this.auth.removeUserData();
-    window.location.href = document.referrer;
   }
 };
 


### PR DESCRIPTION
The problem is that the referrer is not set. Instead simply show the login page.

Closes https://github.com/c2corg/v6_ui/issues/1127