### PR TITLE
add custom field title for gear in route edition

### DIFF
--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -629,7 +629,7 @@ updating_doc = route_id and route_lang
 
             ## GEAR LOCALE
             <div id="gear-group" class="form-group data full">
-              <label translate>gear</label>
+              <label translate>specific gear</label>
               <textarea name="gear" ng-model="route.locales[0].gear" class="form-control" placeholder="{{'Describe here the gear needed for this route' | translate}}"></textarea>
             </div>
 
@@ -662,4 +662,3 @@ updating_doc = route_id and route_lang
   ${show_preview_container()}
   ${show_save_confirmation_modal(updating_doc)}
 </section>
-


### PR DESCRIPTION
In edition form, use `specific gear` key instead of `gear`.
See #1364