### PR TITLE
Rework images inserted in document on mobile

### DIFF
--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -745,7 +745,7 @@ app-add-association {
 
     @media @phone {
       margin: 5px auto !important;
-      max-width: 285px;
+      max-width: 90%;
       float: none !important;
 
       figcaption {
@@ -755,6 +755,8 @@ app-add-association {
       }
       img {
         margin: auto !important;
+        max-width: 100%;
+        height: auto;
       }
     }
     /*Big Image*/
@@ -771,7 +773,6 @@ app-add-association {
       display: none;
     }
     figcaption {
-      max-width: 240px;
       margin: 5px 10px -5px 10px;
       color: dimgray;
       font-size: 14px;


### PR DESCRIPTION
Was (no constraint on image, but 285px figure):
![snapshot17](https://cloud.githubusercontent.com/assets/2234024/22712285/8a9e9f0a-ed84-11e6-832e-28cf85d124b9.png)
![snapshot18](https://cloud.githubusercontent.com/assets/2234024/22712284/8a98058c-ed84-11e6-8759-57cf0d2f0f99.png)


Now (adapts to image size, or max 90% width):
![snapshot15](https://cloud.githubusercontent.com/assets/2234024/22712289/8ffc0bb8-ed84-11e6-935a-99320b83783a.png)
![snapshot16](https://cloud.githubusercontent.com/assets/2234024/22712288/8ff7a424-ed84-11e6-95ca-372426f916da.png)
