### PR TITLE
set 1st wp as main - route editing

### DIFF
--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -124,16 +124,22 @@ app.Document.prototype.hasAssociation = function(type, id) {
  * @param {appx.SimpleSearchDocument} doc
  * @param {string=} doctype Optional doctype
  * @param {boolean=} setOutingTitle
+ * @param {?boolean} editing
  * @export
  */
 app.Document.prototype.pushToAssociations = function(doc, doctype,
-    setOutingTitle) {
+    setOutingTitle, editing) {
   var associations = this.document.associations;
   doctype = doctype || app.utils.getDoctype(doc['type']);
   setOutingTitle = typeof setOutingTitle !== 'undefined' ?
     setOutingTitle : false;
   doc['new'] = true;
   associations[doctype].push(doc);
+
+  // when creating/editing a route, make the first associated wp a main one
+  if (editing && associations.waypoints.length === 1) {
+    this.document['main_waypoint_id'] = doc['document_id'];
+  }
 
   // When creating an outing, the outing title defaults to the title
   // of the first associated route.
@@ -153,9 +159,10 @@ app.Document.prototype.pushToAssociations = function(doc, doctype,
  * @param {number} id Id of document to unassociate
  * @param {string} type Type of document to unassociate
  * @param {goog.events.Event | jQuery.Event} [event]
+ * @param {?boolean} editing
  * @export
  */
-app.Document.prototype.removeAssociation = function(id, type, event) {
+app.Document.prototype.removeAssociation = function(id, type, event, editing) {
   var associations = this.document.associations[type];
 
   event.currentTarget.closest('.list-item').className += ' remove-item';
@@ -165,6 +172,12 @@ app.Document.prototype.removeAssociation = function(id, type, event) {
     for (var i = 0; i < associations.length; i++) {
       if (associations[i]['document_id'] === id) {
         associations.splice(i, 1);
+
+        // when deleting a wp in route editing - make the first associated wp a main one
+        if (editing && type === 'waypoints' && associations.length === 1) {
+          this.document['main_waypoint_id'] = associations[0]['document_id'];
+        }
+
         this.rootScope_.$apply();
         break;
       }

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -12,13 +12,18 @@
         <app-card app-card-doc="wp" app-card-disable-click="true"></app-card>
         % if model == 'route':
           <b class="set-main-waypoint green-text" ng-if="${model}.main_waypoint_id === wp.document_id" ng-init="${model}.main_waypoint_title = wp.locales[0].title" translate>main waypoint</b>
-          <button class="btn btn-sm btn-default set-main-waypoint" translate
+          <button class="btn btn-sm orange-btn set-main-waypoint" translate
                   ng-click="${model}.main_waypoint_id = wp.document_id; ${model}.main_waypoint_title = wp.locales[0].title"
                   ng-if="${model}.main_waypoint_id != wp.document_id">
             Set as main waypoint
           </button>
+          <button class="btn btn-sm orange-btn set-main-waypoint" translate
+                  ng-click="${model}.main_waypoint_id = null;"
+                  ng-if="${model}.main_waypoint_id == wp.document_id">
+            Unset main waypoint
+          </button>
         % endif
-        <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(wp.document_id, '${type}', $event)"></span>
+        <span class="glyphicon glyphicon-trash" ng-click="editCtrl.documentService.removeAssociation(wp.document_id, '${type}', $event, true)"></span>
       </div>
     </article>
   </section>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -100,7 +100,7 @@ updating_doc = route_id and route_lang
           <div class="content">
             ## wr = waypoints, routes
             <app-simple-search parent-id="route.document_id"
-              app-select="editCtrl.documentService.pushToAssociations(doc)" dataset="wr"></app-simple-search>
+              app-select="editCtrl.documentService.pushToAssociations(doc, null, false, true)" dataset="wr"></app-simple-search>
             ${show_editing_associated_waypoints('route')}
             ${show_editing_associated_routes('route')}
           </div>

--- a/less/lists.less
+++ b/less/lists.less
@@ -178,7 +178,10 @@
     }
   }
   .set-main-waypoint {
-    margin: 0 0 10px 10px;
+    margin-left: 10px;
+    margin-bottom: 10px;
+    padding: 3px 10px;
+    max-height: 26px;
   }
 
   // .list-item.waypoints
@@ -390,6 +393,11 @@
   &.waypoints  {
     &.to-route {
       min-height: 115px;
+      flex-wrap: wrap;
+      .flex();
+      app-card {
+        flex-basis: 100%;
+      }
     }
     a {
       height: auto;


### PR DESCRIPTION
related to #1165

+ if creating/editing a route - the first waypoint is set to main by default : if you have 2 waypoints and delete the 1 which was the main wp -> the last remaining wp will become main. If you have no waypoints at all, the 1st will be main. 
+ possibility to unset the main wp.

![screenshot from 2016-12-15 10-51-28](https://cloud.githubusercontent.com/assets/7814311/21219281/7427d246-c2b4-11e6-8203-4cc7d6a891a8.png)
