### PR TITLE
update associations in view.html + tooltip translations

### DIFF
--- a/c2corg_ui/static/partials/cards/areas.html
+++ b/c2corg_ui/static/partials/cards/areas.html
@@ -7,8 +7,8 @@
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality' | translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
-    <span class="area-type">{{::doc['area_type'] | translate}}</span>
+         uib-tooltip="{{'quality' | translate}} : {{doc['quality'] | translate}}" tooltip-append-to-body="true"></div>
+    <span class="area-type">{{doc['area_type'] | translate}}</span>
 
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/articles.html
+++ b/c2corg_ui/static/partials/cards/articles.html
@@ -6,15 +6,15 @@
       <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 
-    <b class="article-type margin-t-sm margin-b-sm"><span class="green-text glyphicon glyphicon-tag margin-r-sm"></span>{{::doc['article_type']| translate }}</b>
+    <b class="article-type margin-t-sm margin-b-sm"><span class="green-text glyphicon glyphicon-tag margin-r-sm"></span>{{doc['article_type'] | translate}}</b>
 
     <div class="article-categories">
-      <b ng-repeat="category in ::doc.categories" class="value">{{::category | translate }}{{$last ? '' : ', '}}</b>
+      <b ng-repeat="category in ::doc.categories" class="value">{{category | translate }}{{$last ? '' : ', '}}</b>
     </div>
 
     <div class="activities flex wrap-row margin-t-sm">
       <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+            uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true"></span>
 
       <span class="flex flexend-align show-more-activities"
             ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
@@ -23,12 +23,12 @@
       </span>
 
       <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
-            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+            class="activity icon-{{::activity}}" uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true">
       </span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-append-to-body="true">
     </div>
 
   </div>

--- a/c2corg_ui/static/partials/cards/books.html
+++ b/c2corg_ui/static/partials/cards/books.html
@@ -7,12 +7,12 @@
     </div>
 
     <div class="article-categories">
-      <span ng-repeat="book_type in ::doc['book_types']" class="value book-type">{{::book_type | translate }}{{$last ? '' : ', '}}</span>
+      <span ng-repeat="book_type in ::doc['book_types']" class="value book-type">{{book_type | translate}}{{$last ? '' : ', '}}</span>
     </div>
 
     <div class="activities flex wrap-row margin-t-sm">
       <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
-            uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+            uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true"></span>
 
       <span class="flex flexend-align show-more-activities"
             ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
@@ -21,12 +21,12 @@
       </span>
 
       <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
-            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+            class="activity icon-{{::activity}}" uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true">
       </span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-append-to-body="true"></div>
 
     <div class="author margin-t-sm" ng-if="::doc['author']">
       <span class="glyphicon glyphicon-pencil"></span>

--- a/c2corg_ui/static/partials/cards/images.html
+++ b/c2corg_ui/static/partials/cards/images.html
@@ -4,7 +4,7 @@
   <div class="list-item-info">
 
     <div class="list-item-title-lang" ng-if="locale.title">
-      <span class="list-item-title"><p translate>{{::locale.title}}</p></span>
+      <span class="list-item-title"><p>{{::locale.title}}</p></span>
       <span class="list-item-lang" ng-if="cardCtrl.lang != locale.lang">({{::locale.lang}})</span>
     </div>
 

--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -26,7 +26,7 @@
     <div class="activity-author">
       <div class="activities flex wrap-row margin-t-sm">
         <span ng-repeat="activity in ::doc.activities | limitTo: 4"  class="activity icon-{{::activity}}"
-              uib-tooltip="{{ cardCtrl.translate(activity)}}"></span>
+              uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true"></span>
 
         <span class="flex flexend-align show-more-activities"
               ng-if="doc.activities.length > 4 && !cardCtrl.remainingActivities"
@@ -35,7 +35,7 @@
         </span>
 
         <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
-              class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+              class="activity icon-{{::activity}}" uib-tooltip="{{cardCtrl.translate(activity)}}" tooltip-append-to-body="true">
         </span>
       </div>
 
@@ -46,7 +46,7 @@
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality' | translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+         uib-tooltip="{{'quality' | translate}} : {{doc['quality'] | translate}}" tooltip-append-to-body="true">
     </div>
   </div>
 

--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -7,7 +7,8 @@
     </div>
 
     <div class="flex wrap-row center-items-align margin-b-sm route-infos">
-      <span class="elevation margin-r-sm" ng-if="::doc['elevation_max']" uib-tooltip="{{'elevation_max'| translate}}">
+      <span class="elevation margin-r-sm" ng-if="::doc['elevation_max']"
+            uib-tooltip="{{'elevation_max'| translate}}" tooltip-append-to-body="true">
         <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
         <span class="value">{{::doc['elevation_max']}}&nbsp;m</span>
       </span>
@@ -17,12 +18,14 @@
         <span class="value">{{::doc['height_diff_up']}}&nbsp;m</span>
       </span>
 
-      <span class="height-diff-difficulties" ng-if="::doc['height_diff_difficulties']" uib-tooltip="{{'height_diff_difficulties'| translate}}">
+      <span class="height-diff-difficulties" ng-if="::doc['height_diff_difficulties']"
+            uib-tooltip="{{'height_diff_difficulties'| translate}}" tooltip-append-to-body="true">
         <span class="value-title glyphicon glyphicon-resize-vertical"></span>
         <span class="value">{{::doc['height_diff_difficulties']}}&nbsp;m</span>
       </span>
 
-      <div ng-if="::doc['orientations']" class="orientations" uib-tooltip="{{'orientations'| translate}}">
+      <div ng-if="::doc['orientations']" class="orientations"
+           uib-tooltip="{{'orientations'| translate}}" tooltip-append-to-body="true">
         <span class="glyphicon glyphicon-fullscreen"></span>
         <span ng-repeat="o in ::doc['orientations']">{{o}}{{$last ? '' : ', '}}</span>
       </div>
@@ -35,24 +38,26 @@
 
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
+         uib-tooltip="{{'quality' | translate}} : {{doc['quality'] | translate}}" tooltip-append-to-body="true"></div>
 
     <div class="global-rating flex" ng-init="globalRatings = cardCtrl.getGlobalRatings()">
       <span class="icon-rating" ng-if="::globalRatings"></span>
-      <div ng-repeat="(attr, val) in ::globalRatings" class="rating" uib-tooltip="{{::attr| translate}}" ng-if="::val">
+      <div ng-repeat="(attr, val) in ::globalRatings" class="rating" tooltip-append-to-body="true" uib-tooltip="{{attr | translate}}" ng-if="::val">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
     <div class="full-rating flex" ng-init="fullRatings = cardCtrl.getFullRatings()">
       <span class="icon-rating" ng-if="::fullRatings"></span>
-      <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{::attr| translate}}" class="rating">
+      <div ng-repeat="(attr, val) in ::fullRatings" uib-tooltip="{{attr | translate}}" class="rating" tooltip-append-to-body="true">
         <span class="value">{{::val}}</span>
       </div>
     </div>
 
     <div class="activities">
-      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}" uib-tooltip="{{ ::cardCtrl.translate(activity)}}"></span>
+      <span ng-repeat="activity in ::doc.activities" class="activity icon-{{::activity}}"
+        uib-tooltip="{{activity | translate}}" tooltip-append-to-body="true">
+      </span>
     </div>
 
   </div>

--- a/c2corg_ui/static/partials/cards/waypoints.html
+++ b/c2corg_ui/static/partials/cards/waypoints.html
@@ -1,6 +1,8 @@
 <a ng-href="{{cardCtrl.createURL()}}" ng-init="doc = cardCtrl.doc; locale = cardCtrl.locale;">
   <div class="flex wrap-row center-items-align">
-    <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type" uib-tooltip="{{ ::cardCtrl.translate(doc['waypoint_type'])}}"></span>
+    <span class="{{'icon-' + doc['waypoint_type']}} waypoint-type"
+      uib-tooltip="{{doc['waypoint_type'] | translate}}" tooltip-append-to-body="true">
+    </span>
 
     <div class="list-item-info">
       <div class="list-item-title-lang">
@@ -9,7 +11,8 @@
       </div>
 
       <div class="waypoint-infos">
-        <span class="waypoint-elevation margin-r-sm margin-b-sm" ng-if="::doc['elevation']" uib-tooltip="{{'elevation_max'| translate}}">
+        <span class="waypoint-elevation margin-r-sm margin-b-sm" ng-if="::doc['elevation']"
+              uib-tooltip="{{'elevation_max'| translate}}" tooltip-append-to-body="true">
           <span class="value-title glyphicon glyphicon-sort-by-attributes rotate-180"></span>
           <span class="value">{{::doc['elevation']}}&nbsp;m</span>
         </span>
@@ -21,7 +24,7 @@
       </div>
 
       <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-           uib-tooltip="{{'quality'| translate}} : {{::doc['quality']| translate}}" tooltip-placement="left"></div>
+           uib-tooltip="{{'quality'| translate}} : {{doc['quality']| translate}}" tooltip-append-to-body="true"></div>
     </div>
   </div>
 </a>

--- a/c2corg_ui/static/partials/cards/xreports.html
+++ b/c2corg_ui/static/partials/cards/xreports.html
@@ -34,12 +34,12 @@
       </span>
 
       <span ng-if="cardCtrl.remainingActivities" ng-repeat="activity in ::doc.activities | limitTo: (4 - doc.activities.length)"
-            class="activity icon-{{::activity}}" uib-tooltip="{{ cardCtrl.translate(activity)}}">
+            class="activity icon-{{::activity}}" uib-tooltip="{{cardCtrl.translate(activity)}}">
       </span>
     </div>
 
     <div class="quality" ng-if="::doc['quality']" ng-class="::doc['quality']"
-         uib-tooltip="{{'quality'| translate}} : {{::doc['quality'] | translate}}" tooltip-placement="left">
+         uib-tooltip="{{'quality'| translate}} : {{doc['quality'] | translate}}" tooltip-placement="left">
     </div>
 
   </div>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -245,6 +245,7 @@
 
 <%def name="show_associated_xreports(document)">\
   <%
+    type='xreports'
     xreports = document['associations']['xreports']
     associations = 'detailsCtrl.documentService.document.associations.' + type
   %>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -6,7 +6,7 @@ from json import dumps
 
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/view.html" import="get_comments, get_image_gallery,
-    photoswipe_gallery, get_document_min_max,
+    photoswipe_gallery, get_document_min_max, show_associated_xreports,
     get_document_locale_text, show_missing_langs_links, show_other_langs_links,
     show_archive_data, show_locale_title, get_activities, show_areas, show_float_buttons,
     show_associated_waypoints, show_associated_routes, show_associated_articles,
@@ -138,6 +138,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
       <section>
         ${show_associated_routes(outing)}
         ${show_associated_articles(outing)}
+        ${show_associated_xreports(outing)}
       </section>
     </span>
   </div>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -134,6 +134,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   </div>
 
   ## ASSOCIATIONS
+  ## route has always at least 1 associated waypoint so this div will always be displayed
   % if not version:
     <div class="view-details-associations col-xs-12  associations">
       <span class="lead">

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -137,10 +137,11 @@ waypoint['doctype'] = 'waypoints'
 
   ## ASSOCIATIONS
   % if not version:
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations" ng-init="a = detailsCtrl.documentService.document.associations"
+         ng-show="userCtrl.auth.isAuthenticated() || a.waypoint_children.length || a.waypoints.length">
       <span class="lead">
         <section>
-          <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+          <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()">
             <label translate>Add association</label>
             <app-add-association parent-id="${waypoint_id}" parent-doctype="waypoints" dataset="wcb"></app-add-association>
           </div>
@@ -149,7 +150,7 @@ waypoint['doctype'] = 'waypoints'
         </section>
       </span>
     </div>
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations" ng-show="a.all_routes.total > 0">
       <span class="lead">
         <section>
           ${show_associated_routes(waypoint, 'all_routes')}
@@ -158,8 +159,7 @@ waypoint['doctype'] = 'waypoints'
     </div>
 
     <div class="view-details-associations col-xs-12 associations"
-         ng-init="associations = detailsCtrl.documentService.document.associations"
-         ng-show="associations.recent_outings.total || associations.articles.length || associations.books.length">
+         ng-show="associations.recent_outings.total > 0 || associations.articles.length || associations.books.length">
       <span class="lead">
         <section>
           ${show_associated_articles(waypoint)}

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -141,7 +141,7 @@ waypoint['doctype'] = 'waypoints'
          ng-show="userCtrl.auth.isAuthenticated() || a.waypoint_children.length || a.waypoints.length">
       <span class="lead">
         <section>
-          <div class="add-association" ng-show="userCtrl.auth.isAuthenticated()">
+          <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
             <label translate>Add association</label>
             <app-add-association parent-id="${waypoint_id}" parent-doctype="waypoints" dataset="wcb"></app-add-association>
           </div>
@@ -158,8 +158,7 @@ waypoint['doctype'] = 'waypoints'
       </span>
     </div>
 
-    <div class="view-details-associations col-xs-12 associations"
-         ng-show="associations.recent_outings.total > 0 || associations.articles.length || associations.books.length">
+    <div class="view-details-associations col-xs-12 associations" ng-show="a.recent_outings.total > 0 || a.articles.length || a.books.length">
       <span class="lead">
         <section>
           ${show_associated_articles(waypoint)}

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -137,7 +137,8 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
 
   ## ASSOCIATIONS
   % if not version:
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations" ng-init="a = detailsCtrl.documentService.document.associations"
+         ng-show="a.waypoints.length || a.routes.length || a.articles.length || a.outings.length">
       <span class="lead">
 ##         <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
 ##           <label translate>Add association</label>

--- a/c2corg_ui/tests/views/data/outing.json
+++ b/c2corg_ui/tests/views/data/outing.json
@@ -116,6 +116,27 @@
 			"elevation_min": 441,
 			"activities": ["hiking"]
 		}],
+		"xreports": [{
+			"type": "x",
+			"available_langs": [ "fr"],
+			"date": "2016-08-19",
+			"version": 1,
+			"event_type": [
+			  "stone_fall"
+			],
+			"nb_participants": 5,
+			"avalanche_slope": null,
+			"locales": [{
+			    "version": 1,
+			    "lang": "fr",
+			    "title": "Aiguille du Grand Laus : Le bonheur est dans le pré - chute de pierre et secours"
+			}],
+			"protected": false,
+			"activities": ["mountain_climbing"],
+			"avalanche_level": null,
+			"elevation": 2400,
+			"document_id": 792147
+		}],
 		"images": [{
 			"protected": false,
 			"locales": [{


### PR DESCRIPTION
related to #1045 
related to #1172

related to #1147 and #1145 (translations) -> double points `::` one-way-binding caused some strings to not to be translated sometimes.

adding `tooltip-append-to-body="true"` to every tooltip fixes the issue of the tooltip being cut because of the parent div ! :fireworks: 