### PR TITLE
Add a route for robots.txt

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -4,8 +4,6 @@ WSGIDaemonProcess c2corg_ui-{instanceid} python-path={site_packages}
 WSGIScriptAlias {base_url} {base_dir}/apache/app-c2corg_ui.wsgi
 WSGIPassAuthorization On
 
-Alias /robots.txt {base_dir}/c2corg_ui/static/robots.txt
-
 <Location {base_url}>
   WSGIProcessGroup c2corg_ui-{instanceid}
   WSGIApplicationGroup %{{GLOBAL}}

--- a/c2corg_ui/__init__.py
+++ b/c2corg_ui/__init__.py
@@ -165,6 +165,7 @@ def main(global_config, **settings):
     config.add_route('mailinglists', '/mailinglists')
     config.add_route('following', '/following')
 
+    config.add_route('robots.txt', '/robots.txt')
     config.add_route('sitemap_index', '/sitemap.xml')
     config.add_route('sitemap', '/sitemaps/{doc_type:[a-z]{1}}/{i:\d+}.xml')
 

--- a/c2corg_ui/views/index.py
+++ b/c2corg_ui/views/index.py
@@ -1,3 +1,5 @@
+import os
+from pyramid.response import Response
 from pyramid.view import view_config
 
 from c2corg_ui.views import get_or_create_page
@@ -61,3 +63,10 @@ class Pages(object):
             self.debug,
             no_etag
         )
+
+    @view_config(route_name='robots.txt')
+    def robotstxt(self):
+        here = os.path.dirname(__file__)
+        robots = open(os.path.join(
+                      here, '..', 'static', 'robots.txt')).read()
+        return Response(content_type='text/plain', body=robots)


### PR DESCRIPTION
@mfournier has suggested that the ``robots.txt`` is fully managed by the UI and that we don't rely on some config in haproxy to alias ``/robots.txt`` and ``/static/robots.txt`` as we previously did it with the apache conf (that is embedded in the UI files).

I have then followed the recommendations of the Pyramid documentation here: http://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/static_assets/files.html#serving-a-single-file-from-the-root