### PR TITLE
Prevent navigating to last page in avanced search

### DIFF
--- a/c2corg_ui/static/js/search/pagination.js
+++ b/c2corg_ui/static/js/search/pagination.js
@@ -54,6 +54,12 @@ app.PaginationController = function($scope, ngeoLocation) {
   this.total = 0;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.showGoToLastPage = true;
+
+  /**
    * @type {number}
    * @export
    */
@@ -81,6 +87,11 @@ app.PaginationController.prototype.handleSearchChange_ = function(event,
     features, total, recenter) {
   this.total = total;
   this.offset = this.location_.getFragmentParamAsInt('offset') || 0;
+  // don't show the "Go to last page" button when doing a full-text-search
+  // (the full result set has to be iterated in ElasticSearch when doing
+  // requests with large offsets)
+  this.showGoToLastPage = !(this.location_.hasFragmentParam('q') &&
+    this.location_.getFragmentParam('q') !== '');
 };
 
 

--- a/c2corg_ui/static/partials/pagination.html
+++ b/c2corg_ui/static/partials/pagination.html
@@ -8,7 +8,8 @@
         class="glyphicon glyphicon-menu-left" ></span></a></li>
     <li ng-if="pageCtrl.offset + pageCtrl.limit < pageCtrl.total"><a class="btn" ng-click="pageCtrl.goToNext();"><span
         class="glyphicon glyphicon-menu-right"></span></a></li>
-    <li ng-if="pageCtrl.offset + pageCtrl.limit < pageCtrl.total"><a class="btn" ng-click="pageCtrl.goToLast();"><span
-        class="glyphicon glyphicon-step-forward"></span></a></li>
+    <li ng-if="pageCtrl.showGoToLastPage && pageCtrl.offset + pageCtrl.limit < pageCtrl.total">
+      <a class="btn" ng-click="pageCtrl.goToLast();"><span class="glyphicon glyphicon-step-forward"></span></a>
+    </li>
   </ul>
 </div>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/578:

> When making a request to an advanced-search view with an offset > 10000 (for [example](http://localhost:6544/routes?bbox=457507%252C5594424%252C559627%252C5730176&offset=30000)), ElasticSearch complains.

This PR proposes to remove the "go to last page" button (and for consistency reasons also the "go to first page" button). This is similar to the behavior with Google: When you have millions of results, you also can't jump to the last page of these results.

