### PR TITLE
Disable not-operational upload button in the editing form

### DIFF
--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -87,13 +87,14 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
             </div>
 
             ## UPLOAD NEW IMAGE BTN
-            <div class="upload-file half">
-              <button class="orange-btn btn" type="button">
-                <span translate>upload a new version</span>&nbsp;
-                <span class="glyphicon glyphicon-upload"></span>
-              </button>
-              <input type="file"/>
-            </div>
+## TODO implement this tool
+##            <div class="upload-file half">
+##              <button class="orange-btn btn" type="button">
+##                <span translate>upload a new version</span>&nbsp;
+##                <span class="glyphicon glyphicon-upload"></span>
+##              </button>
+##              <input type="file"/>
+##            </div>
 
             ## ACTIVITIES
             <div class="form-group full" ng-init="activities = ${activities}" id="image-activities">


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1220

This PR does not fix the feature, it simply comment the upload button out because it is not functional (open the file selection window but does nothing else).

Another PR is needed to actually implement the feature.