### PR TITLE
Mountainbiking distances are in m, not km

### DIFF
--- a/c2corg_ui/templates/route/filters.html
+++ b/c2corg_ui/templates/route/filters.html
@@ -274,17 +274,17 @@ activities = [activity for activity in activities if activity != 'paragliding']
 
         <div class="col-xs-12 col-sm-6 filter">
           <label translate>mtb_length_asphalt</label><br>
-          <app-slider filter="mbroad" filters-list="filtersCtrl.filters" max="50" step="5" unit="km"></app-slider>
+          <app-slider filter="mbroad" filters-list="filtersCtrl.filters" max="50000" step="500" unit="m"></app-slider>
         </div>
 
         <div class="col-xs-12 col-sm-6 filter">
           <label translate>mtb_length_trail</label><br>
-          <app-slider filter="mbtrack" filters-list="filtersCtrl.filters" max="50" step="5" unit="km"></app-slider>
+          <app-slider filter="mbtrack" filters-list="filtersCtrl.filters" max="50000" step="500" unit="m"></app-slider>
         </div>
 
         <div class="col-xs-12 col-sm-6 filter">
           <label translate>mtb_height_diff_portages</label><br>
-          <app-slider filter="mbpush" filters-list="filtersCtrl.filters" max="50" step="5" unit="km"></app-slider>
+          <app-slider filter="mbpush" filters-list="filtersCtrl.filters" max="5000" step="100" unit="m"></app-slider>
         </div>
       </div>
 


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1347

I have changed the search ranges to use meters instead of kilometers.

Perhaps we could improve the slider directive to display kilometer values and send meter values, but at the moment I don't have time to do it.