### PR TITLE
Fix advanced search map display on mobile

### DIFF
--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -340,7 +340,7 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   transition: .3s;
 
   @media @phone {
-    margin-left: 0;
+    left: 0;
     bottom: 40px;
     position: fixed;
     opacity: 0;
@@ -352,12 +352,8 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
       -webkit-box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       -moz-box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
-      height: 250px;
       margin-top: 0;
-      height: 80vh !important;
-    }
-    @media screen and (max-height: 330px) {
-      height: 73vh !important;
+      height: calc(~"100vh - 120px") !important;
     }
   }
 }


### PR DESCRIPTION
* now works on FF (and most likely on Safari and other failing browsers too, to be tested), see #1353
* correct dimensions (height wasn't computed properly)