### PR TITLE
Use 'personal informations' title instead of 'personal' for xreports

### DIFF
--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -267,7 +267,7 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
 
         ## PERSONAL
         <section class="section title" ng-show="userCtrl.auth.isAuthenticated()">
-          <h2 class="heading show-phone" translate>personal</h2>
+          <h2 class="heading show-phone" translate>personal informations</h2>
           <div class="content">
 
             ## age

--- a/c2corg_ui/templates/xreport/helpers/view.html
+++ b/c2corg_ui/templates/xreport/helpers/view.html
@@ -121,10 +121,10 @@
 <%def name="get_xreport_personal(xreport)">\
   % if xreport.get('author_status') or xreport.get('previous_injuries') or xreport.get('gender') or xreport.get('autonomy') or xreport.get('age'):
     <div class="name-icon-value" ng-click="detailsCtrl.openTab($event)" >
-      <h4><span translate>personal</span><span class="glyphicon glyphicon-menu-right"></span></h4>
+      <h4><span translate>personal informations</span><span class="glyphicon glyphicon-menu-right"></span></h4>
       <div class="name-icon">
         <span class="icon-user"></span>
-        <p translate>personal</p>
+        <p translate>personal informations</p>
       </div>
 
       <span class="detail-text accordion">


### PR DESCRIPTION
Related to #1473 
I re-use `personal informations` key, which is similar and used also in outings creation wizard. @asaunier is it best to use different keys, or is it OK like this to limit the number of translation items?