### PR TITLE
Define full-width homepage toolbar on mobile

### DIFF
--- a/less/homepage.less
+++ b/less/homepage.less
@@ -128,6 +128,8 @@
     }
     @media @phone {
       width: 100%;
+      right:0;
+      border-radius: unset;
       .float-buttons, .float-button {
         margin-right: 5px;
       }
@@ -139,4 +141,3 @@
   }
   /*end home-page*/
 }
-


### PR DESCRIPTION
Before:
![snapshot7](https://cloud.githubusercontent.com/assets/2234024/21440520/a6b321d6-c893-11e6-8a79-2f03935426e3.png)

After:
![snapshot8](https://cloud.githubusercontent.com/assets/2234024/21440521/a6db19ca-c893-11e6-9787-35955e2b466f.png)