### PR TITLE
Fix image type field behaviour in image editing form

### DIFF
--- a/c2corg_ui/static/js/editing/imageediting.js
+++ b/c2corg_ui/static/js/editing/imageediting.js
@@ -51,6 +51,11 @@ app.ImageEditingController = function($scope, $element, $attrs, $http,
    */
   this.exposureError = false;
 
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.initialImageType = null;
 };
 goog.inherits(app.ImageEditingController, app.DocumentEditingController);
 
@@ -65,6 +70,7 @@ app.ImageEditingController.prototype.filterData = function(data) {
   // Image's date has to be converted to Date object because uib-datepicker
   // will treat it as invalid -> invalid form.
   data['date_time'] = new Date(data['date_time']);
+  this.initialImageType = data['image_type'];
   return data;
 };
 
@@ -99,6 +105,19 @@ app.ImageEditingController.prototype.convertExposureTime = function(value) {
  */
 app.ImageEditingController.prototype.createImgUrl = function(filename) {
   return this.imageUrl_ + app.utils.createImageUrl(filename, 'BI');
+};
+
+
+/**
+ * @param {Array.<string>} imageTypes
+ * @return {Array.<string>}
+ * @export
+ */
+app.ImageEditingController.prototype.filterImageTypes = function(imageTypes) {
+  var removeCopyright = function(val) {
+    return val !== 'copyright';
+  };
+  return imageTypes.filter(removeCopyright);
 };
 
 app.module.controller('appImageEditingController', app.ImageEditingController);

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -142,7 +142,13 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
               <div ng-class="{ 'has-success': image.image_type}">
                 <label><span translate>image_type</span> *</label>
                 <div class="input-group" ng-init="image_types = ${image_types}">
-                  <select class="form-control" ng-model="image.image_type" ng-options="type as mainCtrl.translate(type) for type in image_types"><option value=""></option></select>
+                  <select class="form-control" ng-model="image.image_type" ng-if="userCtrl.isModerator()"
+                    ng-options="type as mainCtrl.translate(type) for type in image_types"></select>
+                  <div ng-if="!userCtrl.isModerator()">
+                    <select class="form-control" ng-model="image.image_type" ng-if="editCtrl.initialImageType == 'personal'"
+                      ng-options="type as mainCtrl.translate(type) for type in editCtrl.filterImageTypes(image_types)"></select>
+                    <input type="text" disabled class="form-control" ng-model="image.image_type" ng-if="editCtrl.initialImageType != 'personal'" />
+                  </div>
                   <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
                 </div>
                 <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.image_type"></span>


### PR DESCRIPTION
- Moderators can change to whatever type
- Non moderators can only change type from 'personal' to 'collaborative'. If type is 'collaborative' or 'copyright' the field is disabled.

Related to https://github.com/c2corg/v6_ui/issues/1441