### PR TITLE
remove br tag before gpx download buttons

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -818,7 +818,7 @@
 <%def name="show_track_download(document)">\
   % if document.get('geometry') and document.get('geometry').get('geom_detail'):
     <p class="hidden-print">
-      <span translate class="value-title">Download track as</span><br>
+      <span translate class="value-title">Download track as</span>
       <app-track-download></app-track-download>
     </p>
   % endif


### PR DESCRIPTION
I forgot to remove it with #1360. It is really not critical, can be propagated later.