### PR TITLE
Fix articles because of association key problems

### DIFF
--- a/c2corg_ui/templates/article/helpers/view.html
+++ b/c2corg_ui/templates/article/helpers/view.html
@@ -31,13 +31,13 @@
       <p><span class="value-title" translate>article_type</span>: <span class="value" x-translate>${article['article_type']}</span></p>
     % endif
 
-    % if article.get('author') and article['article_type'] != 'collab' and article['author']['user_id'] != article['associations']['users'][0]['document_id']:
+    % if article.get('author') and article['article_type'] == 'personal':
       <%
           user_id = article['author']['user_id']
           user_lang = article['locales'][0]['lang']
       %>
       <p><span class="value-title" translate>author</span>:
-        <a class="value" href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}" >${article['author']['name']}</a>
+      <a class="value" href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}" >${article['author']['name']}</a>
     % endif
 
     % if article.get('quality'):
@@ -49,30 +49,29 @@
 </%def>
 
 <%def name="get_article_associated_users(article)">\
-  % if article['associations']['users']:
-    % if len(article['associations']['users']) > 1 or not article['associations']['users'][0]['document_id'] == article['author']['user_id']:
-      <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
-        <h4><span translate>associated users</span><span class="glyphicon glyphicon-menu-right"></span></h4>
-        <div class="name-icon">
-          <span class="icon-user"></span>
-          <p translate>associated users</p>
-        </div>
-        <span class="detail-text accordion">
-          % if article.get('associations').get('users'):
-            <p>
-              % for user in article['associations']['users']:
-                <%
-                    user_id = user['document_id']
-                    user_lang = user['locales'][0]['lang']
-                    is_last_associated_user = loop.last
-                %>
-                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if is_last_associated_user else ', '}
-              % endfor
-            </p>
-          % endif
-
-        </span>
+  % if article.get('associations') and article['associations']['users'] and len(article['associations']['users']) > 1:
+    <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)">
+      <h4><span translate>associated users</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <div class="name-icon">
+        <span class="icon-user"></span>
+        <p translate>associated users</p>
       </div>
-    % endif
+      <span class="detail-text accordion">
+        % if article.get('associations').get('users'):
+          <p>
+            % for user in article['associations']['users']:
+              <%
+                  user_id = user['document_id']
+                  user_lang = user['locales'][0]['lang']
+              %>
+              % if user_id != article['author']['user_id']:
+                <a href="${request.route_path('profiles_view', id=user_id, lang=user_lang)}">${user['name']}</a>${'' if loop.last else ', '}
+              % endif
+            % endfor
+          </p>
+        % endif
+
+      </span>
+    </div>
   % endif
 </%def>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1404

All example articles (from related issue) should work
- https://www.camptocamp.org/articles/465897/fr/concours-photo-sophie-2013
- https://www.camptocamp.org/articles/106726/fr/140483
- https://www.camptocamp.org/articles/844265/fr/test (this one is new and not available in local DB to test)

Basically, there problems were with:
-  with `article['associations']['users'][0]['document_id']` when no associated users were available. I deleted it to make it work now.
-  in `get_article_associated_users` with `article['associations']['users']` - it was not available sometimes and causing an error (comparing versions in history)