### PR TITLE
Open the comment URL in the current page

### DIFF
--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -338,7 +338,7 @@ app.ViewDetailsController.prototype.createTopic = function() {
     this.documentService.document.topic_id = topic_id;
     this.getComments();
     var url = this.discourseUrl_ + 't/' + document_id + '_' + lang + '/' + topic_id;
-    window.open(url);
+    window.location = url;
   }.bind(this));
 };
 


### PR DESCRIPTION
because opening a new window might be disabled by popup policies.

Related to  https://github.com/c2corg/v6_ui/issues/1216#issuecomment-270126737