### PR TITLE
Use xs button for consistency with other map buttons

### DIFF
--- a/c2corg_ui/static/partials/map/map.html
+++ b/c2corg_ui/static/partials/map/map.html
@@ -14,6 +14,6 @@
   </div>
 
   <button type="button" ng-show="mapCtrl.edit" ng-click="mapCtrl.resetFeature()"
-          class="btn btn-primary map-reset-feature" translate>Reset feature</button>
+          class="btn btn-primary btn-xs map-reset-feature" translate>Reset feature</button>
   <app-baselayer-selector app-baselayer-selector-map="::mapCtrl.map"></app-baselayer-selector>
 </div>


### PR DESCRIPTION
Now:
![certif27](https://cloud.githubusercontent.com/assets/2234024/22248976/5df67f8e-e241-11e6-831d-b8405fec8b85.png)

Was:
![certif28](https://cloud.githubusercontent.com/assets/2234024/22248977/5df6dcd6-e241-11e6-8e9c-590ea2c92ef4.png)
