### PR TITLE
Add gear-specific articles depending on ratings

### DIFF
--- a/c2corg_ui/templates/route/helpers/view.html
+++ b/c2corg_ui/templates/route/helpers/view.html
@@ -1,5 +1,8 @@
+<%!
+from c2corg_ui.templates.utils import get_route_gear_articles
+%>
 <%namespace file="../../helpers/view.html" import="get_global_rating, get_hiking_mtb_rating, get_skitouring_rating,
-    get_document_min_max, get_document_up_down, show_areas, show_maps, show_track_download"/>
+    get_document_min_max, get_document_up_down, show_areas, show_maps, show_track_download, show_attr"/>
 <%namespace file="../../helpers/orientations.svg" import="show_orientations"/>
 
 ## LOCATION
@@ -252,6 +255,35 @@
         <span translate class="value-title">glacier_gear</span>:
         <span class="value" x-translate>${route.get('glacier_gear')}</span>
       </span>
+    </div>
+  % endif
+</%def>
+
+## SPECIFIC GEAR
+<%def name="get_route_gear(route, locale)">\
+  <%
+    gear_articles = get_route_gear_articles(route)
+  %>
+  % if locale['gear'] or gear_articles:
+    <div class="view-details-info col-xs-12">
+      <h3 class="heading show-phone"
+          ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#${'gear'}">
+        <span x-translate>gear</span><span class="glyphicon glyphicon-menu-down"></span>
+      </h3>
+      <section class="collapse in" id="gear" aria-expanded="true">
+        <div class="lead">
+          % if gear_articles:
+            <ul>
+            % for article_id, name in gear_articles.items():
+              <li><a href="${request.route_path('articles_view_id', id=article_id)}" x-translate>${name}</a></li>
+            % endfor
+            </ul>
+          % endif
+          % if locale['gear']:
+            ${show_attr(locale, 'gear')}
+          % endif
+        </div>
+      </section>
     </div>
   % endif
 </%def>

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -17,7 +17,8 @@ from json import dumps
 
 <%namespace file="helpers/view.html" import="get_route_location,
     get_route_glacier_gear, get_route_rating, get_route_general, get_route_heights,
-    get_route_access, get_route_associated_maps, get_route_orientations" />
+    get_route_access, get_route_associated_maps, get_route_orientations,
+    get_route_gear" />
 
 <%
 route_id = route['document_id']
@@ -129,7 +130,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   <div class="description">
     ${get_document_locale_text(locale, 'remarks', True)}
-    ${get_document_locale_text(locale, 'gear', True)}
+    ${get_route_gear(route, locale)}
     ${get_document_locale_text(locale, 'route_history', True)}
     ${get_document_locale_text(locale, 'external_resources', True)}
   </div>

--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -82,3 +82,31 @@ def has_associations(doc):
         a.get('all_routes') or a.get('routes') or \
         a.get('recent_outings') or a.get('outings') or \
         a.get('articles') or a.get('xreports') or a.get('books')
+
+
+def get_route_gear_articles(route):
+    articles = []
+    activities = route.get('activities')
+    if activities:
+        if 'snowshoeing' in activities or 'skitouring' in activities:
+            articles.append(('183333', 'skitouring gear'))
+        if 'snow_ice_mixed' in activities and \
+                route.get('global_rating') in ['F', 'F+', 'PD', 'PD+']:
+            articles.append(('185750', 'easy snow ice mixed gear'))
+        if 'mountain_climbing' in activities and \
+                route.get('global_rating') in ['F', 'F+', 'PD', 'PD+', 'AD']:
+            articles.append(('185384', 'easy rock climbing gear'))
+        if 'rock_climbing' in activities and \
+                route.get('equipment_rating') in ['P1', 'P1+']:
+            articles.append(('185384', 'easy rock climbing gear'))
+        if 'ice_climbing' in activities:
+            articles.append(('194479', 'ice and dry climbing gear'))
+        if any(activity in activities for activity in [
+                'skitouring',
+                'snow_ice_mixed',
+                'snowshoeing'
+                ]) and \
+                route.get('glacier_gear') and \
+                route.get('glacier_gear') != 'no':
+            articles.append(('185750', 'easy snow ice mixed gear'))
+    return dict(articles)


### PR DESCRIPTION
References #1005

Currently, we do not respect the anchor for glacier gear (it's not yet possible)

I have 2 questions though:

* is there a way to use comparisons rather than testing if value is in list for ratings?
* can you check the i18n keys are consistent?