### PR TITLE
Remove scroll for cards sections

### DIFF
--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -875,8 +875,6 @@ ul {
     margin-top: 10px;
   }
   .associated-documents {
-    max-height: 600px;
-    overflow-y: auto;
     width: 100%;
     .flex();
     flex-wrap: wrap;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -302,8 +302,6 @@
     }
 
     .associated-documents {
-      max-height: 600px;
-      overflow-y: auto;
       margin-bottom: 5px;
       padding-left: 10px;
 


### PR DESCRIPTION
Removes scroll for cards sections (currently, max-width is set to 600px).