### PR TITLE
Bug with image title displaying with pswp

### DIFF
--- a/less/images.less
+++ b/less/images.less
@@ -168,7 +168,7 @@
 .photoswipe-image-container {
   height: 100%;
   display: flex;
-  align-items: center;
+  flex-direction: column;
 
   @media @phone {
     .calc(height, "100% - 45px");


### PR DESCRIPTION
Adding `flex-direction: column` allow the hover to work (but `row` not, maybe a conflict with the absolute position of the title?)
`align-items: center` apports nothing because the img is already `margin: auto` so it's horizontal centered, but aligns the title in the middle (by default with flex-direction to column, it's on the left) -> removed

Related to #1182