### PR TITLE
Add outings to the sidemenu

### DIFF
--- a/c2corg_ui/static/js/maincontroller.js
+++ b/c2corg_ui/static/js/maincontroller.js
@@ -75,16 +75,17 @@ app.module.controller('MainController', app.MainController);
  */
 app.MainController.prototype.isPath = function(path) {
   var location = window.location.pathname;
-  // path = '/'
   if (path === location) {
+    // path = '/'
     return 'home';
-  // if topoguide, it can be all kinds of documents. Articles/xreports have their own line in the sidemenu.
   } else if (path === 'topoguide') {
-    return location.indexOf('outings') > -1 || location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1
-            || location.indexOf('images') > -1 || location.indexOf('areas') > -1 || location.indexOf('books') > -1;
-  } else {
-    return location.indexOf(path) > -1;
+    // if topoguide, it can be all kinds of documents.
+    // Articles, xreports and outings have their own line in the sidemenu.
+    return location.indexOf('waypoints') > -1 || location.indexOf('routes') > -1 ||
+           location.indexOf('images') > -1 || location.indexOf('areas') > -1 ||
+           location.indexOf('books') > -1;
   }
+  return location.indexOf(path) > -1;
 };
 
 

--- a/c2corg_ui/templates/sidemenu.html
+++ b/c2corg_ui/templates/sidemenu.html
@@ -24,6 +24,12 @@ version = request.registry.settings.get('cache_version')
         <span class="menu-text" translate>Topoguide</span>
       </a>
     </li>
+    <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('outings')}">
+      <a href="${request.route_path('outings_index')}">
+        <i class="glyphicon glyphicon-time" tooltip-placement="right" uib-tooltip="{{'Outings' | translate}}"></i>
+        <span class="menu-text" translate>Outings</span>
+      </a>
+    </li>
     <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('forum')}">
       <a href="${discourse_url}">
         <i class="glyphicon glyphicon-comment" tooltip-placement="right" uib-tooltip="{{'Forum' | translate}}"></i>
@@ -42,12 +48,6 @@ version = request.registry.settings.get('cache_version')
         <span class="menu-text" translate>Articles</span>
       </a>
     </li>
-    <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('Association')}">
-      <a href="${request.route_path('articles_view_id', id=106726)}">
-        <i class="glyphicon glyphicon-user" tooltip-placement="right" uib-tooltip="{{'Association' | translate}}"></i>
-        <span class="menu-text" translate>Association</span>
-      </a>
-    </li>
   </ul>
 
   <footer>
@@ -63,6 +63,8 @@ version = request.registry.settings.get('cache_version')
       <li><a href="${request.route_path('articles_view_id', id=106731)}" translate>terms of use</a></li>
       <span class="bullet">&bull; </span>
       <li><a href="${request.route_path('articles_view_id', id=106728)}" translate>content license</a></li>
+      <span class="bullet">&bull; </span>
+      <li><a href="${request.route_path('articles_view_id', id=106726)}" translate>Association</a></li>
     </ul>
 
     <div class="version">

--- a/less-discourse/menu.html
+++ b/less-discourse/menu.html
@@ -43,6 +43,18 @@
         <span class="lang es menu-text">Topoguía</span>
       </a>
     </li>
+    <li class="main-menu">
+      <a href="#" url="outings" class="menu-link">
+        <i class="glyphicon glyphicon-time"></i>
+        <span class="lang en menu-text">Outings</span>
+        <span class="lang fr menu-text">Sorties</span>
+        <span class="lang it menu-text">Gitte</span>
+        <span class="lang de menu-text">Tourenberichte</span>
+        <span class="lang eu menu-text">Irteerak</span>
+        <span class="lang ca menu-text">Sortides</span>
+        <span class="lang es menu-text">Salidas</span>
+      </a>
+    </li>
     <li class="main-menu menu-selected">
       <a href="/">
         <i class="glyphicon glyphicon-comment"></i>
@@ -77,18 +89,6 @@
         <span class="lang eu menu-text">Artikulua</span>
         <span class="lang ca menu-text">Articles</span>
         <span class="lang es menu-text">Artículos</span>
-      </a>
-    </li>
-    <li class="main-menu">
-      <a href="#" url="articles/106726" class="menu-link">
-        <i class="glyphicon glyphicon-user"></i>
-        <span class="lang en menu-text">Camptocamp Association</span>
-        <span class="lang fr menu-text">Camptocamp Association</span>
-        <span class="lang it menu-text">Camptocamp Association</span>
-        <span class="lang de menu-text">Camptocamp Verein</span>
-        <span class="lang eu menu-text">Camptocamp Elkartea</span>
-        <span class="lang ca menu-text">Camptocamp Associació</span>
-        <span class="lang es menu-text">Camptocamp Asociación</span>
       </a>
     </li>
   </ul>
@@ -142,6 +142,18 @@
           <span class="lang eu menu-text">Edukiaren lizentziak</span>
           <span class="lang ca menu-text">Llicències del contingut</span>
           <span class="lang es menu-text">Licencias de los contenidos</span>
+        </a>
+      </li>
+      <span class="bullet">&bull; </span>
+      <li>
+        <a href="#" url="articles/106726" class="menu-link">
+          <span class="lang en menu-text">Association</span>
+          <span class="lang fr menu-text">Camptocamp Association</span>
+          <span class="lang it menu-text">Camptocamp Association</span>
+          <span class="lang de menu-text">Camptocamp Verein</span>
+          <span class="lang eu menu-text">Camptocamp Elkartea</span>
+          <span class="lang ca menu-text">Associació</span>
+          <span class="lang es menu-text">Asociación</span>
         </a>
       </li>
     </ul>

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -102,7 +102,8 @@
   .menu-text {
     margin-left: 10px;
   }
-  .glyphicon-arrow-right, .glyphicon-th-list, .glyphicon-info-sign, .glyphicon-book, .glyphicon-warning-sign {
+  .glyphicon-home, .glyphicon-arrow-right, .glyphicon-info-sign,
+  .glyphicon-warning-sign, .glyphicon-time, .glyphicon-comment {
     color: @bright-green;
   }
 


### PR DESCRIPTION
* [x] Add an "outings" entry to the sidemenu
* [x] Move the "Camptocamp Association" entry to the footer links (might need a shorter translation to take less space)
* [x] Fix the styles (in prod some menu icons are not green as expected)
* [x] Update the forum file as well (should be apply by hand in Discourse admin) => I have made the changes carefully but have not been able to test them in a real discourse.

<img width="245" alt="capture d ecran 2016-12-12 a 14 26 17" src="https://cloud.githubusercontent.com/assets/1192331/21101021/4f173422-c077-11e6-9c0f-ba9c668a9a02.png">
