### PR TITLE
health: add maintenance mode

### DIFF
--- a/c2corg_ui/views/health.py
+++ b/c2corg_ui/views/health.py
@@ -22,6 +22,7 @@ class Health(object):
             - API status
             - Redis status
             - Number of keys in Redis
+            - Maintenance mode status
 
         """
         status = {

--- a/c2corg_ui/views/health.py
+++ b/c2corg_ui/views/health.py
@@ -73,8 +73,9 @@ class Health(object):
 
         if isfile(maintenance_file):
             maintenance_mode = True
-            log.warn('service is in maintenance mode, remove %s to reenable.' %
-                    maintenance_file)
+            log.warn(
+              'service is in maintenance mode, remove %s to reenable.' %
+              maintenance_file)
             self.request.response.status_code = 404
 
         status['maintenance_mode'] = maintenance_mode

--- a/c2corg_ui/views/health.py
+++ b/c2corg_ui/views/health.py
@@ -75,6 +75,6 @@ class Health(object):
             maintenance_mode = True
             log.warn('service is in maintenance mode, remove %s to reenable.' %
                     maintenance_file)
-            self.request.response.status_code = 503
+            self.request.response.status_code = 404
 
         status['maintenance_mode'] = maintenance_mode

--- a/c2corg_ui/views/health.py
+++ b/c2corg_ui/views/health.py
@@ -3,6 +3,7 @@ import logging
 from c2corg_ui.caching import cache_document_detail
 from c2corg_ui.views import call_api
 from pyramid.view import view_config
+from os.path import isfile
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class Health(object):
 
         self._add_redis_status(status)
         self._add_api_status(status)
+        self._add_maintenance_mode_status(status)
 
         return status
 
@@ -64,3 +66,15 @@ class Health(object):
 
         status['api'] = 'ok' if success else 'error'
         status['api_status'] = api_status
+
+    def _add_maintenance_mode_status(self, status):
+        maintenance_mode = False
+        maintenance_file = 'maintenance_mode.txt'
+
+        if isfile(maintenance_file):
+            maintenance_mode = True
+            log.warn('service is in maintenance mode, remove %s to reenable.' %
+                    maintenance_file)
+            self.request.response.status_code = 503
+
+        status['maintenance_mode'] = maintenance_mode


### PR DESCRIPTION
When doing upgrades, simply shutting down the service will kill ongoing
requests.

With this "maintenance mode", `docker exec <container> touch maintenance_mode.txt`
will gracefully remove the server from the load-balancer, letting the
open connections terminate but not sending any new ones to it. After a
few seconds, the service can be safely shutdown and upgraded.