### PR TITLE
Check properly for missing route attributes to prevent server error

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -111,7 +111,8 @@
       title = ''
       if 'title_prefix' in locale and locale['title_prefix']:
           title = locale['title_prefix'] + ' : '
-      title += locale['title']
+      if 'title' in locale and locale['title']:
+          title += locale['title']
   %>\
   ${title}${' - Camptocamp.org' if is_tab_title else ''}\
 </%def>

--- a/c2corg_ui/templates/route/helpers/view.html
+++ b/c2corg_ui/templates/route/helpers/view.html
@@ -264,7 +264,7 @@ from c2corg_ui.templates.utils import get_route_gear_articles
   <%
     gear_articles = get_route_gear_articles(route)
   %>
-  % if locale['gear'] or gear_articles:
+  % if ('gear' in locale and locale['gear']) or gear_articles:
     <div class="view-details-info col-xs-12">
       <h3 class="heading show-phone"
           ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#gear">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -40,7 +40,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
 <%block name="moduleConstantsValues">
   <%
-      if route['geometry']:
+      if 'geometry' in route and route['geometry']:
           geometry = route['geometry']['geom_detail'] \
               if route['geometry']['geom_detail'] else route['geometry']['geom']
       else:


### PR DESCRIPTION
related to https://github.com/c2corg/v6_ui/issues/1469#issuecomment-277222520

It was not possible to browse some archived versions of Routes. For some reason (missing attributes?), there are unknown keys in historic documents. They created internal server error because of Mako templates rendering.