### PR TITLE
Make OL buttons styling consistent

### DIFF
--- a/less/map.less
+++ b/less/map.less
@@ -141,10 +141,19 @@ app-map-search {
   top: 10px;
 }
 
-.ol-control button {
-  background-color: @btn-primary-bg;
+.ol-control {
+  background-color: initial;
 
-  &:hover, &:focus {
-    background-color: fadeout(@btn-primary-bg, 10%);
+  &:hover {
+    background-color: initial;
+  }
+
+  button {
+    background-color: @btn-primary-bg;
+
+    &:hover, &:focus {
+      background-color: darken(@btn-primary-bg, 10%);
+      border-color: darken(@btn-primary-border, 25%);
+    }
   }
 }


### PR DESCRIPTION
* no semi-transparent border around attribution button
* when hovered, darken like other bootstrap buttons rather than ligthen

E.g. attribution button hovered:
![certif4](https://cloud.githubusercontent.com/assets/2234024/21765216/b8f1b13c-d667-11e6-9879-3631488367ee.png)
