### PR TITLE
Add GPX/KML download buttons in outings/routes detail views

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ LIBS_JS_FILES += \
     node_modules/photoswipe/dist/photoswipe-ui-default.min.js \
     node_modules/angular-slug/angular-slug.js \
     node_modules/ng-infinite-scroll/build/ng-infinite-scroll.min.js \
+    node_modules/file-saver/FileSaver.min.js \
     node_modules/slug/slug.js
 
 # CSS files of dependencies that are concatenated into a single file

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -48,6 +48,7 @@ goog.require('app.slideInfoDirective');
 goog.require('app.sliderDirective');
 goog.require('app.stickyFiltersDirective');
 goog.require('app.suggestionDirective');
+goog.require('app.trackDownloadDirective');
 goog.require('app.userDirective');
 goog.require('app.userProfileDirective');
 goog.require('app.versionsDirective');

--- a/c2corg_ui/static/js/trackdownload.js
+++ b/c2corg_ui/static/js/trackdownload.js
@@ -1,0 +1,105 @@
+goog.provide('app.TrackDownloadController');
+goog.provide('app.trackDownloadDirective');
+
+goog.require('app');
+goog.require('ngeo.Download');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.format.GPX');
+goog.require('ol.format.KML');
+
+
+/**
+ * This directive is used to display a track download button.
+ *
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.trackDownloadDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'AppTrackDownloadController',
+    controllerAs: 'trackCtrl',
+    templateUrl: '/static/partials/trackdownload.html'
+  };
+};
+
+
+app.module.directive('appTrackDownload', app.trackDownloadDirective);
+
+
+/**
+ * @param {ngeo.Download} ngeoDownload ngeo download service.
+ * @param {?GeoJSONFeatureCollection} mapFeatureCollection FeatureCollection of
+ *    features shown on the map.
+ * @constructor
+ * @export
+ * @ngInject
+ */
+app.TrackDownloadController = function(ngeoDownload, mapFeatureCollection) {
+
+  /**
+   * @type {ngeo.Download}
+   * @private
+   */
+  this.download_ = ngeoDownload;
+
+  /**
+   * @type {?GeoJSONFeatureCollection}
+   * @private
+   */
+  this.featureCollection_ = mapFeatureCollection;
+};
+
+
+/**
+ * @param {ol.Feature} feature
+ * @return {boolean}
+ * @private
+ */
+app.TrackDownloadController.prototype.isLineFeature_ = function(feature) {
+  return feature.getGeometry() instanceof ol.geom.LineString ||
+    feature.getGeometry() instanceof ol.geom.MultiLineString;
+};
+
+
+/**
+ * @param {ol.format.XMLFeature} format
+ * @param {string} extension
+ * @param {string} mimetype
+ * @private
+ */
+app.TrackDownloadController.prototype.downloadFeatures_ = function(
+  format, extension, mimetype) {
+  var geojson = new ol.format.GeoJSON();
+  var features = geojson.readFeatures(this.featureCollection_);
+  features = features.filter(this.isLineFeature_);
+  if (features.length) {
+    var filename = features[0].get('documentId') + extension;
+    var content = format.writeFeatures(features, {
+      featureProjection: 'EPSG:3857'
+    });
+    this.download_(content, filename, mimetype + ';charset=utf-8');
+  }
+};
+
+
+/**
+ * @export
+ */
+app.TrackDownloadController.prototype.downloadGpx = function() {
+  this.downloadFeatures_(
+    new ol.format.GPX(), '.gpx', 'application/gpx+xml');
+};
+
+
+/**
+ * @export
+ */
+app.TrackDownloadController.prototype.downloadKml = function() {
+  this.downloadFeatures_(
+    new ol.format.KML(), '.kml', 'application/vnd.google-earth.kml+xml');
+};
+
+
+app.module.controller(
+  'AppTrackDownloadController', app.TrackDownloadController);

--- a/c2corg_ui/static/partials/trackdownload.html
+++ b/c2corg_ui/static/partials/trackdownload.html
@@ -1,0 +1,2 @@
+<button class="btn btn-primary" ng-click="trackCtrl.downloadGpx()">GPX</button>
+<button class="btn btn-primary" ng-click="trackCtrl.downloadKml()">KML</button>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -110,6 +110,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_path('%s/angular-slug/angular-slug.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/slug/slug.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-debounce/angular-debounce.js' % node_modules_path)}"></script>
+    <script src="${request.static_path('%s/file-saver/FileSaver.js' % node_modules_path)}"></script>
     <script src="${request.route_path('deps.js')}"></script>
     <script src="${request.static_path('c2corg_ui:static/js/main.js')}"></script>
 % else:

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -812,3 +812,12 @@
     % endif
   </label>
 </%def>
+
+<%def name="show_track_download(document)">\
+  % if document.get('geometry') and document.get('geometry').get('geom_detail'):
+    <p>
+      <span translate class="value-title">Download track as</span><br>
+      <app-track-download></app-track-download>
+    </p>
+  % endif
+</%def>

--- a/c2corg_ui/templates/outing/helpers/view.html
+++ b/c2corg_ui/templates/outing/helpers/view.html
@@ -2,7 +2,8 @@
     import datetime
     from json import loads
 %>
-<%namespace file="../../helpers/view.html" import="get_document_up_down, get_document_min_max, show_attr"/>
+<%namespace file="../../helpers/view.html" import="get_document_up_down, get_document_min_max,
+    show_attr, show_track_download"/>
 
 <%def name="show_fulldate(dateStart, dateEnd)">\
   % if dateStart == dateEnd:
@@ -61,6 +62,9 @@
     % if outing.get('quality'):
     <p><span class="value-title" translate>quality</span>: <span class="value" x-translate>${outing['quality']}</span></p>
     % endif
+
+    ${show_track_download(outing)}
+
   </span>
 </div>
 </%def>

--- a/c2corg_ui/templates/route/helpers/view.html
+++ b/c2corg_ui/templates/route/helpers/view.html
@@ -1,5 +1,5 @@
 <%namespace file="../../helpers/view.html" import="get_global_rating, get_hiking_mtb_rating, get_skitouring_rating,
-    get_document_min_max, get_document_up_down, show_areas, show_maps"/>
+    get_document_min_max, get_document_up_down, show_areas, show_maps, show_track_download"/>
 <%namespace file="../../helpers/orientations.svg" import="show_orientations"/>
 
 ## LOCATION
@@ -98,9 +98,11 @@
         </article>
       % endif
 
-    % if route.get('quality'):
-    <p><span class="value-title" translate>quality</span>: <span class="value" x-translate>${route['quality']}</span></p>
-    % endif
+      % if route.get('quality'):
+        <p><span class="value-title" translate>quality</span>: <span class="value" x-translate>${route['quality']}</span></p>
+      % endif
+
+      ${show_track_download(route)}
 
     </span>
   </div>
@@ -160,7 +162,6 @@
       <span class="detail-text accordion">
 
        ${get_document_min_max(route, 'elevation')}
-
        ${get_document_up_down(route, 'height_diff')}
 
         % if route.get('route_length'):

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -127,7 +127,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   ${get_document_description(locale, 'route')}
 
-  <div class="description ">
+  <div class="description">
     ${get_document_locale_text(locale, 'remarks', True)}
     ${get_document_locale_text(locale, 'gear', True)}
     ${get_document_locale_text(locale, 'route_history', True)}
@@ -137,7 +137,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   ## ASSOCIATIONS
   ## route has always at least 1 associated waypoint so this div will always be displayed
   % if not version:
-    <div class="view-details-associations col-xs-12  associations">
+    <div class="view-details-associations col-xs-12 associations">
       <span class="lead">
         <section>
           <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "angular-slug": "git://github.com/lucasconstantino/angular-slug#v0.0.4",
     "eslint": "2.13.1",
     "eslint-config-openlayers": "5.0.0",
+    "file-saver": "1.3.3",
     "jquery": "2.2.4",
     "less": "2.7.1",
     "less-plugin-clean-css": "1.5.1",


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/678

The buttons only appear if the route/outing has a ``geom_detail`` (aka GPS track).

![capture du 2017-01-10 20-49-47](https://cloud.githubusercontent.com/assets/1192331/21822328/1623388e-d777-11e6-9f68-35685bff19f0.png)

![capture du 2017-01-10 20-50-48](https://cloud.githubusercontent.com/assets/1192331/21822338/1d145fb0-d777-11e6-993e-b493d6037f2b.png)

