### PR TITLE
Use specific key for xreport condition field

### DIFF
--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -393,7 +393,7 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
 
             ## conditions
             <div id="conditions-group" class="form-group full">
-              <label translate>conditions</label>
+              <label translate>conditions study</label>
               <textarea name="conditions" ng-model="xreport.locales[0].conditions" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].conditions"></span>
             </div>

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -127,7 +127,7 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
   <div class="description">
     ${get_document_locale_text(locale, 'place', True)}
     ${get_document_locale_text(locale, 'route_study', True)}
-    ${get_document_locale_text(locale, 'conditions', True)}
+    ${get_document_locale_text(locale, 'conditions', True, 'conditions study')}
     ${get_document_locale_text(locale, 'training', True)}
     ${get_document_locale_text(locale, 'motivations', True)}
     ${get_document_locale_text(locale, 'group_management', True)}


### PR DESCRIPTION
`conditions` is also used in other places. Thus use `conditions study` key instead.

See https://forum.camptocamp.org/t/nouvelle-version-v6-0-8/177838/7?u=b_b