### PR TITLE
Fix error in old outing versions without any geometry

### DIFF
--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -42,26 +42,30 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
       else:
           geometry = None
   %>
-  module.value('mapFeatureCollection', {
-    "type": "FeatureCollection",
-    "properties": {},
-    "features": [{
-      "type": "Feature",
-      % if geometry:
-        "geometry": ${geometry | n},
-      % endif
-      "properties": {
-        "title": ${dumps(locale['title']) | n},
-        "lang": "${locale['lang']}",
-        "documentId": ${outing['document_id']},
-        "module": "outings"
-      }
-    }
-    % if not version:
-      ${associated_images_featurelist(outing)}
+  module.value('mapFeatureCollection',
+    % if geometry:
+      {
+        "type": "FeatureCollection",
+        "properties": {},
+        "features": [
+        {
+          "type": "Feature",
+          "geometry": ${geometry | n},
+          "properties": {
+            "title": ${dumps(locale['title']) | n},
+            "lang": "${locale['lang']}",
+            "documentId": ${outing['document_id']},
+            "module": "outings"
+          }
+        }
+        % if not version:
+          ${associated_images_featurelist(outing)}
+        % endif
+      ]}
+    % else:
+      null
     % endif
-    ]
-  });
+  );
 
   module.value('documentData', {
     "document_id": ${outing.get('document_id')},

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -36,15 +36,20 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
 <%block name="moduleConstantsValues">
   <%
-      geometry = outing['geometry']['geom_detail'] \
-          if outing['geometry']['geom_detail'] else outing['geometry']['geom']
+      if outing.get('geometry'):
+          geometry = outing['geometry']['geom_detail'] \
+              if outing['geometry']['geom_detail'] else outing['geometry']['geom']
+      else:
+          geometry = None
   %>
   module.value('mapFeatureCollection', {
     "type": "FeatureCollection",
     "properties": {},
     "features": [{
       "type": "Feature",
-      "geometry": ${geometry | n},
+      % if geometry:
+        "geometry": ${geometry | n},
+      % endif
       "properties": {
         "title": ${dumps(locale['title']) | n},
         "lang": "${locale['lang']}",
@@ -84,7 +89,10 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     ${show_areas(outing)}
   </article>
 % endif
-<app-map class="view-details-map"></app-map>
+
+% if outing.get('geometry'):
+  <app-map class="view-details-map"></app-map>
+% endif
 
 <section class="view-details-section" app-view-details>
 


### PR DESCRIPTION
related to https://github.com/c2corg/v6_ui/issues/1491

there is `geometry: null` in this version of an outing which was causing an error ...
http://localhost:6548/outings/815298/fr/1284552

I removed map too when there is no geometry.