### PR TITLE
Handle different cases with summary and description

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -462,16 +462,18 @@
       <span class="lead">
         <div id="document-description" class="collapse in">
           % if locale.get('summary'):
-            <summary class="document-summary">
-              <label translate>summary</label><br>
+            % if locale.get('description'):
+              <summary class="document-summary">
+                <label translate>summary</label><br>
+                ${show_attr(locale, 'summary')}
+              </summary>
+            % else:
               ${show_attr(locale, 'summary')}
-            </summary>
+            % endif
           % endif
 
           % if locale.get('description'):
             ${show_attr(locale, 'description')}
-          % else:
-            <h3 class="text-center" translate>No description available</h3>
           % endif
         </div>
       </span>


### PR DESCRIPTION
When there is a summary but no description, display the summary as if it was the description