### PR TITLE
Similar visuals for no outing button and new comments button

### DIFF
--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -146,10 +146,12 @@ other_langs, missing_langs = get_lang_lists(route, lang)
           </div>
           % if len(route['associations']['recent_outings']['documents']) == 0:
             <div class="add-outing">
-              <p class="text-center"><strong translate>no outings yet?</strong><p>
-                <button type="button" class="btn gray-btn" protected-url-btn
-                        url="${request.route_path('outings_add')}#r=${route_id}"
-                        translate>add a new one to this document</button>
+              <div>
+                <p class="text-center" translate>no outings yet?<p>
+                  <button type="button" class="btn gray-btn" protected-url-btn
+                          url="${request.route_path('outings_add')}#r=${route_id}"
+                          translate>add a new one to this document</button>
+              </div>
             </div>
           % endif
           ${show_associated_waypoints(route)}

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -280,13 +280,18 @@
       }
     }
     .add-outing {
-      float: right;
-      background: #CACACA;
-      margin-bottom: 10px;
-      padding: .5%;
-      color: white;
-      border-radius: 5px;
-      font-variant: small-caps;
+      text-align: center;
+      font-size: 0.9em;
+
+      > div {
+        display: inline-block;
+        background: #CACACA;
+        margin-bottom: 10px;
+        padding: .5%;
+        color: white;
+        border-radius: 5px;
+        font-variant: small-caps;
+      }
     }
     .show-more {
       float: right;


### PR DESCRIPTION
This applies when there is no outing for a route yet.

* adjust font size
* center button

Before:
![certif16](https://cloud.githubusercontent.com/assets/2234024/21931582/885e9a5c-d99c-11e6-9131-9aa2abd22659.png)

Now:
![certif15](https://cloud.githubusercontent.com/assets/2234024/21931563/6b126ba4-d99c-11e6-85e3-b7a291ab716f.png)
