### PR TITLE
Preselect activity when uploading image to outing

### DIFF
--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -48,6 +48,7 @@ app.Document = function(appAuthentication, $rootScope) {
     },
     'locales': [{'title': '', 'lang': ''}],
     'type': '',
+    'activities': [],
     'document_id': 0,
     'quality': ''
   });

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -116,6 +116,12 @@ app.ImageUploaderController = function($scope, $uibModal, $compile, $q, appAlert
 
   /**
    * @type {Array.<string>}
+   * @private
+   */
+  this.defaultActivities_ = this.documentService.document.activities || [];
+
+  /**
+   * @type {Array.<string>}
    * @export
    */
   this.types;
@@ -185,7 +191,7 @@ app.ImageUploaderController.prototype.uploadFile_ = function(file) {
     'processed': false,
     'metadata': {
       'id': file['name'] + '-' + new Date().toISOString(),
-      'activities': [],
+      'activities': angular.copy(this.defaultActivities_),
       'categories': [],
       'image_type': this.image_type_,
       'elevation': null,

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -32,6 +32,8 @@
       </div>
 
       <div class="img-data">
+
+
         <!-- TITLE-->
         <input type="text" class="form-control" ng-model="file.metadata.title" placeholder="{{'title' | translate}}" ng-change="uplCtrl.rename(file, file.metadata.title)">
 
@@ -45,7 +47,7 @@
             <ul class="dropdown-menu multiselect-box type">
               <li ng-repeat="activity in activities">
                 <a ng-click="uplCtrl.selectOption(file.metadata, 'activities', activity, $event)">
-                  <input type="checkbox">
+                  <input type="checkbox" ng-checked="file.metadata.activities.indexOf(activity) > -1">
                   <span class="activity">{{activity| translate}}</span>
                 </a>
               </li>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -61,6 +61,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     "document_id": ${outing.get('document_id')},
     "lang": "${lang}",
     "type": "o",
+    "activities": ${dumps(outing.get('activities')) | n},
     "topic_id": ${dumps(locale.get('topic_id'))}
     % if not version:
        , "associations": ${dumps(outing.get('associations')) | n}

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -74,6 +74,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     "document_id": ${route.get('document_id')},
     "lang": "${lang}",
     "type": "r",
+    "activities": ${dumps(route.get('activities')) | n},
     "topic_id": ${dumps(locale.get('topic_id'))},
     % if route.get('orientations'):
       "orientations": [${'"' + '","'.join(route['orientations']) + '"' if len(route['orientations']) else '' | n}],


### PR DESCRIPTION
related to #1014

when you upload images to a outing, preselect the activities for all images, being those of the outing.

Seems pretty simple but I've got a problem I cannot solve, maybe @tsauerwein you have an idea. 

1) upload multiple images
2) they do get their activities preselected, being those of the outing
3) when I change the activities of one image, it changes the activities of all of them
4) if I don't use a variable like` 'activities': this.defaultActivities_` but instead `'activities': ['hiking', 'snowshoeing']`, no problem with defining specific activities for every image.

Any ideas?
