### PR TITLE
Show error['name'] in front of the error['description']

### DIFF
--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -135,11 +135,11 @@ app.Alerts.prototype.formatErrorMsg_ = function(response) {
   if (len > 1) {
     var msg = '<ul>';
     for (var i = 0; i < len; i++) {
-      msg += '<li>' + this.filterStr_(errors[i]['description']) + ' : ' + this.filterStr_(errors[i]['name']) + '</li>';
+      msg += '<li>' + this.filterStr_(errors[i]['name']) + ' : ' + this.filterStr_(errors[i]['description']) + '</li>';
     }
     return msg + '</ul>';
   }
-  return this.filterStr_(errors[0]['description']) + ' : ' + this.filterStr_(errors[0]['name']);
+  return this.filterStr_(errors[0]['name']) + ' : ' + this.filterStr_(errors[0]['description']);
 };
 
 


### PR DESCRIPTION
It seems really better to show:
```
name : description.
```
than
```
description. : name
```
