### PR TITLE
Do not show "Got to last" button if there are too many results

### DIFF
--- a/c2corg_ui/static/js/search/pagination.js
+++ b/c2corg_ui/static/js/search/pagination.js
@@ -73,6 +73,11 @@ app.PaginationController = function($scope, ngeoLocation) {
     this.handleSearchChange_.bind(this));
 };
 
+/**
+ * @const
+ * @type {number}
+ */
+app.PaginationController.MAX_RESULT_OFFSET = 10000;
 
 /**
  * @param {Object} event
@@ -85,11 +90,10 @@ app.PaginationController.prototype.handleSearchChange_ = function(event,
     features, total, recenter) {
   this.total = total;
   this.offset = this.location_.getFragmentParamAsInt('offset') || 0;
-  // don't show the "Go to last page" button when doing a full-text-search
-  // (the full result set has to be iterated in ElasticSearch when doing
-  // requests with large offsets)
-  this.showGoToLastPage = !(this.location_.hasFragmentParam('q') &&
-    this.location_.getFragmentParam('q') !== '');
+  // don't show the "Go to last page" button if the offset is above
+  // maxResultOffset_, or the API will return an error
+  this.showGoToLastPage =
+    this.total <= app.PaginationController.MAX_RESULT_OFFSET;
 };
 
 


### PR DESCRIPTION
If offset is above 9970, the API will return an error.

See #1487 