### PR TITLE
Areas in cards

### DIFF
--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -215,9 +215,7 @@ app.CardController.prototype.getGlobalRatings = function() {
       ratings['biking_rating'] = this.slashSeparatedRating_(doc.mtb_down_rating, doc.hiking_mtb_exposition);
     }
   }.bind(this));
-
-  ratings = Object.keys(ratings)[0] ? ratings : null;
-  return ratings;
+  return ratings[Object.keys(ratings)[0]] ? ratings : null;
 };
 
 
@@ -268,7 +266,7 @@ app.CardController.prototype.getFullRatings = function() {
       fullRatings[rating] = ratings[rating];
     }
   });
-  return fullRatings;
+  return fullRatings[Object.keys(fullRatings)[0]] ? fullRatings : null;
 };
 
 /**

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -130,6 +130,34 @@ app.CardController.prototype.translate = function(str) {
 
 
 /**
+ * Show only one of the area types, the first that is available:
+ * 1) range 2) admin limits 3) country
+ * @param {?Array<Object>} areas
+ * @return {string | null}
+ * @export
+ */
+app.CardController.prototype.showArea = function(areas) {
+  if (!app.utils.isTopoguide(window.location.pathname.substring(1)) && areas) {
+    // the areas often come in different orders within 3 area objects
+    var orderedAreas = {};
+
+    for (var i = 0; i < areas.length; i++) {
+      orderedAreas[ areas[i]['area_type']] = areas[i]['locales'][0]['title'];
+    }
+
+    if (orderedAreas.hasOwnProperty('range')) {
+      return orderedAreas['range'];
+    } else if (orderedAreas.hasOwnProperty('admin_limits')) {
+      return orderedAreas['admin_limits'];
+    } else {
+      return orderedAreas['country'];
+    }
+  }
+  return null;
+};
+
+
+/**
  * Creates a link to the document view-page
  * @export
  * @return {string | undefined}

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -133,24 +133,23 @@ app.CardController.prototype.translate = function(str) {
  * Show only one of the area types, the first that is available:
  * 1) range 2) admin limits 3) country
  * @param {?Array<Object>} areas
- * @return {string | null}
+ * @return {Object | null}
  * @export
  */
 app.CardController.prototype.showArea = function(areas) {
-  if (!app.utils.isTopoguide(window.location.pathname.substring(1)) && areas) {
-    // the areas often come in different orders within 3 area objects
-    var orderedAreas = {};
+  if (areas) {
+    // the areas often come in different orders within 3 area objects.
+    var orderedAreas = {'range': [], 'admin_limits': [], 'country': []};
+    var type;
 
     for (var i = 0; i < areas.length; i++) {
-      orderedAreas[ areas[i]['area_type']] = areas[i]['locales'][0]['title'];
+      type = areas[i]['area_type'];
+      orderedAreas[type].push(areas[i]['locales'][0]['title']);
     }
-
-    if (orderedAreas.hasOwnProperty('range')) {
-      return orderedAreas['range'];
-    } else if (orderedAreas.hasOwnProperty('admin_limits')) {
-      return orderedAreas['admin_limits'];
-    } else {
-      return orderedAreas['country'];
+    for (var t in orderedAreas) {
+      if (orderedAreas[t].length) {
+        return orderedAreas[t].join(' - ');
+      }
     }
   }
   return null;

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -81,8 +81,6 @@ app.MainController.prototype.isPath = function(path) {
     return 'home';
   } else if (path === 'topoguide') {
     return app.utils.isTopoguide(location.substring(1));
-  } else {
-    return location.indexOf(path) > -1;
   }
   return location.indexOf(path) > -1;
 };

--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -1,6 +1,7 @@
 goog.provide('app.MainController');
 
 goog.require('app');
+goog.require('app.utils');
 /** @suppress {extraRequire} */
 goog.require('app.HttpAuthenticationInterceptor');
 /** @suppress {extraRequire} */
@@ -79,11 +80,9 @@ app.MainController.prototype.isPath = function(path) {
     // path = '/'
     return 'home';
   } else if (path === 'topoguide') {
-    // if topoguide, it can be all kinds of documents.
-    // Articles, xreports and outings have their own line in the sidemenu.
-    return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1 ||
-           location.indexOf('images') > -1 || location.indexOf('areas') > -1 ||
-           location.indexOf('books') > -1;
+    return app.utils.isTopoguide(location.substring(1));
+  } else {
+    return location.indexOf(path) > -1;
   }
   return location.indexOf(path) > -1;
 };

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -169,6 +169,16 @@ app.utils.createImageUrl = function(url, suffix) {
 
 
 /**
+ * @param {string} location
+ * @return {boolean}
+ * @export
+ */
+app.utils.isTopoguide = function(location) {
+  return location.indexOf('outings') > -1 || location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1
+  || location.indexOf('images') > -1 || location.indexOf('areas') > -1 || location.indexOf('books') > -1;
+};
+
+/**
  * http://openlayers.org/en/latest/examples/vector-labels.html
  * http://stackoverflow.com/questions/14484787/wrap-text-in-javascript
  * @param {string} str String to divide.

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -174,7 +174,7 @@ app.utils.createImageUrl = function(url, suffix) {
  * @export
  */
 app.utils.isTopoguide = function(location) {
-  return location.indexOf('outings') > -1 || location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1
+  return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1
   || location.indexOf('images') > -1 || location.indexOf('areas') > -1 || location.indexOf('books') > -1;
 };
 

--- a/c2corg_ui/static/partials/cards/books.html
+++ b/c2corg_ui/static/partials/cards/books.html
@@ -10,9 +10,19 @@
       <span ng-repeat="book_type in ::doc['book_types']" class="value book-type">{{::book_type | translate }}{{$last ? '' : ', '}}</span>
     </div>
 
-    <div class="activities">
-      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
+    <div class="activities flex wrap-row margin-t-sm">
+      <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
             uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+
+      <span class="flex flexend-align show-more-activities"
+            ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
+            ng-click="$event.preventDefault(); cardCtrl.remainingActivities = true">
+        ...(+ {{::doc.activities.length - 4}})
+      </span>
+
+      <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
+            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+      </span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"

--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -6,7 +6,7 @@
       <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <div class="flex wrap-row">
+    <div class="flex wrap-row margin-t-sm center-items-align">
       <span class="date margin-r-sm">
         <span class="value-title glyphicon glyphicon-time"></span>
         <span class="value">{{ ::doc['date_end'] | date: 'dd/MM/yyyy'}}</span>
@@ -16,12 +16,27 @@
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
+
+      <span class="location" ng-if="::doc['areas']">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
+      </span>
     </div>
 
     <div class="activity-author">
-      <div class="activities">
-        <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
-              uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
+      <div class="activities flex wrap-row margin-t-sm">
+        <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
+              uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+
+        <span class="flex flexend-align show-more-activities"
+              ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
+              ng-click="$event.preventDefault(); cardCtrl.remainingActivities = true">
+          ...(+ {{::doc.activities.length - 4}})
+        </span>
+
+        <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
+              class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+        </span>
       </div>
 
       <div class="outing-author flex baseline-align" ng-if="!feed">

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -27,7 +27,7 @@
         <span ng-repeat="o in ::doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
       </div>
 
-      <span class="location margin-t-sm" ng-if="::cardCtrl.showArea(doc['areas'])">
+      <span class="location" ng-if="::doc['areas']">
         <span class="glyphicon glyphicon-map-marker"></span>
         <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
       </span>

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -6,14 +6,11 @@
       <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <div class="flex wrap-row margin-t-sm center-items-align">
+    <div class="flex wrap-row center-items-align margin-b-sm route-infos">
       <span class="elevation margin-r-sm" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
-
-      <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-           uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
 
       <span class="height-diff" ng-if="::doc['height_diff_up']" uib-tooltip="{{'height_diff_up'| translate}}">
         <span class="icon-height_diff"></span>
@@ -30,22 +27,26 @@
         <span ng-repeat="o in ::doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
       </div>
 
-      <span class="location" ng-if="::cardCtrl.showArea(doc['areas'])">
+      <span class="location margin-t-sm" ng-if="::cardCtrl.showArea(doc['areas'])">
         <span class="glyphicon glyphicon-map-marker"></span>
         <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
       </span>
     </div>
 
-    <div class="global-rating flex flexend-align margin-b-sm" ng-init="globalRatings = cardCtrl.getGlobalRatings()">
-      <span class="icon-rating"></span>
-      <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr | translate}}" ng-if="::val">
+
+    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+         uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
+
+    <div class="global-rating flex" ng-init="globalRatings = cardCtrl.getGlobalRatings()">
+      <span class="icon-rating" ng-if="::globalRatings"></span>
+      <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr| translate}}" ng-if="::val">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
     <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()">
-      <span class="icon-rating" ng-if="fullRatings"></span>
-      <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr | translate}}" class="rating">
+      <span class="icon-rating" ng-if="::fullRatings"></span>
+      <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr| translate}}" class="rating">
         <span class="value">{{::val}}</span>
       </div>
     </div>

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -6,8 +6,8 @@
       <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <div class="flex wrap-row">
-      <span class="elevation-max margin-r-sm" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
+    <div class="flex wrap-row margin-t-sm center-items-align">
+      <span class="elevation margin-r-sm" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
@@ -29,17 +29,22 @@
         <span class="glyphicon glyphicon-fullscreen"></span>
         <span ng-repeat="o in ::doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
       </div>
+
+      <span class="location" ng-if="::cardCtrl.showArea(doc['areas'])">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
+      </span>
     </div>
 
-    <div class="global-rating flex flexend-align margin-b-sm" ng-init="globalRatings = cardCtrl.getGlobalRatings()" ng-show="::globalRatings">
+    <div class="global-rating flex flexend-align margin-b-sm" ng-init="globalRatings = cardCtrl.getGlobalRatings()">
       <span class="icon-rating"></span>
       <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr | translate}}" ng-if="::val">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
-    <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()" ng-if="fullRatings">
-      <span class="icon-rating"></span>
+    <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()">
+      <span class="icon-rating" ng-if="fullRatings"></span>
       <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr | translate}}" class="rating">
         <span class="value">{{::val}}</span>
       </div>

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -1,5 +1,4 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-
   <div class="list-item-info">
     <div class="list-item-title-lang">
       <span class="list-item-title"><p>{{::locale.title}}</p></span>
@@ -9,10 +8,20 @@
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
          uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
 
-    <div class="waypoint-type-elevation">
+    <div class="waypoint-infos">
       <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type" uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type'])}}"></span>
-      <span ng-if="::doc['elevation']"><span class="value">{{::doc['elevation']}}&nbsp;m</span></span>
-    </div>
-  </div>
 
+      <span class="location" ng-if="::cardCtrl.showArea(doc['areas'])">
+        <span class="glyphicon glyphicon-map-marker"></span>
+        <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
+      </span>
+      <br>
+
+      <span class="waypoint-elevation" ng-if="::doc['elevation']" uib-tooltip="{{'elevation_max'| translate}}">
+        <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+        <span class="value">{{::doc['elevation']}}&nbsp;m</span>
+      </span>
+    </div>
+
+  </div>
 </a>

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -1,27 +1,27 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
-  <div class="list-item-info">
-    <div class="list-item-title-lang">
-      <span class="list-item-title"><p>{{::locale.title}}</p></span>
-      <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+  <div class="flex wrap-row center-items-align">
+    <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type" uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type'])}}"></span>
+
+    <div class="list-item-info">
+      <div class="list-item-title-lang">
+        <span class="list-item-title"><p>{{::locale.title}}</p></span>
+        <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
+      </div>
+
+      <div class="waypoint-infos">
+        <span class="waypoint-elevation margin-r-sm margin-b-sm" ng-if="::doc['elevation']" uib-tooltip="{{'elevation_max'| translate}}">
+          <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
+          <span class="value">{{::doc['elevation']}}&nbsp;m</span>
+        </span>
+
+        <span class="location" ng-if="::doc['areas']">
+          <span class="glyphicon glyphicon-map-marker"></span>
+          <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
+        </span>
+      </div>
+
+      <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
+           uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
     </div>
-
-    <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
-
-    <div class="waypoint-infos">
-      <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type" uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type'])}}"></span>
-
-      <span class="location" ng-if="::cardCtrl.showArea(doc['areas'])">
-        <span class="glyphicon glyphicon-map-marker"></span>
-        <span class="value">{{::cardCtrl.showArea(doc['areas'])}}</span>
-      </span>
-      <br>
-
-      <span class="waypoint-elevation" ng-if="::doc['elevation']" uib-tooltip="{{'elevation_max'| translate}}">
-        <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
-        <span class="value">{{::doc['elevation']}}&nbsp;m</span>
-      </span>
-    </div>
-
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/xreports.html
+++ b/c2corg_ui/static/partials/cards/xreports.html
@@ -23,9 +23,19 @@
       </span>
     </div>
 
-    <div class="activities">
-      <span ng-repeat="activity in doc.activities" class="activity icon-{{activity}}"
-            uib-tooltip="{{ ::cardCtrl.translate(activity) }}"></span>
+    <div class="activities flex wrap-row margin-t-sm">
+      <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
+            uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+
+      <span class="flex flexend-align show-more-activities"
+            ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
+            ng-click="$event.preventDefault(); cardCtrl.remainingActivities = true">
+        ...(+ {{::doc.activities.length - 4}})
+      </span>
+
+      <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
+            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+      </span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"

--- a/less/lists.less
+++ b/less/lists.less
@@ -12,6 +12,9 @@
   & + .no-results {
     display: none;
   }
+  .list-item.waypoints .waypoint-infos{
+    .flex() !important;
+  }
 }
 
 .list-item {
@@ -21,7 +24,7 @@
   margin-top: 10px;
   outline: none;
   border-radius: 7px;
-  min-height: 90px;
+  min-height: 80px;
   -moz-border-radius: 7px;
   -webkit-border-radius: 7px;
   transition: .2s ease-in-out;
@@ -80,7 +83,9 @@
     white-space: nowrap;
     font-weight: normal;
   }
-
+  .activities {
+    margin-top: 5px;
+  }
   .list-item-title {
     font-weight: bold;
     color: graytext;
@@ -100,8 +105,9 @@
   .list-item-title-lang {
     .flex();
     align-items: center;
+    margin-bottom: 5px;
   }
-  .elevation {
+  .elevation, .waypoint-elevation {
     align-items: flex-start;
     .flex();
   }
@@ -118,7 +124,7 @@
     -webkit-flex-direction: column;
     justify-content: space-between;
 
-    .quality, .orientations, .date,  .height-diff, .height-diff-difficulties, .elevation {
+    .quality, .orientations, .date,  .height-diff, .height-diff-difficulties, .elevation, .waypoint-elevation {
       white-space: nowrap;
       .glyphicon {
         margin-right: 3px;
@@ -129,6 +135,7 @@
     }
     .icon-rating {
       font-size: 1.4em;
+      margin-bottom: 5px;
     }
     .orientations, .height-diff, .height-diff-difficulties, .elevation {
       @media (max-width: @phone-max) {
@@ -141,8 +148,6 @@
       }
     }
     .full-rating {
-      margin-bottom: 5px;
-      margin-top: 5px;
       flex-wrap: wrap;
       .glyphicon {
         font-size: 1.3em;
@@ -176,7 +181,11 @@
   .set-main-waypoint {
     margin: 0 0 10px 10px;
   }
+<<<<<<< 13af3643315a7bb972ad972728171f052a7c70f0
   .article-activities {
+=======
+  .outing-author, .activities {
+>>>>>>> route card rating fix
     .calc(width, "100% - 40px");
   }
   // .list-item.waypoints
@@ -195,13 +204,20 @@
     .waypoint-infos {
       .calc(width, "100% - 20px");
       display: block;
-      align-items: baseline;
+      align-items: flex-end;
       flex-wrap: wrap;
     }
   }
   // .list-item.routes
-  &.routes .activities {
-    margin-bottom: -5px;
+  &.routes {
+    .route-infos{
+      @media @phone {
+        display: none;
+      }
+    }
+    .activities {
+      margin-bottom: -5px;
+    }
   }
   // .list-item.books
   &.books {

--- a/less/lists.less
+++ b/less/lists.less
@@ -92,11 +92,19 @@
     }
   }
 
+  .location {
+    line-height: normal;
+    margin-right: 5px;
+  }
+
   .list-item-title-lang {
     .flex();
     align-items: center;
   }
-
+  .elevation {
+    align-items: flex-start;
+    .flex();
+  }
   .list-item-info {
     margin: auto;
     height: 100%;
@@ -116,15 +124,11 @@
         margin-right: 3px;
       }
     }
-    .elevation, .height-diff, .height-diff-difficulties, .orientations {
-      margin-right: 8px;
+    .elevation, .height-diff, .height-diff-difficulties, .orientations, .icon-rating, .rating {
+      margin-right: 5px;
     }
     .icon-rating {
       font-size: 1.4em;
-      margin-left: -2px;
-    }
-    .rating {
-      margin-right: 8px;
     }
     .orientations, .height-diff, .height-diff-difficulties, .elevation {
       @media (max-width: @phone-max) {
@@ -177,17 +181,22 @@
   }
   // .list-item.waypoints
   &.waypoints {
-    max-height : 100px;
 
     .waypoint-type {
-      font-size: 2em;
+      font-size: 3em;
       color: @C2C-orange;
       margin-right: 10px;
+      float: left;
+      @media @phone {
+        font-size: 2.5em;
+      }
     }
 
-    .waypoint-type-elevation {
-      display: inherit;
-      align-items: flex-end;
+    .waypoint-infos {
+      .calc(width, "100% - 20px");
+      display: block;
+      align-items: baseline;
+      flex-wrap: wrap;
     }
   }
   // .list-item.routes

--- a/less/lists.less
+++ b/less/lists.less
@@ -8,12 +8,12 @@
   @media (max-width: @screen-sm-min) {
     padding-bottom: 50px;
   }
+  .list-item {
+    min-height: initial;
+  }
 
   & + .no-results {
     display: none;
-  }
-  .list-item.waypoints .waypoint-infos{
-    .flex() !important;
   }
 }
 
@@ -107,9 +107,8 @@
     align-items: center;
     margin-bottom: 5px;
   }
-  .elevation, .waypoint-elevation {
-    align-items: flex-start;
-    .flex();
+  .elevation, .waypoint-elevation .glyphicon {
+    margin-top: -1px;
   }
   .list-item-info {
     margin: auto;
@@ -181,40 +180,32 @@
   .set-main-waypoint {
     margin: 0 0 10px 10px;
   }
-<<<<<<< 13af3643315a7bb972ad972728171f052a7c70f0
-  .article-activities {
-=======
-  .outing-author, .activities {
->>>>>>> route card rating fix
-    .calc(width, "100% - 40px");
-  }
+
   // .list-item.waypoints
   &.waypoints {
 
     .waypoint-type {
       font-size: 3em;
       color: @C2C-orange;
-      margin-right: 10px;
-      float: left;
+      margin-right: 0;
       @media @phone {
         font-size: 2.5em;
+        margin-left: 10px;
       }
     }
+    .list-item-info {
+      flex-basis: 75%;
 
+    }
     .waypoint-infos {
       .calc(width, "100% - 20px");
-      display: block;
-      align-items: flex-end;
+      .flex();
+      align-items: baseline;
       flex-wrap: wrap;
     }
   }
   // .list-item.routes
   &.routes {
-    .route-infos{
-      @media @phone {
-        display: none;
-      }
-    }
     .activities {
       margin-bottom: -5px;
     }
@@ -380,7 +371,7 @@
 
 // + 1 more card per row than usual, max 4
 .documents-list-section-container, .section.associations, .view-details-associations {
-  &.no-map .list-item, .list-item.waypoints {
+  &.no-map .list-item{
     @media (min-width: 1200px) and (max-width: @large-width) {
       flex-basis: 32%;
     }
@@ -409,6 +400,12 @@
 #feed .list-item {
   .list-item-info {
     min-height: 60px;
+  }
+  &.waypoints .waypoint-type {
+    flex-basis: 25%;
+    @media @phone {
+      flex-basis: 0;
+    }
   }
   &.outings {
     .list-item-info {


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1157
related to #1195
related to #1212

Adds areas to waypoints, outings and routes. The info is not relevant for other document types. The areas are shown only in the feed - there were problems with the layout with long area titles, in addition there is a map in the advanced search and on most of other pages.

At first,  `range` will be shown -> if not exists, `admin_limints` -> else, `country`.

![screenshot from 2016-12-09 14-42-41](https://cloud.githubusercontent.com/assets/7814311/21052844/35d1353c-be27-11e6-9b5c-605a59666830.png)

other small updates:
+ hide/show activities in other document cards, as was done for articles
+ route rating fix (was hidden for some reason)


