### PR TITLE
Break words in topoguide bullets appropriately

### DIFF
--- a/less/topoguide.less
+++ b/less/topoguide.less
@@ -41,6 +41,7 @@
     transition: .2s;
     background-color: rgba(117, 117, 117, 0.44);
     margin-bottom: 15px;
+    padding: 2px;
     &:hover {
       cursor: pointer;
       background-color: rgba(66, 66, 66, 0.52);

--- a/less/topoguide.less
+++ b/less/topoguide.less
@@ -62,7 +62,7 @@
       }
     }
     span {
-      word-break: break-all;
+      overflow-wrap: break-word;
     }
   }
   .waypoint-type, .activity {

--- a/less/topoguide.less
+++ b/less/topoguide.less
@@ -62,6 +62,7 @@
       }
     }
     span {
+      word-wrap: break-word;
       overflow-wrap: break-word;
     }
   }


### PR DESCRIPTION
Use space for breaking, unless the word is too long. Then it can be cut too.

![certif7](https://cloud.githubusercontent.com/assets/2234024/21883290/a909d382-d8ae-11e6-9c89-bb6d739c15fe.png)
