### PR TITLE
Ugrade ngeo to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "angular-gettext-tools": "2.2.3",
     "angular-messages": "1.5.8",
     "slug": "0.9.1",
-    "angular-slug": "git://github.com/lucasconstantino/angular-slug#v0.0.4",
+    "angular-slug": "0.0.4",
     "eslint": "2.13.1",
     "eslint-config-openlayers": "5.0.0",
     "file-saver": "1.3.3",
@@ -44,7 +44,7 @@
     "less": "2.7.1",
     "less-plugin-clean-css": "1.5.1",
     "ng-file-upload": "12.2.13",
-    "ngeo": "git://github.com/camptocamp/ngeo#2.1.0-rc.7",
+    "ngeo": "2.1.1",
     "nomnom": "1.8.1",
     "openlayers": "3.19.1",
     "corejs-typeahead": "1.0.1"


### PR DESCRIPTION
I wanted to use the actual ngeo 2.1.0 release instead of a release candidate but noticed 2.1.1 was out shortly after.
Tested successfully with Chrome and FF.

ngeo 2.2.0 is available too but @sbrunner told me it uses ES6 instead of ES5 and might require changes in our Closure compiler settings to make the compiled code work with older browser...