### PR TITLE
Images upload fixes

### DIFF
--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -199,8 +199,7 @@ app.Document.prototype.removeAssociation = function(id, type, event, editing) {
 app.Document.prototype.isCollaborative = function(type) {
   if (type === 'waypoints' || type === 'routes' || type === 'books') {
     return true;
-  } else if (type === 'xreports') {
-    // personal -> check if user == owner
+  } else if (type === 'users' || type === 'xreports') {
     return false;
   } else if (type === 'outings' || type === 'articles') {
     // check if user == owner or participant of the outing/article

--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -188,28 +188,27 @@ app.Document.prototype.removeAssociation = function(id, type, event, editing) {
 
 
 /**
- * - waypoints, routes and books are collaborative
- * - outings and books are personal and we have to check if the current user
- *   has editing rights
- * - images can be both and we have to check the image_type property
  * @param {string} type
  * @return boolean
  * @export
  */
 app.Document.prototype.isCollaborative = function(type) {
-  if (type === 'waypoints' || type === 'routes' || type === 'books') {
-    return true;
-  } else if (type === 'users' || type === 'xreports') {
-    return false;
-  } else if (type === 'outings' || type === 'articles') {
-    // check if user == owner or participant of the outing/article
-    return this.auth_.hasEditRights(type, this.document.associations['users']);
-  } else if (type === 'images') {
-    return this.document['image_type'] === 'collaborative';
-  } else if (type === 'articles') {
-    return this.document['article_type'] === 'collaborative';
+  switch (type) {
+    case 'waypoints':
+    case 'routes':
+    case 'books':
+      return true;
+    case 'outings':
+    case 'users':
+    case 'xreports':
+      return false;
+    case 'images':
+      return this.document['image_type'] === 'collaborative';
+    case 'articles':
+      return this.document['article_type'] === 'collab';
+    default:
+      return false;
   }
-  return true;
 };
 
 app.module.service('appDocument', app.Document);

--- a/c2corg_ui/static/js/documentservice.js
+++ b/c2corg_ui/static/js/documentservice.js
@@ -125,7 +125,7 @@ app.Document.prototype.hasAssociation = function(type, id) {
  * @param {appx.SimpleSearchDocument} doc
  * @param {string=} doctype Optional doctype
  * @param {boolean=} setOutingTitle
- * @param {?boolean} editing
+ * @param {boolean=} editing
  * @export
  */
 app.Document.prototype.pushToAssociations = function(doc, doctype,
@@ -160,7 +160,7 @@ app.Document.prototype.pushToAssociations = function(doc, doctype,
  * @param {number} id Id of document to unassociate
  * @param {string} type Type of document to unassociate
  * @param {goog.events.Event | jQuery.Event} [event]
- * @param {?boolean} editing
+ * @param {boolean=} editing
  * @export
  */
 app.Document.prototype.removeAssociation = function(id, type, event, editing) {

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -152,6 +152,12 @@ app.ImageUploaderController = function($scope, $uibModal, $compile, $q,
    */
   this.resizeOptions = {'width': 2048, 'height': 2048, 'quality': 0.9};
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.saving = false;
+
   this.scope_['activities'] = this.activities;
   this.scope_['types'] = this.types;
   this.scope_['categories'] = this.categories;
@@ -475,7 +481,9 @@ app.ImageUploaderModalController = function($scope, $uibModalInstance) {
  * @export
  */
 app.ImageUploaderModalController.prototype.close = function() {
-  this.modalInstance_.close();
+  if (!this.scope_['uplCtrl'].saving) {
+    this.modalInstance_.close();
+  }
 };
 
 
@@ -483,7 +491,14 @@ app.ImageUploaderModalController.prototype.close = function() {
  * @export
  */
 app.ImageUploaderModalController.prototype.save = function() {
-  this.scope_['uplCtrl'].save().then(function() {
+  var uplCtrl = this.scope_['uplCtrl'];
+  if (uplCtrl.saving) {
+    // saving is already in progress
+    return;
+  }
+  uplCtrl.saving = true;
+  uplCtrl.save().then(function() {
+    uplCtrl.saving = false;
     this.modalInstance_.close();
   }.bind(this));
 };

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -42,11 +42,13 @@ app.module.directive('appImageUploader', app.imageUploaderDirective);
  * @param {app.Document} appDocument service
  * @param {String} imageUrl URL to the image backend.
  * @param {app.Url} appUrl
+ * @param {app.Authentication} appAuthentication
  * @constructor
  * @struct
  * @ngInject
  */
-app.ImageUploaderController = function($scope, $uibModal, $compile, $q, appAlerts, appApi, appDocument, imageUrl, appUrl) {
+app.ImageUploaderController = function($scope, $uibModal, $compile, $q,
+    appAlerts, appApi, appDocument, imageUrl, appUrl, appAuthentication) {
 
   /**
    * @type {app.Document}
@@ -65,6 +67,12 @@ app.ImageUploaderController = function($scope, $uibModal, $compile, $q, appAlert
    * @private
    */
   this.api_ = appApi;
+
+  /**
+   * @type {app.Authentication}
+   * @private
+   */
+  this.auth_ = appAuthentication;
 
   /**
    * @type {app.Url}
@@ -406,6 +414,23 @@ app.ImageUploaderController.prototype.resizeIf = function(
     return file.size > 2 * 1024 * 1024; /** 2 MB */
   }
   return false;
+};
+
+
+/**
+ * @param {Array.<string>} imageTypes
+ * @return {Array.<string>}
+ * @export
+ */
+app.ImageUploaderController.prototype.filterImageTypes = function(imageTypes) {
+  if (this.auth_.isModerator()) {
+    // moderators have access to all image types
+    return imageTypes;
+  }
+  var removeCopyright = function(val) {
+    return val !== 'copyright';
+  };
+  return imageTypes.filter(removeCopyright);
 };
 
 

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -146,6 +146,12 @@ app.ImageUploaderController = function($scope, $uibModal, $compile, $q,
    */
   this.image_type_ = this.setImageType_();
 
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.resizeOptions = {'width': 2048, 'height': 2048, 'quality': 0.9};
+
   this.scope_['activities'] = this.activities;
   this.scope_['types'] = this.types;
   this.scope_['categories'] = this.categories;

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -75,7 +75,7 @@
               <span class="glyphicon glyphicon-menu-down"></span>
             </button>
             <ul class="dropdown-menu">
-              <li ng-repeat="type in types">
+              <li ng-repeat="type in uplCtrl.filterImageTypes(types)">
                 <div class="radio">
                   <label><input type="radio" ng-model="file.metadata.image_type" ng-value="type">{{type | translate}}</label>
                 </div>

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -9,7 +9,7 @@
        ngf-fix-orientation="true"
        ngf-allow-dir="true"
        ngf-resize-if="uplCtrl.resizeIf($file, $width, $height)"
-       ngf-resize="{width: 2048, height: 2048, quality: 0.9}"
+       ngf-resize="uplCtrl.resizeOptions"
        accept="image/*"
        ngf-pattern="'image/*'">
     <span translate>Drop images here or click to upload</span>
@@ -113,6 +113,8 @@
          ngf-keep="'distinct'"
          ngf-fix-orientation="true"
          ngf-allow-dir="true"
+         ngf-resize-if="uplCtrl.resizeIf($file, $width, $height)"
+         ngf-resize="uplCtrl.resizeOptions"
          accept="image/*"
          ngf-pattern="'image/*'">
       <button class="orange-btn btn" type="button" translate>Add images</button>

--- a/c2corg_ui/static/partials/imageuploader.html
+++ b/c2corg_ui/static/partials/imageuploader.html
@@ -120,5 +120,8 @@
       <button class="orange-btn btn" type="button" translate>Add images</button>
     </div>
   </div>
-  <button class="btn btn-warning" type="button" ng-click="imageModalCtrl.close()" translate>Close</button>
-  <button class="btn btn-primary" type="button" ng-click="imageModalCtrl.save()" ng-show="uplCtrl.areAllUploaded" translate>Save</button>
+  <button class="btn btn-warning" type="button" ng-click="imageModalCtrl.close()"
+          ng-class="{disabled: uplCtrl.saving}" translate>Close</button>
+  <button class="btn btn-primary" type="button" ng-click="imageModalCtrl.save()"
+          ng-class="{disabled: uplCtrl.saving}"
+          ng-show="uplCtrl.areAllUploaded" translate>Save</button>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -34,6 +34,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
     "document_id": ${article.get('document_id')},
     "lang": "${lang}",
     "type": "c",
+    "article_type": "${article.get('article_type')}",
     "topic_id": ${dumps(locale.get('topic_id'))}
     % if not version:
        , "associations": ${dumps(article.get('associations')) | n}

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -56,6 +56,7 @@ from json import dumps
     "document_id": ${image.get('document_id')},
     "lang": "${lang}",
     "type": "i",
+    "image_type": "${image.get('image_type')}",
     "topic_id": ${dumps(locale.get('topic_id'))}
     % if not version:
        , "associations": ${dumps(image.get('associations')) | n}


### PR DESCRIPTION
* Only moderators can upload copyright-typed images => see https://github.com/c2corg/v6_ui/issues/1272
* Client-side resizing was active only for the initial upload panel, not for the additional panel shown after a first upload has been triggered => there was no resizing in that case => perhaps causing https://github.com/c2corg/v6_ui/issues/929#issuecomment-268836270
* Save/Close buttons are disabled after clicking the Save button => prevent multiple requests, see https://github.com/c2corg/v6_ui/issues/1112 It would be nice to show a loading indicator too but not sure we can really use the ``appLoading`` directive here since we don't want to trigger the loading indicator when uploading files, only when saving the images data to the API.