### PR TITLE
Add a link to the forum profile in the UI profile page

### DIFF
--- a/c2corg_ui/templates/profile/helpers/view.html
+++ b/c2corg_ui/templates/profile/helpers/view.html
@@ -7,7 +7,12 @@
       <p translate>General</p>
     </div>
     <span class="detail-text accordion">
-      <p><span translate class="value-title">Forum username</span>: <span class="value">${profile['forum_username']}</span></p>
+      <p>
+        <span translate class="value-title">Forum username</span>:
+        <span class="value">
+          <a href="${discourse_url}users/${profile['forum_username']}">${profile['forum_username']}</a>
+        </span>
+      </p>
 
       % if profile.get('activities'):
         <article class="value activities">


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/973

<img width="654" alt="capture d ecran 2016-12-27 a 19 59 36" src="https://cloud.githubusercontent.com/assets/1192331/21506308/7780e486-cc6f-11e6-812c-3ca21f151851.png">


It would be useful to have a revert link (forum profile > UI profile) but it's a bit more complicated because the user id is not known in the profile (?). A solution would be to have a UI service ``profiles/<forum username>`` that would redirect to the actual profile URL via an API request to get the user id from the forum username.