### PR TITLE
Geom download button is displayed only for WP and routes/outings with…

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -831,15 +831,18 @@
   </label>
 </%def>
 
-<%def name="show_geom_download(document)">\
+<%def name="show_geom_download(document, isLine=False)">\
   % if document.get('geometry'):
-    <p class="hidden-print">
-      % if document.get('geometry').get('geom_detail'):
+    % if isLine and document.get('geometry').get('geom_detail'):
+      <p class="hidden-print">
         <span translate class="value-title">Download track as</span>
-      % elif document.get('geometry').get('geom'):
+        <app-geom-download></app-geom-download>
+      </p>
+    % elif not isLine and document.get('geometry').get('geom'):
+      <p class="hidden-print">
         <span translate class="value-title">Download waypoint as</span>
-      % endif
-      <app-geom-download></app-geom-download>
-    </p>
+        <app-geom-download></app-geom-download>
+      </p>
+    % endif
   % endif
 </%def>

--- a/c2corg_ui/templates/outing/helpers/view.html
+++ b/c2corg_ui/templates/outing/helpers/view.html
@@ -64,7 +64,7 @@
     % endif
 
     % if not isPreview:
-      ${show_geom_download(outing)}
+      ${show_geom_download(outing, True)}
     % endif
 
   </span>

--- a/c2corg_ui/templates/route/helpers/view.html
+++ b/c2corg_ui/templates/route/helpers/view.html
@@ -106,7 +106,7 @@ from c2corg_ui.templates.utils import get_route_gear_articles
       % endif
 
       % if not isPreview:
-        ${show_geom_download(route)}
+        ${show_geom_download(route, True)}
       % endif
 
     </span>


### PR DESCRIPTION
… an actual geom_detail

Related to #1457
Former PR #1460 had an error and made the download button appear for all routes or outings even with no ``geom_detailed`` because all routes/outings have at least a point geom (a WP download button was then displayed, which was not wanted).