### PR TITLE
reduce card font-size + larger cards treshold

### DIFF
--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -18,14 +18,16 @@
       </span>
     </div>
 
-    <div class="activities">
-      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
-            uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
-    </div>
+    <div class="activity-author">
+      <div class="activities">
+        <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
+              uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
+      </div>
 
-    <div class="outing-author flex baseline-align" ng-if="!feed">
-      <span class="icon-user"></span>
-      <span class="author-name">{{::doc['author']['name']}}</span>
+      <div class="outing-author flex baseline-align" ng-if="!feed">
+        <span class="icon-user"></span>
+        <span class="author-name">{{::doc['author']['name']}}</span>
+      </div>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"

--- a/less/lists.less
+++ b/less/lists.less
@@ -172,7 +172,7 @@
   .set-main-waypoint {
     margin: 0 0 10px 10px;
   }
-  .outing-author, .article-activities {
+  .article-activities {
     .calc(width, "100% - 40px");
   }
   // .list-item.waypoints
@@ -267,29 +267,6 @@
       .calc(top, "100% - 60px");
     }
 
-    @media @phone {
-
-      .list-item-info {
-        padding-left: 25%;
-      }
-      .outing-author {
-        top: 35%;
-        left: 10px;
-        width: 20%;
-        text-align: center;
-        display: initial;
-        position: absolute;
-
-        .icon-user {
-          float: none;
-          width: 100%;
-        }
-      }
-      .activities {
-        margin-bottom: 0;
-        margin-top: 3px;
-      }
-    }
   } // end outing cards
 
   // .list-item.highlight

--- a/less/lists.less
+++ b/less/lists.less
@@ -8,15 +8,7 @@
   @media (max-width: @screen-sm-min) {
     padding-bottom: 50px;
   }
-  .list-item {
-    flex-basis: 32%;
-    @media (max-width: 1200px){
-      flex-basis: 48%;
-    }
-    @media (max-width: 730px) {
-      flex-basis: 100%;
-    }
-  }
+
   & + .no-results {
     display: none;
   }
@@ -55,7 +47,6 @@
   }
   @media @phone {
     border-width: 1px;
-    font-size: 1.2em;
   }
 
   a {
@@ -68,7 +59,7 @@
     padding: 10px;
 
     @media @phone {
-      font-size: .8em;
+      font-size: 1.1em;
       padding: 7px;
     }
 
@@ -93,7 +84,6 @@
   .list-item-title {
     font-weight: bold;
     color: graytext;
-    font-size: 14px;
     margin-right: 5px;
     p {
       line-height: normal;
@@ -111,6 +101,7 @@
     margin: auto;
     height: 100%;
     width: 100%;
+    font-size: 90%;
     text-decoration: none;
     color: #919191;
     font-weight: normal;
@@ -250,8 +241,13 @@
       color: #b2bcc4 !important;
     }
     .activities {
-      margin-top: 5px;
-      margin-bottom: 5px;
+      margin-right: 5px;
+    }
+    .activity-author {
+      .calc(width, "100% - 25px");
+      .flex();
+      justify-content: space-between;
+      flex-wrap: wrap;
     }
     .author-name {
       font-weight: bold;
@@ -365,17 +361,34 @@
   }
 }
 
-.section.associations .list-item, .view-details-section .list-item {
-  margin-right: .5%;
-  margin-left: .5%;
-  width: 49%;
+.section.associations, .view-details-associations, .list {
+  .list-item {
+    flex-basis: 48%;
+    @media (min-width: @large-width){
+      flex-basis: 32%;
+    }
+    @media (min-width: 2100px) {
+      flex-basis: 24%;
+    }
+    @media (max-width: 900px) {
+      flex-basis: 100% !important;
+    }
+  }
+}
 
-  @media @big {
-    width: 32%;
+// + 1 more card per row than usual, max 4
+.documents-list-section-container, .section.associations, .view-details-associations {
+  &.no-map .list-item, .list-item.waypoints {
+    @media (min-width: 1200px) and (max-width: @large-width) {
+      flex-basis: 32%;
+    }
+    @media (min-width: @large-width) {
+      flex-basis: 24%;
+    }
   }
-  @media @phone {
-    width: 100%;
-  }
+}
+
+.section.associations .list-item, .view-details-section .list-item {
 
   &.new-outing a, &.new-route a {
     .flex();

--- a/less/variables.less
+++ b/less/variables.less
@@ -4,6 +4,7 @@
 @phone: ~"only screen and (max-width: 619px)";
 @phone-max: 620px;
 @tablet-max: 1100px;
+@large-width: 1800px;
 @lightgrey: #F0F0F0;
 @C2C-orange: #FFAA45;
 @bg-color1 : #ebe4d1;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -304,27 +304,17 @@
       border-color: #eee;
       font-size: 1.1em;
     }
-    .list-item {
-      &.waypoints {
-        @media @big {
-          width: 24%;
-        }
-        @media @desktop {
-          width: 32%;
-        }
-        @media @tablet {
-          width: 49%;
-        }
-      }
-      .list-item-title {
-        font-size: 0.9em;
-      }
-    }
 
     .associated-documents {
       max-height: 600px;
       overflow-y: auto;
       margin-bottom: 5px;
+      padding-left: 10px;
+
+      .list-item {
+        margin-right: .5%;
+        margin-left: .5%;
+      }
     }
   }
 
@@ -722,7 +712,7 @@ app-add-association {
     right: 50px;
   }
   @media @desktop {
-     right: 50px;
+    right: 50px;
   }
 
   p {
@@ -795,7 +785,7 @@ app-add-association {
       font-size: 14px;
     }
     img {
-     margin: auto auto 0 auto;
+      margin: auto auto 0 auto;
     }
   }
 
@@ -847,6 +837,6 @@ app-add-association {
 .show-phone.elevation {
   display: none;
   @media @phone {
-     display: block;
+    display: block;
   }
 }


### PR DESCRIPTION
related to #1186
![screenshot from 2016-12-13 12-53-33](https://cloud.githubusercontent.com/assets/7814311/21139583/e311b3ca-c133-11e6-9165-dd6668a504b4.png)


+ 3 cards per row for >2000px screens width
+ 2 cards per row default
+ 1 card per row for < 800px screens width
+ 90% card font size (super small imho)

Should this change be applied only to the advanced search lists? or also to associated documents in views/editing pages? 