### PR TITLE
Use links rather than buttons for 'show more results'

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -394,8 +394,10 @@
           <%
               fragment = '{0}={1}'.format(document['type'], document['document_id'])
           %>
-          <div class="list-item vertical-align" onclick="window.location='${request.route_path('outings_index')}#${fragment}';">
-            <button class="gray-btn btn show-more" translate>show more</button>
+          <div class="list-item">
+            <a class="vertical-align" ng-href="${request.route_path('outings_index')}#${fragment}">
+              <button class="gray-btn btn show-more" translate>show more</button>
+            </a>
           </div>
         % endif
       </div>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -300,8 +300,10 @@
           <%
               fragment = '{0}={1}'.format(document['type'], document['document_id'])
           %>
-          <div class="list-item vertical-align" onclick="window.location='${request.route_path('routes_index')}#${fragment}';">
-            <button class="gray-btn btn show-more" translate>show more</button>
+          <div class="list-item">
+            <a class="vertical-align" ng-href="${request.route_path('routes_index')}#${fragment}">
+              <button class="gray-btn btn show-more" translate>show more</button>
+            </a>
           </div>
         % endif
         % if document['doctype'] == 'waypoints':


### PR DESCRIPTION
Fixes some items of #1326, namely 'show more results' buttons for

* routes section in waypoint page
* outings section in waypoint page
* outings section in route page