### PR TITLE
Correct position of thumbnails in feed

### DIFF
--- a/less/feed.less
+++ b/less/feed.less
@@ -39,18 +39,20 @@
         transform: scale(1.1);
       }
     }
-    .big-image {
+    
+    a {
       float: left;
-      height: 150px;
-      width: 60%;
-    }
-    .small-image {
-      float: left;
-      width: 38%;
-      height: 73px;
-      margin-left: 5px;
-      &:last-of-type {
-        margin-top: -5px;
+      &:nth-child(2) {
+        margin-bottom: 5px;
+      }
+      &.big-image {
+        height: 150px;
+        width: 60%;
+      }
+      &.small-image {
+        width: 38%;
+        height: 73px;
+        margin-left: 5px;
       }
     }
   }


### PR DESCRIPTION
When there are 2 images, ensure correct position.

Before:
![certif3](https://cloud.githubusercontent.com/assets/2234024/21716886/d1bb5f9e-d40d-11e6-9b67-a8fdedb86623.png)

Now:
![certif2](https://cloud.githubusercontent.com/assets/2234024/21716885/d1b98d9a-d40d-11e6-842c-17ada9f252cb.png)
