### PR TITLE
Gpx download design

### DIFF
--- a/c2corg_ui/static/js/trackdownload.js
+++ b/c2corg_ui/static/js/trackdownload.js
@@ -72,18 +72,22 @@ app.TrackDownloadController.prototype.downloadFeatures_ = function(
 
 
 /**
+ * @param {goog.events.Event | jQuery.Event} event
  * @export
  */
-app.TrackDownloadController.prototype.downloadGpx = function() {
+app.TrackDownloadController.prototype.downloadGpx = function(event) {
+  event.stopPropagation();
   this.downloadFeatures_(
     new ol.format.GPX(), '.gpx', 'application/gpx+xml');
 };
 
 
 /**
+ * @param {goog.events.Event | jQuery.Event} event
  * @export
  */
-app.TrackDownloadController.prototype.downloadKml = function() {
+app.TrackDownloadController.prototype.downloadKml = function(event) {
+  event.stopPropagation();
   this.downloadFeatures_(
     new ol.format.KML(), '.kml', 'application/vnd.google-earth.kml+xml');
 };

--- a/c2corg_ui/static/partials/trackdownload.html
+++ b/c2corg_ui/static/partials/trackdownload.html
@@ -1,2 +1,2 @@
-<button class="btn btn-primary" ng-click="trackCtrl.downloadGpx()">GPX</button>
-<button class="btn btn-primary" ng-click="trackCtrl.downloadKml()">KML</button>
+<button class="btn btn-primary btn-xs" ng-click="trackCtrl.downloadGpx($event)">GPX</button>
+<button class="btn btn-primary btn-xs" ng-click="trackCtrl.downloadKml($event)">KML</button>


### PR DESCRIPTION
* use smaller buttons
* on mobile, clicking the GPX or KML button won't close the corresponding section too

![certif9](https://cloud.githubusercontent.com/assets/2234024/21884530/0ddd884e-d8b4-11e6-942b-55c1e25f45fe.png)
![certif10](https://cloud.githubusercontent.com/assets/2234024/21884531/0ddfc910-d8b4-11e6-860e-8adfdc6a973c.png)
