### PR TITLE
Fix flex lists display

### DIFF
--- a/c2corg_ui/static/js/constants.js
+++ b/c2corg_ui/static/js/constants.js
@@ -11,7 +11,7 @@ app.module.constant('constants', app.constants);
 
 app.constants = {
   SCREEN: {
-    SMARTPHONE : 620,
+    SMARTPHONE : 768,
     TABLET : 1099,
     DEKTOP : 1400
   },

--- a/c2corg_ui/static/partials/advancedsearch.html
+++ b/c2corg_ui/static/partials/advancedsearch.html
@@ -1,8 +1,13 @@
-<div class="list" app-loading>
+<div class="list advanced-search" app-loading>
   <div id="card{{doc.document_id}}" class="list-item" ng-class="[searchCtrl.doctype, {'highlight': doc.document_id === searchCtrl.highlightId}]"
        ng-repeat="doc in searchCtrl.documents track by doc.document_id">
     <app-card app-card-doc="::doc" ng-mouseenter="searchCtrl.onMouseEnter(doc.document_id)"
               ng-mouseleave="searchCtrl.onMouseLeave(doc.document_id)"></app-card>
   </div>
+  <!--
+    add 5 empty items to fix last row item width
+    see http://stackoverflow.com/a/22018710
+  !-->
+  <div class="list-item" ng-repeat="n in [].constructor(5) track by $index"></div>
 </div>
 <p translate class="text-warning text-center no-results" ng-class="{'show': searchCtrl.noResults}">No results</p>

--- a/c2corg_ui/templates/following.html
+++ b/c2corg_ui/templates/following.html
@@ -2,7 +2,7 @@
 from c2corg_common.attributes import mailinglists
 %>
 <%inherit file="base.html"/>
-<%namespace file="helpers/common.html" import="show_title"/>
+<%namespace file="helpers/common.html" import="show_title, generate_empty_list_items"/>
 <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Followed users')">${show_title('Followed users')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
@@ -11,7 +11,7 @@ from c2corg_common.attributes import mailinglists
     <h3 class="green-text" translate>Followed users</h3>
     <p translate>Here is the list of users you are following and whose activity you will see in your personal feed.</p>
     <app-simple-search app-select="flCtrl.addUser(doc)" dataset="u"></app-simple-search>
-    <div class="flex wrap-row areas" ng-show="flCtrl.following.length > 0">
+    <div class="list users" ng-show="flCtrl.following.length > 0">
       <div class="list-item users" ng-repeat="user in flCtrl.following">
         <app-card app-card-doc="user"></app-card>
         <span class="glyphicon glyphicon-minus-sign follow-btn" ng-click="flCtrl.toggle(user.document_id)"
@@ -19,6 +19,7 @@ from c2corg_common.attributes import mailinglists
         <span class="glyphicon glyphicon-plus-sign follow-btn" ng-click="flCtrl.toggle(user.document_id)"
               ng-hide="flCtrl.followingIds.indexOf(user.document_id) > -1" uib-tooltip="{{'Follow' | translate}}" tooltip-append-to-body="true"></span>
       </div>
+      ${generate_empty_list_items(5)}
     </div>
   </section>
 </div>

--- a/c2corg_ui/templates/helpers/common.html
+++ b/c2corg_ui/templates/helpers/common.html
@@ -14,3 +14,9 @@ ${title + ' - ' if title else ''}Camptocamp.org\
     </div>
   </div>
 </%def>
+
+<%def name="generate_empty_list_items(count)">\
+  ## add 5 empty items to fix last row item width (works with up to 6 items in a row)
+  ## see http://stackoverflow.com/a/22018710
+  <div class="list-item" ng-repeat="n in [].constructor(${count}) track by $index"></div>
+</%def>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -5,6 +5,7 @@
     from math import floor
     from c2corg_ui.views.document import get_slug
 %>
+<%namespace file="common.html" import="generate_empty_list_items"/>
 
 <%def name="get_licence(doc)">\
   <%
@@ -217,6 +218,7 @@
                 ng-if="${test_association_rights(document)}"></app-delete-association>
           % endif
         </div>
+        ${generate_empty_list_items(5)}
       </div>
     </section>
 </%def>
@@ -241,6 +243,7 @@
                 ng-if="${test_association_rights(document)}"></app-delete-association>
           % endif
         </div>
+        ${generate_empty_list_items(5)}
       </div>
     </section>
 </%def>
@@ -265,6 +268,7 @@
               ng-if="${test_association_rights(document)}"></app-delete-association>
           % endif
         </div>
+        ${generate_empty_list_items(5)}
       </div>
     </section>
 </%def>
@@ -316,6 +320,7 @@
             </a>
           </div>
         % endif
+        ${generate_empty_list_items(5)}
       </div>
     </section>
 </%def>
@@ -350,6 +355,7 @@
             "></app-delete-association>
         % endif
       </div>
+      ${generate_empty_list_items(5)}
     </div>
   </section>
 </%def>
@@ -405,6 +411,7 @@
           </a>
         </div>
       % endif
+      ${generate_empty_list_items(5)}
     </div>
   </article>
 </%def>

--- a/c2corg_ui/templates/preferences.html
+++ b/c2corg_ui/templates/preferences.html
@@ -2,7 +2,7 @@
 from c2corg_common.attributes import activities
 %>
 <%inherit file="base.html"/>
-<%namespace file="helpers/common.html" import="show_title"/>
+<%namespace file="helpers/common.html" import="show_title, generate_empty_list_items"/>
 <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Filter preferences')">${show_title('Filter preferences')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
@@ -27,12 +27,13 @@ from c2corg_common.attributes import activities
         <h3 translate class="green-text">Areas</h3>
         <app-simple-search app-select="prefCtrl.addArea(doc)" dataset="a"></app-simple-search>
         <p translate ng-show="prefCtrl.areas.length == 0">Select the region of your interest by typing in the fied.</p>
-        <div class="flex wrap-row areas" ng-show="prefCtrl.areas.length > 0">
-          <div class="list-item new-item"
+        <div class="list areas" ng-show="prefCtrl.areas.length > 0">
+          <div class="list-item areas new-item"
                ng-repeat="area in prefCtrl.areas">
             <app-card app-card-doc="area" app-card-disable-click="true"></app-card>
             <span class="glyphicon glyphicon-trash" ng-click="prefCtrl.removeArea(area.document_id)"></span>
           </div>
+          ${generate_empty_list_items(5)}
         </div>
       </div>
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -844,19 +844,9 @@ ul {
   float: left;
 }
 
-.section.associations, .view-details-section {
+.section.associations,
+.view-details-section {
   .list-item {
-    margin-right: .5%;
-    margin-left: .5%;
-    width: 49%;
-
-    @media @big {
-      width: 32%;
-    }
-    @media @phone {
-      width: 100%;
-    }
-
     &.new-outing a, &.new-route a {
       .flex();
       align-items: center;
@@ -927,9 +917,6 @@ ul {
       }
       [class^="icon-"] {
         font-size: 4em;
-        @media @big {
-          font-size: 4em;
-        }
         @media (max-width: @screen-sm-min) {
           font-size: 3.5em;
         }
@@ -963,9 +950,6 @@ ul {
     app-simple-search {
       width: 100%;
     }
-    .list-item {
-      flex-basis: 100% !important;
-    }
   }
 }
 
@@ -987,10 +971,6 @@ ul {
   .preferences-activities, .preferences-areas {
     border-top: 1px solid rgba(221, 221, 221, 0.5);
     margin-top: 30px;
-  }
-  .areas .list-item {
-    flex-basis: 33%;
-    margin-right: 10px;
   }
   @media @phone {
     .route-activity {

--- a/less/lists.less
+++ b/less/lists.less
@@ -1,9 +1,10 @@
 .list {
   width:100%;
-  padding: 1% 2% 50px 2%;
+  padding: 2px 2px 50px 2px;
   .flex();
-  justify-content: space-around;
-  flex-flow: wrap row;
+  flex-flow: wrap;
+  margin-left: -4px;
+  margin-top: -4px;
 
   .list-item {
     min-height: initial;
@@ -292,10 +293,6 @@
   }
   // .list-item.users
   &.users {
-    margin-left: 3px;
-    margin-right: 3px;
-    flex-basis: 300px;	
-    max-width: 350px;
     .list-item-info {
       justify-content: center;
     }
@@ -317,13 +314,6 @@
   &.no-map {
     .page-main-title, .documents-list-section {
       flex-basis: 100%;
-    }
-    .list-item {
-      flex-basis: 300px;
-      flex-grow: 1;
-      margin-right: 2px;
-      margin-left: 2px;	
-      max-width: 350px;
     }
   }
   &.no-list  .documents-list-section {
@@ -370,22 +360,23 @@
   }
 }
 
-.section.associations, .view-details-associations, .list {
-  .list-item {
-    flex-basis: 300px;
-    flex-grow: 1;
-    margin-right: 2px;
-    margin-left: 2px;
-    max-width: 350px;	
+.list-item {
+  flex: 1 0 300px;
+  margin-top: 4px;
+  margin-left: 4px;
+
+  // http://stackoverflow.com/a/22018710
+  &:empty {
+    min-height: 0;
+    height: 0;
+    border: none;
   }
 }
 
-.documents-list-section-container, .section.associations, .view-details-associations {
-  &.no-map .list-item{
-    flex-basis: 300px;
-    flex-grow: 1;
-    margin-right: 2px;
-    margin-left: 2px;	
+.list.users,
+.list.areas {
+  .list-item {
+    flex: 1 0 200px;
   }
 }
 
@@ -411,6 +402,9 @@
 }
 
 #feed .list-item {
+  margin-left: 0;
+  margin-top: 10px;
+
   .list-item-info {
     min-height: 60px;
   }
@@ -459,4 +453,10 @@
       }
     }
   }
+}
+
+.list.advanced-search {
+  padding-left: 10px;
+  padding-right: 10px;
+  margin: 0;
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,10 +1,9 @@
-@big: ~"only screen and (min-width: 1400px) and (max-width: 3000px)";
+@big: ~"only screen and (min-width: 1400px)";
 @desktop: ~"only screen and (min-width: 1100px) and (max-width: 1399px)";
 @tablet: ~"only screen and (min-width: 769px) and (max-width: 1099px)";
 @phone: ~"only screen and (max-width: 768px)";
 @phone-max: 768px;
-@tablet-max: 1100px;
-@large-width: 1800px;
+@tablet-max: 1099px;
 @lightgrey: #F0F0F0;
 @C2C-orange: #FFAA45;
 @bg-color1 : #ebe4d1;

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -304,11 +304,6 @@
     .associated-documents {
       margin-bottom: 5px;
       padding-left: 10px;
-
-      .list-item {
-        margin-right: 2px;
-        margin-left: 2px;
-      }
     }
   }
 


### PR DESCRIPTION
To ensure a correct positioning of items in last row, we use the technique described here: http://stackoverflow.com/a/22018710, adding empty div elements at the end.

The base size for items is 300px, except for areas in preferences and users in following, which use a 200px basis. The sizes could be adjusted following your comments. The new behaviour is:

* the items have a min size of 300px (resp. 200px)
* they expand until there is place for another item in the row
* last row items are aligned to the left and have the same size as the others

Note: the less code is quite a mess on this matter (sorry), so I hope I didn't introduce bugs. Please test it carefully.