### PR TITLE
Add create/edit report titles i18n

### DIFF
--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -331,6 +331,8 @@
 <span translate>Creating an article</span>
 <span translate>Editing an article</span>
 <span translate>Editing an image</span>
+<span translate>Creating a report</span>
+<span translate>Editing a report</span>
 
 ## home
 <span translate>Home</span>


### PR DESCRIPTION
`<title>` tag for xreports wasn't detected by gettext.