### PR TITLE
Use specific translation keys for waypoint access and description fields

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -461,12 +461,16 @@
   % endif
 </%def>
 
-<%def name="get_document_description(locale, doctype)">\
+<%def name="get_document_description(locale, doctype, title=None)">\
   % if locale.get('summary') or locale.get('description'):
     <div class="view-details-description col-xs-12  description">
       % if doctype not in ['article', 'profile']:
         <h3 class="heading show-phone">
-          <span translate>description</span>
+          % if title:
+            <span x-translate>${title}</span>
+          % else:
+            <span translate>description</span>
+          % endif
         </h3>
       % endif
       <span class="lead">

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -741,7 +741,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## ACCESS
             <div class="form-group data full" ng-if="['access', 'local_product', 'climbing_outdoor'].indexOf(type) > -1">
-              <label translate>access</label>
+              <label translate>road access</label>
               <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control" placeholder="{{'Describe access' | translate}}"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access"></span>
             </div>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -735,14 +735,22 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## DESCRIPTION
             <div id="description-group" class="form-group data full">
-              <label translate>description</label>
-              <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control description" placeholder="{{'Describe here the waypoint' | translate}}"></textarea>
+              <label translate ng-if="type == 'access'">road access</label>
+              <label translate ng-if="type != 'access'">description</label>
+              <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control description"
+                placeholder="{{ type =='access' ? mainCtrl.translate('Describe here the waypoint') : mainCtrl.translate('Describe road access') | translate}}"></textarea>
             </div>
 
             ## ACCESS
-            <div class="form-group data full" ng-if="['access', 'local_product', 'climbing_outdoor'].indexOf(type) > -1">
-              <label translate>road access</label>
-              <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control" placeholder="{{'Describe access' | translate}}"></textarea>
+            <div class="form-group data full" ng-if="['access', 'local_product', 'climbing_outdoor', 'climbing_indoor', 'hut'].indexOf(type) > -1">
+              <label translate ng-if="type == 'access'">public transportation access</label>
+              <label translate ng-if="type == 'hut' || type == 'climbing_indoor' || type == 'climbing_outdoor'">pedestrian access</label>
+              <label translate ng-if="type == 'local_product'">road or pedestrian access</label>
+              <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control"
+                placeholder="{{ type == 'access' ? mainCtrl.translate('Describe pt access') :
+                  ( (type == 'hut' || type == 'climbing_indoor' || type == 'climbing_outdoor') ?
+                    mainCtrl.translate('Describe pedestrian access') :
+                    mainCtrl.describe('Describe access') ) | translate}}"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.locales[0].access"></span>
             </div>
 

--- a/c2corg_ui/templates/waypoint/helpers/view.html
+++ b/c2corg_ui/templates/waypoint/helpers/view.html
@@ -402,22 +402,44 @@
 
 <%def name="get_waypoint_access_period(locale, waypoint_type, open_tab=False)">\
   % if locale.get('access_period'):
-    <%
-        if waypoint_type in ['hut', 'gite', 'camp_site']:
-            attribute_name = 'opening_periods'
-        elif waypoint_type == 'local_product':
-            attribute_name = 'opening_hours'
-        else:
-            attribute_name = 'access_period'
-    %>
     <div class="view-details-info col-xs-12">
       <h3 class="heading ${'' if open_tab else 'closed '}show-phone"
           ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#access_period">
-        <span x-translate>${attribute_name}</span><span class="glyphicon glyphicon-menu-${'down' if open_tab else 'right'}"></span>
+        % if waypoint_type in ['hut', 'gite', 'camp_site']:
+          <span translate>opening_periods</span>
+        % elif waypoint_type == 'local_product':
+          <span translate>opening_hours</span>
+        % else:
+          <span translate>access_period</span>
+        % endif
+        <span class="glyphicon glyphicon-menu-${'down' if open_tab else 'right'}"></span>
       </h3>
       <section class="collapse${' in' if open_tab else ''}" id="access_period" aria-expanded="true">
         <div class="lead">
           ${show_attr(locale, 'access_period')}
+        </div>
+      </section>
+    </div>
+  % endif
+</%def>
+
+<%def name="get_waypoint_access_field(locale, waypoint_type, open_tab=False)">\
+  % if locale.get('access'):
+    <div class="view-details-info col-xs-12">
+      <h3 class="heading ${'' if open_tab else 'closed '}show-phone"
+          ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#access_period">
+          % if waypoint_type == 'access':
+            <span translate>public transportation access</span>
+          % elif waypoint_type in ['hut', 'climbing_indoor', 'climbing_outdoor']:
+            <span translate>pedestrian access</span>
+          % else:
+            <span translate>road or pedestrian access</span>
+          % endif
+          <span class="glyphicon glyphicon-menu-${'down' if open_tab else 'right'}"></span>
+      </h3>
+      <section class="collapse${' in' if open_tab else ''}" id="access" aria-expanded="true">
+        <div class="lead">
+          ${show_attr(locale, 'access')}
         </div>
       </section>
     </div>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -16,7 +16,7 @@ from json import dumps
 <%namespace file="helpers/view.html" import="get_waypoint_equipment,
     get_waypoint_orientations, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
-    get_waypoint_maps_info, get_waypoint_access_period"/>
+    get_waypoint_maps_info, get_waypoint_access_field, get_waypoint_access_period"/>
 
 <%
 waypoint_id = waypoint['document_id']
@@ -127,11 +127,11 @@ waypoint['doctype'] = 'waypoints'
       ${get_licence(waypoint)}
     </section>
   </div>
-
-  ${get_document_description(locale, 'waypoint')}
+  <% description_title = 'road access' if waypoint['waypoint_type'] == 'access' else 'description' %>
+  ${get_document_description(locale, 'waypoint', description_title)}
 
   <div class="description ">
-    ${get_document_locale_text(locale, 'access', True)}
+    ${get_waypoint_access_field(locale, waypoint['waypoint_type'], True)}
     ${get_waypoint_access_period(locale, waypoint['waypoint_type'], True)}
   </div>
 


### PR DESCRIPTION
A waypoint of type 'access' has an `access` field which corresponds to the description of how to reach the parking by road.
The key `access` cannot be used because it is already used for access waypoint.
Thus, use another key `road access`.

References #942