### PR TITLE
Printing style for detail views

### DIFF
--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -55,3 +55,11 @@
 .heading {
 	text-decoration: underline;
 }
+
+.heading.closed{
+ 	display: none;
+}
+
+.heading .glyphicon{
+	display: none;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -4,14 +4,13 @@
 }
 
 .view-details-title {
-	display: block;
 	font-size: .75em !important;
 	margin-top: 0px;
 	margin-bottom: 10px;
 }
 
-.description , .view-details-info {
-	display: block !important;
+.view-details-info , .view-details-section .view-details-description {
+	float: none;
 }
 
 .view-details-section {
@@ -42,7 +41,6 @@
 
 .view-details-title, .view-details-description, .view-details-informations , .view-details-info {
 	border: none !important;
-	display: block;
 	width: 100%;
 }
 
@@ -62,16 +60,11 @@
 	text-decoration: underline;
 }
 
-.heading.closed {
+.heading.closed, .heading .glyphicon {
  	display: none;
 }
 
-.heading .glyphicon {
-	display: none;
-}
-
 .location-static {
-	position: static;
 	float: none;
 	transform: none;
 	max-width: none;

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -1,9 +1,9 @@
 .view-details-associations, .view-details-comments, .view-details-photos,
 .scroll-top-btn, .view-details-map, .badge, .icons-header {
-  display: none !important;
+ 	display: none !important;
 }
 
-.view-details-title{
+.view-details-title {
 	display: block;
 	font-size: .75em !important;
 	margin-top: 0px;
@@ -22,7 +22,7 @@
 	width: 100%;
 }
 
-.lead{
+.lead {
 	padding: 0 10px !important;
 }
 
@@ -31,7 +31,7 @@
 }
 
 .view-details-section .view-details-informations .accordion {
-    padding: 0;
+	padding: 0;
 }
 
 .document-summary {
@@ -62,11 +62,11 @@
 	text-decoration: underline;
 }
 
-.heading.closed{
+.heading.closed {
  	display: none;
 }
 
-.heading .glyphicon{
+.heading .glyphicon {
 	display: none;
 }
 
@@ -79,12 +79,13 @@
 	padding: 5px;
 	margin-bottom: 0;
 	top: 0;
- }
- .location-static li {
-	display: inline;
- }
+}
 
- .view-details-title>h1.routes .title {
-    max-width: 100%;
-    margin-right: 0;
+.location-static li {
+	display: inline;
+}
+
+.view-details-title>h1.routes .title {
+	max-width: 100%;
+	margin-right: 0;
 }

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -17,6 +17,9 @@
 .view-details-section {
 	display: block;
 	font-size: .75em !important;
+	margin-left: 0;
+	padding-bottom: 0;
+	width: 100%;
 }
 
 .lead{
@@ -40,6 +43,7 @@
 .view-details-title, .view-details-description, .view-details-informations , .view-details-info {
 	border: none !important;
 	display: block;
+	width: 100%;
 }
 
 #orientation-svg {
@@ -79,3 +83,8 @@
  .location-static li {
 	display: inline;
  }
+
+ .view-details-title>h1.routes .title {
+    max-width: 100%;
+    margin-right: 0;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -1,5 +1,5 @@
 .view-details-associations, .view-details-comments, .view-details-photos,
-.scroll-top-btn, .view-details-map, .location-static, .badge, .icons-header {
+.scroll-top-btn, .view-details-map, .badge, .icons-header {
   display: none !important;
 }
 
@@ -11,7 +11,7 @@
 }
 
 .description , .view-details-info {
-	display: inline-block !important;
+	display: block !important;
 }
 
 .view-details-section {
@@ -37,8 +37,9 @@
 	margin: 0;
 }
 
-.view-details-description, .view-details-informations , .view-details-info {
+.view-details-title, .view-details-description, .view-details-informations , .view-details-info {
 	border: none !important;
+	display: block;
 }
 
 #orientation-svg {
@@ -50,6 +51,7 @@
 	border-bottom: none !important;
 	min-height: 10px !important;
 	max-width: 50%;
+	display: inline;
 }
 
 .heading {
@@ -63,3 +65,17 @@
 .heading .glyphicon{
 	display: none;
 }
+
+.location-static {
+	position: static;
+	float: none;
+	transform: none;
+	max-width: none;
+	min-height: 0;
+	padding: 5px;
+	margin-bottom: 0;
+	top: 0;
+ }
+ .location-static li {
+	display: inline;
+ }

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -38,11 +38,17 @@
 	margin: 0;
 }
 
-.view-details-description, .view-details-informations , .view-details-info, .name-icon-value {
+.view-details-description, .view-details-informations , .view-details-info {
 	border: none !important;
 }
 
 #orientation-svg {
 	height: 55px !important;
 	margin-left: 0 !important;
+}
+
+.name-icon-value {
+	border-bottom: none !important;
+	min-height: 10px !important;
+	max-width: 50%;
 }

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -3,3 +3,17 @@
 .logo {
   display: none;
 }
+
+.view-details-title{
+	display: block;
+	font-size: .75em !important;
+}
+
+.description , .view-details-info {
+	display: inline-block !important;
+}
+
+.view-details-section {
+	display: block;
+	font-size: .75em !important;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -52,3 +52,7 @@
 	min-height: 10px !important;
 	max-width: 50%;
 }
+
+.heading {
+	text-decoration: underline;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -7,6 +7,8 @@
 .view-details-title{
 	display: block;
 	font-size: .75em !important;
+	margin-top: 0px;
+	margin-bottom: 10px;
 }
 
 .description , .view-details-info {
@@ -16,4 +18,16 @@
 .view-details-section {
 	display: block;
 	font-size: .75em !important;
+}
+
+.lead{
+	padding: 0 10px !important;
+}
+
+.heading {
+	padding: 5px 10px !important;
+}
+
+.view-details-section .view-details-informations .accordion {
+    padding: 0;
 }

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -1,92 +1,92 @@
 .view-details-associations, .view-details-comments, .view-details-photos,
 .scroll-top-btn, .view-details-map, .badge, .icons-header {
- 	display: none !important;
+   display: none !important;
 }
 
 .view-details-title {
-	font-size: .75em !important;
-	margin-top: 0px;
-	margin-bottom: 10px;
+  font-size: .75em !important;
+  margin-top: 0px;
+  margin-bottom: 10px;
 }
 
 .view-details-info , .view-details-section .view-details-description {
-	float: none;
+  float: none;
 }
 
 .view-details-section {
-	display: block;
-	font-size: .75em !important;
-	margin-left: 0;
-	padding-bottom: 0;
-	width: 100%;
-	
-	.view-details-informations .accordion {
-		padding: 0;
-	}
+  display: block;
+  font-size: .75em !important;
+  margin-left: 0;
+  padding-bottom: 0;
+  width: 100%;
+  
+  .view-details-informations .accordion {
+    padding: 0;
+  }
 }
 
 .lead {
-	padding: 0 10px !important;
+  padding: 0 10px !important;
 }
 
 .heading {
-	padding: 5px 10px !important;
-	text-decoration: underline;
-	
-	&.closed,
-	.glyphicon {
-		display: none;
-	}
+  padding: 5px 10px !important;
+  text-decoration: underline;
+  
+  &.closed,
+  .glyphicon {
+    display: none;
+  }
 }
 
 .document-summary {
-	border: none !important;
-	padding: 5px;
-	margin: 0;
+  border: none !important;
+  padding: 5px;
+  margin: 0;
 }
 
 .view-details-title, .view-details-description, .view-details-informations , .view-details-info {
-	border: none !important;
-	width: 100%;
+  border: none !important;
+  width: 100%;
 }
 
 #orientation-svg {
-	height: 55px !important;
-	margin-left: 0 !important;
+  height: 55px !important;
+  margin-left: 0 !important;
 }
 
 .name-icon-value {
-	border-bottom: none !important;
-	min-height: 10px !important;
-	max-width: 50%;
-	display: inline;
+  border-bottom: none !important;
+  min-height: 10px !important;
+  max-width: 50%;
+  display: inline;
 }
 
 .location-static {
-	float: none;
-	transform: none;
-	max-width: none;
-	min-height: 0;
-	padding: 5px;
-	margin-bottom: 0;
-	top: 0;
-	
-	li {
-		display: inline;
-	}
+  float: none;
+  transform: none;
+  max-width: none;
+  min-height: 0;
+  padding: 5px;
+  margin-bottom: 0;
+  top: 0;
+  
+  li {
+    display: inline;
+  }
 }
 
 .view-details-title>h1.routes .title {
-	max-width: 100%;
-	margin-right: 0;
+  max-width: 100%;
+  margin-right: 0;
 }
 
 .view-details-description .embedded_right {
-	page-break-inside: avoid;
+  page-break-inside: avoid;
 }
 
 h3 {
-	font-size: 1em;
-	font-weight: bold;
-	padding: 5px 0 5px 0;	
+  font-size: 1em;
+  font-weight: bold;
+  padding: 5px 0 5px 0;  
 }

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -31,3 +31,13 @@
 .view-details-section .view-details-informations .accordion {
     padding: 0;
 }
+
+.document-summary {
+	border: none !important;
+	padding: 5px;
+	margin: 0;
+}
+
+.view-details-description, .view-details-informations , .view-details-info, .name-icon-value {
+	border: none !important;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -1,7 +1,6 @@
 .view-details-associations, .view-details-comments, .view-details-photos,
-.scroll-top-btn, .view-details-map, .location-static, .badge, .icons-header,
-.logo {
-  display: none;
+.scroll-top-btn, .view-details-map, .location-static, .badge, .icons-header {
+  display: none !important;
 }
 
 .view-details-title{

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -19,6 +19,10 @@
 	margin-left: 0;
 	padding-bottom: 0;
 	width: 100%;
+	
+	.view-details-informations .accordion {
+		padding: 0;
+	}
 }
 
 .lead {
@@ -27,10 +31,12 @@
 
 .heading {
 	padding: 5px 10px !important;
-}
-
-.view-details-section .view-details-informations .accordion {
-	padding: 0;
+	text-decoration: underline;
+	
+	&.closed,
+	.glyphicon {
+		display: none;
+	}
 }
 
 .document-summary {
@@ -56,14 +62,6 @@
 	display: inline;
 }
 
-.heading {
-	text-decoration: underline;
-}
-
-.heading.closed, .heading .glyphicon {
- 	display: none;
-}
-
 .location-static {
 	float: none;
 	transform: none;
@@ -72,10 +70,10 @@
 	padding: 5px;
 	margin-bottom: 0;
 	top: 0;
-}
-
-.location-static li {
-	display: inline;
+	
+	li {
+		display: inline;
+	}
 }
 
 .view-details-title>h1.routes .title {

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -41,3 +41,8 @@
 .view-details-description, .view-details-informations , .view-details-info, .name-icon-value {
 	border: none !important;
 }
+
+#orientation-svg {
+	height: 55px !important;
+	margin-left: 0 !important;
+}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -82,3 +82,13 @@
 	max-width: 100%;
 	margin-right: 0;
 }
+
+.view-details-description .embedded_right {
+	page-break-inside: avoid;
+}
+
+h3 {
+	font-size: 1em;
+	font-weight: bold;
+	padding: 5px 0 5px 0;	
+}


### PR DESCRIPTION
Related to #211 

What is done  : 
- Reduce font size
- Reduce margin
- Display area under the title
- Do not display the picto at the right of the title
- Do not display the headers of the collapsed boxes
- Do not display the arrows to collapse boxes
- Do not display the borders
- Underline the headers
- Reduce the orientation picto

_**Before :**_ 
![image](https://cloud.githubusercontent.com/assets/24532066/21206490/b2d55510-c262-11e6-82ae-3bec63a3e782.png)
With a lot of blank page in the first page
![image](https://cloud.githubusercontent.com/assets/24532066/21206513/e2a3687c-c262-11e6-9041-5846a95fcf8e.png)

_**After :**_ 
![image](https://cloud.githubusercontent.com/assets/24532066/21206756/447c8c76-c264-11e6-8843-bb6d1008d746.png)
The headers (Remarques, Matériel) don't appear even if the box is extanded but it's because of a bug in my copied html page on Firefox (class "closed" is not added when the box is collapsed, works well on the site). Works well on both screen and print when I test with Chrome.
![image](https://cloud.githubusercontent.com/assets/24532066/21206894/114f5eea-c265-11e6-8d88-3b04d30c0dea.png)

Several tests with images but there is a bug with the diaporama. However, the bug is also here on the screen. (I work with saved pages from the site, so I hope the bug is not related to CSS)
![image](https://cloud.githubusercontent.com/assets/24532066/21206412/07668fa0-c262-11e6-88cf-14e976fef357.png)
![image](https://cloud.githubusercontent.com/assets/24532066/21206398/f157e178-c261-11e6-9027-dbfc2fe55aa5.png)

If someone could test and confirm (or not) that the bugs I have found are not related to CSS problem but to the "extract" I have made from the site.



