### PR TITLE
Fix version of pyramid_closure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
+-e git+https://github.com/camptocamp/pyramid_closure@1.0.0#egg=pyramid_closure
 
 pyramid==1.7
 pyramid-debugtoolbar==2.4.2


### PR DESCRIPTION
Fix the error that recently appeared after new commits in pyramid_closure.
I have tried to use version 1.1.0 but also had the error.