### PR TITLE
Don't include Bootstrap CSS twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ LIBS_JS_FILES += \
 
 # CSS files of dependencies that are concatenated into a single file
 LIBS_CSS_FILES += \
-    node_modules/bootstrap/dist/css/bootstrap.min.css \
     node_modules/bootstrap-slider/dist/css/bootstrap-slider.css \
     node_modules/slick-carousel/slick/slick.css \
     node_modules/photoswipe/dist/photoswipe.css \


### PR DESCRIPTION
The CSS for Bootstrap is already included in our LESS files:
https://github.com/c2corg/v6_ui/blob/master/less/c2corg_ui.less#L2

This should resolve the problem with 404 requests to /static/5ff028d/fonts/glyphicons-halflings-regular.ttf 

But please test properly if the layout is not broken somewhere.