### PR TITLE
Update xreports menu link

### DIFF
--- a/c2corg_ui/templates/sidemenu.html
+++ b/c2corg_ui/templates/sidemenu.html
@@ -37,7 +37,7 @@ version = request.registry.settings.get('cache_version')
       </a>
     </li>
     <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('xreports')}">
-      <a href="${request.route_path('xreports_index')}">
+      <a href="${request.route_path('articles_view_id', id=697210)}">
         <i class="glyphicon glyphicon-warning-sign" tooltip-placement="right" uib-tooltip="{{'Accident database' | translate}}"></i>
         <span class="menu-text" translate>Accident database</span>
       </a>

--- a/less-discourse/menu.html
+++ b/less-discourse/menu.html
@@ -68,7 +68,7 @@
       </a>
     </li>
     <li class="main-menu">
-      <a href="#" url="xreports" class="menu-link">
+      <a href="#" url="articles/697210" class="menu-link">
         <i class="glyphicon glyphicon-warning-sign"></i>
         <span class="lang en menu-text">Incidents and Accidents</span>
         <span class="lang fr menu-text">Incidents et accidents</span>


### PR DESCRIPTION
@mgerbaux has asked that the menu entry for xreports points to the introduction article instead of the advanced search page.