### PR TITLE
Enable setup of main WP from URL fragment for new routes

### DIFF
--- a/c2corg_ui/static/js/editing/routeediting.js
+++ b/c2corg_ui/static/js/editing/routeediting.js
@@ -40,7 +40,7 @@ app.RouteEditingController = function($scope, $element, $attrs, $http,
     if (ngeoLocation.hasFragmentParam('w')) {
       var waypointId = parseInt(ngeoLocation.getFragmentParam('w'), 10);
       appApi.getDocumentByIdAndDoctype(waypointId, 'w', appLang.getLang()).then(function(doc) {
-        this.documentService.pushToAssociations(doc.data['waypoints'].documents[0], 'waypoints', true);
+        this.documentService.pushToAssociations(doc.data['waypoints'].documents[0], 'waypoints', false, true);
       }.bind(this));
     }
   }


### PR DESCRIPTION
Related to a problem mentioned in https://github.com/c2corg/v6_ui/issues/1165#issuecomment-272719016

There was missing parameter and editing was set as undefined here in [documentservice.js](https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/documentservice.js#L141). It works now.