### PR TITLE
Wind roses simplification

### DIFF
--- a/c2corg_ui/templates/helpers/orientations.svg
+++ b/c2corg_ui/templates/helpers/orientations.svg
@@ -1,257 +1,32 @@
 <%def name="show_orientations(ctrl, model, filterName='')">\
-  <svg
-     xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:cc="http://creativecommons.org/ns#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:svg="http://www.w3.org/2000/svg"
-     xmlns="http://www.w3.org/2000/svg"
-     xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-     width="200"
-     height="200"
-     viewBox="0 0 744.09448819 1052.3622047"
-     id="orientation-svg"
-     version="1.1"
-     inkscape:version="0.91 r13725"
-     sodipodi:docname="orientation.svg"
-     inkscape:export-xdpi="87.938904"
-     inkscape:export-ydpi="87.938904">
-    <defs
-       id="defs4" />
-    <sodipodi:namedview
-       id="base"
-       pagecolor="#ffffff"
-       bordercolor="#666666"
-       borderopacity="1.0"
-       inkscape:pageopacity="0.0"
-       inkscape:pageshadow="2"
-       inkscape:zoom="2.8"
-       inkscape:cx="89.770297"
-       inkscape:cy="94.212051"
-       inkscape:document-units="px"
-       inkscape:current-layer="g4160"
-       showgrid="false"
-       inkscape:window-width="1855"
-       inkscape:window-height="1056"
-       inkscape:window-x="3585"
-       inkscape:window-y="24"
-       inkscape:window-maximized="1" />
-    <metadata
-       id="metadata7">
-      <rdf:RDF>
-        <cc:Work
-           rdf:about="">
-          <dc:format>image/svg+xml</dc:format>
-          <dc:type
-             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-          <dc:title></dc:title>
-        </cc:Work>
-      </rdf:RDF>
-    </metadata>
-    <g
-       inkscape:label="Layer 1"
-       inkscape:groupmode="layer"
-       id="layer1">
-      <g
-         style="shape-rendering:geometricPrecision"
-         id="g4163"
-         transform="matrix(0.46798709,0,0,0.46798709,1.1749871,-0.80949143)">
-        <g
-           id="g4160"
-           transform="translate(-134.37278,-286.88378)">
-          <g ng-click="${ctrl}.toggleOrientation('N', ${model}, $event, '${filterName}')">
-            <rect x="722.5813"  y="453.6731" width="400" height="400" style="opacity: 0;"></rect>
-            <text
-                   ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('N') > -1 }"
-                   style="font-size:294.78234863px;fill:#808080"
-                   x="822.5813"
-                   y="753.6731"
-                   font-size="55"
-                   id="text-N"
-                   inkscape:export-xdpi="87.938904"
-                   inkscape:export-ydpi="87.938904">N</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('NE', ${model}, $event, '${filterName}')">
-             <rect x="1360"  y="700" width="350" height="300" style="opacity: 0;"></rect>
-             <text
-                  ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('NE') > -1 }"
-                  style="font-size:155px;fill:#808080"
-                  x="1420"
-                  y="900"
-                  font-size="35"
-                  id="text-NE"
-                  inkscape:export-xdpi="87.938904"
-                  inkscape:export-ydpi="87.938904">NE</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('NW', ${model}, $event, '${filterName}')">
-            <rect x="140"  y="700" width="350" height="300" style="opacity: 0;"></rect>
-            <text
-                  ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('NW') > -1 }"
-                  style="font-size:155px;fill:#808080"
-                  x="170"
-                  y="900"
-                  font-size="35"
-                  id="text-NW"
-                  inkscape:export-xdpi="87.938904"
-                  inkscape:export-ydpi="87.938904">NW</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('SE', ${model}, $event, '${filterName}')">
-            <rect x="1350"  y="1900" width="350" height="300" style="opacity: 0;"></rect>
-            <text
-                ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('SE') > -1 }"
-               style="font-size:155px;fill:#808080"
-               x="1420"
-               y="2100"
-               font-size="35"
-               id="text-SE"
-               inkscape:export-xdpi="87.938904"
-               inkscape:export-ydpi="87.938904">SE</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('SW', ${model}, $event, '${filterName}')">
-            <rect x="150"  y="1900" width="350" height="300" style="opacity: 0;"></rect>
-            <text
-                    ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('SW') > -1 }"
-                    style="font-size:155px;fill:#808080"
-                    x="180"
-                    y="2100"
-                    font-size="35"
-                    id="text-SW"
-                    inkscape:export-xdpi="87.938904"
-                    inkscape:export-ydpi="87.938904">SW</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('S', ${model}, $event, '${filterName}')">
-            <rect x="722.5813"  y="2000" width="400" height="400" style="opacity: 0;"></rect>
-            <text
-               ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('S') > -1 }"
-               style="font-size:294.78234863px;fill:#808080"
-               x="830"
-               y="2287.98"
-               font-size="55"
-               id="text-S"
-               inkscape:export-xdpi="87.938904"
-               inkscape:export-ydpi="87.938904">S</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('E', ${model}, $event, '${filterName}')">
-            <rect x="1500"  y="1250" width="400" height="400" style="opacity: 0;"></rect>
-            <text
-               ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('E') > -1 }"
-               style="font-size:294.78234863px;fill:#808080"
-               x="1626.5331"
-               y="1559.9829"
-               font-size="55"
-               id="text-E"
-               inkscape:export-xdpi="87.938904"
-               inkscape:export-ydpi="87.938904">E</text>
-          </g>
-          <g ng-click="${ctrl}.toggleOrientation('W', ${model}, $event, '${filterName}')">
-            <rect x="-20"  y="1250" width="400" height="400" style="opacity: 0;"></rect>
-            <text
-               ng-class="{ 'orientation-text-selected': ${model}.orientations.indexOf('W') > -1 }"
-               style="font-size:294.78234863px;fill:#808080"
-               x="18.629496"
-               y="1559.9829"
-               font-size="55"
-               id="text-W"
-               inkscape:export-xdpi="87.938904"
-               inkscape:export-ydpi="87.938904">W</text>
-          </g>
-          <g
-             id="layer2"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904"
-             transform="matrix(5.3596791,0,0,5.3596791,-1106.9032,-1280.6464)">
-            <circle
-               r="191.92999"
-               cy="504.85999"
-               cx="377.82001"
-               id="path4136-0"
-               style="fill:none;stroke:#1c0000;stroke-width:5.9000001;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.37562998" />
-          </g>
-          <path
-             ng-class="{ 'half-circle-selected': ${model}.orientations.indexOf('SE') > -1 }"
-             style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
-             d="m 944.48909,2448.8091 c 547.72661,-15.9027 986.84591,-458.3667 998.59261,-1006.1983 -11.5333,548.874 -450.5029,990.8632 -998.59261,1006.1983 z"
-             id="circle-SE"
-             ng-click="${ctrl}.toggleOrientation('SE', ${model}, $event, '${filterName}')"
-             inkscape:label="#path4325"
-             inkscape:connector-curvature="0"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904" />
-          <path
-             ng-class="{ 'half-circle-selected': ${model}.orientations.indexOf('SW') > -1 }"
-             style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
-             d="m -112.73114,1442.6108 c 11.91194,551.4284 456.6057,995.3332 1008.0545,1006.2653 -551.18312,-11.2334 -996.02593,-454.7977 -1008.0545,-1006.2653 z"
-             id="circle-SW"
-             ng-click="${ctrl}.toggleOrientation('SW', ${model}, $event, '${filterName}')"
-             inkscape:label="#path4323"
-             inkscape:connector-curvature="0"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904" />
-          <path
-             ng-class="{ 'half-circle-selected': ${model}.orientations.indexOf('NE') > -1 }"
-             style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
-             d="M 944.48909,393.98048 C 1496.7393,410.51081 1937.2443,858.62339 1943.0145,1410.8033 1936.8867,858.85815 1496.2317,410.12866 944.48909,393.98048 Z"
-             id="circle-NE"
-             ng-click="${ctrl}.toggleOrientation('NE', ${model}, $event, '${filterName}')"
-             inkscape:label="#path4321"
-             inkscape:connector-curvature="0"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904" />
-          <path
-             ng-class="{ 'half-circle-selected': ${model}.orientations.indexOf('NW') > -1 }"
-             style="fill:none;fill-opacity:1;stroke:#E8E5E5;stroke-width:60;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:0.72588998"
-             d="M 895.32336,393.19744 C 339.22605,403.87284 -107.67176,854.63472 -113.55873,1410.8033 -108.83519,853.44058 338.57019,404.06847 895.32336,393.19744 Z"
-             id="circle-NW"
-             ng-click="${ctrl}.toggleOrientation('NW', ${model}, $event, '${filterName}')"
-             inkscape:label="#circle-main"
-             inkscape:connector-curvature="0"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904" />
-          <g
-             style="fill:#FFD7A8"
-             id="g4142"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904"
-             transform="matrix(5.3596791,0,0,5.3596791,-1106.9032,-1280.6464)">
-            <circle
-               ng-class="{ 'circle-selected': ${model}.orientations.indexOf('N') > -1 }"
-               ng-click="${ctrl}.toggleOrientation('N', ${model}, $event, '${filterName}')"
-               id="circle-N"
-               cx="380"
-               cy="312.59"
-               r="17" />
-            <circle
-               ng-class="{ 'circle-selected': ${model}.orientations.indexOf('S') > -1 }"
-               ng-click="${ctrl}.toggleOrientation('S', ${model}, $event, '${filterName}')"
-               id="circle-S"
-               cx="380"
-               cy="694.90997"
-               r="17" />
-            <circle
-               ng-class="{ 'circle-selected': ${model}.orientations.indexOf('W') > -1 }"
-               ng-click="${ctrl}.toggleOrientation('W', ${model}, $event, '${filterName}')"
-               id="circle-W"
-               cx="188"
-               cy="506.07999"
-               r="17" />
-            <circle
-               ng-class="{ 'circle-selected': ${model}.orientations.indexOf('E') > -1 }"
-               ng-click="${ctrl}.toggleOrientation('E', ${model}, $event, '${filterName}')"
-               id="circle-E"
-               cx="570"
-               cy="506.07999"
-               r="17" />
-          </g>
-          <path
-             sodipodi:nodetypes="cccccccsccccccccccccccscsccccscccscsssccccccccccccsccccccccccccscccccsccccscsccccscccssscsssscc"
-             style="fill:#000000;fill-opacity:0.3"
-             inkscape:connector-curvature="0"
-             id="path4430"
-             d="m 932.5458,1052.6256 c -18.50912,-0.8774 -35.16003,25.6433 -84.72045,126.0006 l -56.43742,114.247 -111.33125,59.4763 c -61.2397,32.7203 -114.83649,63.0674 -119.09207,67.4194 -20.56188,21.0496 3.41642,41.4036 117.2269,99.5132 l 114.73465,58.5759 50.67094,104.5942 c 27.86605,57.52 55.52628,112.3656 61.4648,121.8898 11.09132,17.7866 22.83438,21.3503 37.7107,11.4295 4.66223,-3.1097 34.09614,-58.0828 65.4095,-122.1685 l 56.9359,-116.5087 114.9973,-60.4733 c 102.0697,-53.6718 115.2438,-62.8208 117.3394,-81.4135 2.2405,-19.901 -3.4366,-23.8978 -113.459,-80.0736 l -115.7959,-59.1334 -57.6487,-118.3363 c -31.71268,-65.088 -63.14773,-120.5017 -69.85269,-123.1386 -2.82118,-1.1079 -5.50493,-1.7912 -8.14886,-1.9167 z m -318.24703,30.3625 c -6.94989,0 -17.0904,5.4728 -22.51815,12.1681 -8.30536,10.2445 -5.31766,26.3825 18.81194,101.9411 15.76978,49.3798 32.18273,94.2768 36.47529,99.7704 10.24932,13.1184 35.54111,8.836 45.68644,-7.7351 6.03875,-9.8634 3.95314,-26.048 -8.40933,-64.9753 -9.05518,-28.5114 -15.13627,-53.1868 -13.52408,-54.8403 1.61278,-1.6513 26.66547,4.842 55.67634,14.4079 43.79769,14.4406 54.73305,15.6846 64.49838,7.3889 14.55475,-12.3659 15.19148,-34.0908 1.34368,-45.8558 -12.53361,-10.6487 -160.1365,-62.2742 -178.04319,-62.2742 z m 632.28133,0.7386 c -19.588,-0.8795 -53.3652,9.8768 -105.591,28.6309 -70.7424,25.4038 -79.141,30.4006 -81.167,48.2339 -4.197,36.9619 13.9604,41.6232 77.2008,19.857 31.1188,-10.7107 56.5875,-18.5252 56.5875,-17.3632 0,1.1631 -6.773,22.247 -15.0409,46.8484 -17.1702,51.0896 -19.2937,85.444 -5.6351,91.0878 32.2427,13.3188 41.0428,1.401 73.1006,-99.1487 26.4377,-82.9143 33.1893,-116.6856 0.5419,-118.1488 z m -317.63601,72.7576 44.01744,90.9967 44.01747,90.9966 93.8426,48.28 93.8212,48.2569 -91.9132,47.1716 -91.9131,47.1722 -45.18799,92.2883 c -24.85766,50.7631 -46.12969,92.3098 -47.26862,92.3098 -1.13904,0 -21.96986,-41.1672 -46.27172,-91.479 l -44.16911,-91.4791 -90.05333,-48.1647 -90.05333,-48.1648 89.37801,-46.9411 89.37801,-46.9642 46.18489,-92.149 46.18489,-92.1275 z m 4.75404,188.1108 c -96.10976,0 -129.8275,129.8061 -44.86266,172.7318 31.29356,15.8105 55.92289,14.7589 85.41185,-3.6478 30.34918,-18.9427 49.50038,-61.8614 43.12878,-96.6297 -6.467,-35.2902 -49.37656,-72.4575 -83.68065,-72.4575 z m -1.88554,61.556 c 7.2956,0 16.76508,6.7071 21.04425,14.8929 10.0628,19.2487 9.94274,20.2832 -4.03118,34.5882 -13.6913,14.016 -17.35089,14.3912 -35.17503,3.7635 -24.42621,-14.5644 -11.2296,-53.2446 18.1618,-53.2446 z m -263.71764,162.0177 c -8.15315,-0.4502 -16.13532,2.5641 -21.30419,9.1897 -4.12739,5.2905 -20.40216,50.0208 -36.17194,99.4006 -24.12981,75.5554 -27.1173,91.7202 -18.81194,101.9625 13.30648,16.4141 14.95619,16.1718 109.49288,-15.7933 93.02796,-31.4549 103.15239,-37.4277 99.97946,-59.0637 -4.31143,-29.3796 -23.86611,-33.0906 -78.54074,-14.8924 -27.85104,9.2696 -51.96209,15.5045 -53.57535,13.8537 -1.61267,-1.6508 4.72177,-27.3076 14.06594,-57.0055 14.10614,-44.8364 15.32064,-56.0408 7.21681,-66.0366 -5.86778,-7.2378 -14.1919,-11.1621 -22.3445,-11.6139 z m 521.79695,3.4173 c -19.1277,0 -22.9137,3.2812 -24.967,21.6119 -1.3315,11.8856 4.362,42.1839 12.6569,67.3283 8.2951,25.1449 13.0041,45.7169 10.4679,45.7169 -2.5361,0 -27.247,-7.4547 -54.9206,-16.5785 -58.8332,-19.3978 -74.7943,-16.0576 -74.7943,15.7006 0,24.7189 -0.3575,24.527 116.5141,65.8062 58.3186,20.5977 64.9003,21.8005 82.0727,15.0542 18.477,-7.2586 13.7996,-44.5587 -16.7967,-133.8472 -26.845,-78.3425 -28.3725,-80.7918 -50.2379,-80.7918 z"
-             inkscape:export-xdpi="87.938904"
-             inkscape:export-ydpi="87.938904" />
-        </g>
-      </g>
-    </g>
+  <svg id="orientation-svg" xmlns="http://www.w3.org/2000/svg" width=150" height="150" version="1.1" viewBox="0 0 454.00715 454.00714">
+    <path id="ori-e" style="fill:#b3b3b3" d="m370.28 168.82-142.14 58.18 142.14 58.185h0.005l83.722-58.185z"
+      ng-click="${ctrl}.toggleOrientation('E', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('E') > -1 }"/>
+    <path id="ori-w" style="fill:#b3b3b3" d="m83.727 168.82 142.14 58.18-142.14 58.185h-0.0046l-83.725-58.18z"
+      ng-click="${ctrl}.toggleOrientation('W', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('W') > -1 }"/>
+    <path id="ori-s" style="fill:#b3b3b3" d="m285.19 370.28-58.18-142.14-58.185 142.14v0.005l58.185 83.722z"
+      ng-click="${ctrl}.toggleOrientation('S', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('S') > -1 }"/>
+    <path id="ori-n" style="fill:#b3b3b3" d="m285.19 83.727-58.18 142.14-58.19-142.14v-0.005l58.19-83.725z"
+      ng-click="${ctrl}.toggleOrientation('N', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('N') > -1 }"/>
+    <path id="ori-se" style="fill:#b3b3b3" d="m369.46 287.17-141.65-59.371 59.368 141.65 0.002 0.002 100.34 18.058z"
+      ng-click="${ctrl}.toggleOrientation('SE', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('SE') > -1 }"/>
+    <path id="ori-nw" style="fill:#b3b3b3" d="m166.83 84.55 59.371 141.65-141.65-59.368-0.0032-0.002l-18.058-100.34z"
+      ng-click="${ctrl}.toggleOrientation('NW', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('NW') > -1 }"/>
+    <path id="ori-sw" style="fill:#b3b3b3" d="m166.83 369.46 59.371-141.65-141.65 59.368-0.0032 0.002-18.058 100.34z"
+      ng-click="${ctrl}.toggleOrientation('SW', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('SW') > -1 }"/>
+    <path id="ori-ne" style="fill:#b3b3b3" d="m369.46 166.83-141.65 59.371 59.368-141.65 0.002-0.002 100.34-18.058z"
+      ng-click="${ctrl}.toggleOrientation('NE', ${model}, $event, '${filterName}')"
+      ng-class="{ 'orientation-selected': ${model}.orientations.indexOf('NE') > -1 }"/>
+    <text id="text-n" y="99.007141" x="212.0424" font-size="40">N</text>
+    <text id="text-s" y="385.00714" x="214.10295" font-size="40">S</text>
+    <text id="text-w" y="241.58344" x="64" font-size="40">W</text>
+    <text id="text-e" y="241.58344" x="358" font-size="40">E</text>
   </svg>
 </%def>

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -587,9 +587,14 @@ input[type="radio"] {
   }
 
   #ori-n, #ori-s, #ori-w, #ori-e, #ori-se, #ori-ne, #ori-sw, #ori-nw {
-    cursor: pointer;
-    transition: 0.3s ease-in-out;
     fill: gray;
+    transition: 0.3s ease-in-out;
+
+    &.orientation-selected {
+      transition: 0.3s ease-in-out;
+      fill: @C2C-orange !important;
+    }
+
   }
 
   text {
@@ -597,9 +602,11 @@ input[type="radio"] {
   }
 }
 
-.orientation-selected {
-  transition: 0.3s ease-in-out;
-  fill: @C2C-orange !important;
+.form-group,
+.filter.orientation {
+  #ori-n, #ori-s, #ori-w, #ori-e, #ori-se, #ori-ne, #ori-sw, #ori-nw {
+    cursor: pointer;
+  }
 }
 
 .nav-step-selected {

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -586,28 +586,20 @@ input[type="radio"] {
     width: 90%;
   }
 
-  #circle-N, #circle-S, #circle-W, #circle-E,
-  #circle-SE, #circle-NE, #circle-SW, #circle-NW, #text-N, #text-E, #text-W,
-  #text-S, #text-SE, #text-SW, #text-NW, #text-NE{
+  #ori-n, #ori-s, #ori-w, #ori-e, #ori-se, #ori-ne, #ori-sw, #ori-nw {
     cursor: pointer;
     transition: 0.3s ease-in-out;
+    fill: gray;
+  }
+
+  text {
+    fill:#fff;
   }
 }
 
-.circle-selected {
+.orientation-selected {
   transition: 0.3s ease-in-out;
-  fill: @bright-green;
-}
-
-.half-circle-selected {
-  transition: 0.3s ease-in-out;
-  stroke: #2F8D20 !important;
-}
-
-.orientation-text-selected {
-  font-weight: bold !important;
-  transition: 0.3s ease-in-out;
-  text-decoration: underline;
+  fill: @C2C-orange !important;
 }
 
 .nav-step-selected {


### PR DESCRIPTION
* Use a wind roses similar to that of MeteoFrance avalanche bulletins. This makes it easier to (un)select
* No pointer cursor when the widget is not interactive
* Max size is 150px instead of 200px

![certif4](https://cloud.githubusercontent.com/assets/2234024/21816348/3354a33c-d760-11e6-8817-9bc76ed0d0cc.png)
