### PR TITLE
Del. outing assoc. section from book view; add assoc. section to edit page

### DIFF
--- a/c2corg_ui/templates/book/edit.html
+++ b/c2corg_ui/templates/book/edit.html
@@ -6,7 +6,8 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
   updating_doc = book_id and book_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons"/>
+<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons,
+    show_editing_associated_waypoints, show_editing_associated_routes, show_editing_associated_articles"/>
 
 <%block name="pagetitle"><title ng-init="id = ${book_id if book_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a book') : mainCtrl.page_title('Creating a book')">${show_title('Create/edit book')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -149,6 +150,21 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
               </div>
             </div>
 
+          </div>
+        </section>
+
+        ## ASSOCIATIONS
+        <section class="section associations">
+          <h2 class="heading show-phone"><span translate>associations</span></h2>
+          <h5 class="full" translate ng-show="editCtrl.documentService.document.associations.routes.length == 0 && editCtrl.documentService.document.associations.waypoints.length == 0">
+            You can add associated documents by searching in the field.
+          </h5>
+          <div class="content route-associations">
+            <app-simple-search parent-id="book.document_id"
+              app-select="editCtrl.documentService.pushToAssociations(doc)" dataset="wrc"></app-simple-search>
+            ${show_editing_associated_waypoints('book')}
+            ${show_editing_associated_routes('book')}
+            ${show_editing_associated_articles('book')}
           </div>
         </section>
 

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -94,16 +94,6 @@ other_langs, missing_langs = get_lang_lists(book, lang)
     </div>
   % endif
 
-  % if 'recent_outings' in book['associations'] and book['associations']['recent_outings']['total'] > 0:
-    <div class="view-details-associations col-xs-12  associations">
-      <span class="lead">
-        <section>
-          ${show_associated_outings(book)}
-        </section>
-      </span>
-    </div>
-  % endif
-
   ${get_comments()}
 
   ## OTHER BUTTON contents


### PR DESCRIPTION
- Historic versions of books were not loaded because of error with missing outing 'associations' key when searching for outings. I deleted that block completely because it shouldn't be possible to assoc. book to outing.
f.r. versions here https://www.camptocamp.org/books/history/14490/fr 

- I also added assoc. section on the editing page like we did it for other document types.