### PR TITLE
Add 24h time selector to Image edit page

### DIFF
--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -133,7 +133,11 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
                 </span>
               </div>
 
-              <br>
+              ## TIME
+              <div class="input-group" uib-timepicker ng-model="image.date_time" hour-step="1" minute-step="1" second-step="1"
+                   show-seconds="1" show-spinners="1" show-meridian="ismeridian">
+              </div>
+
               <div ng-class="{ 'has-success': image.image_type}">
                 <label><span translate>image_type</span> *</label>
                 <div class="input-group">
@@ -143,7 +147,6 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
                 <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.image_type"></span>
               </div>
 
-              <br>
               ## ELEVATION
               <div ng-class="{ 'has-success': image.elevation}">
                 <label translate>elevation</label>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1176

So easiest was to add time picker from tools we already use and have time selector separately https://angular-ui.github.io/bootstrap/#/timepicker
What do you think - is this time picker ok?

Some images do not have date_time and in edit the form they have this date.
http://localhost:6558/images/edit/824766/fr
![image](https://cloud.githubusercontent.com/assets/6165660/22151964/d142473a-df20-11e6-9a78-783e213c7146.png)

https://github.com/dalelotts/angular-bootstrap-datetimepicker#screen-shots
There is also this tool but I personally do not like when I want to select a time and I need to go through few steps with a selection of date also.