### PR TITLE
[WIP] iPhone-Safari map buttons - styles fix

### DIFF
--- a/config/dkocich
+++ b/config/dkocich
@@ -1,6 +1,6 @@
 include config/dev
 
-export debug_port = 6558
+export debug_port = 3000
 export instanceid = dkocich
 export base_url = /${instanceid}
 export api_url = http://localhost:6548

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -357,6 +357,14 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   margin: 3% 0 3% 0;
 }
 
+//Safari 9+ fix
+_::-webkit-:not(:root:root), .map-right {
+  top: @page-header-height + @page-main-title-height;
+  .map {
+    .calc(height, "100vh - 120px - @{page-header-height} - @{page-main-title-height}") !important;
+  }
+}
+
 .map-right {
   flex: 1;
   transition: .3s;
@@ -375,7 +383,7 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
       -moz-box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       margin-top: 0;
-      height: calc(~"100vh - 120px") !important;
+      height: calc(~"100vh - 120px");
     }
   }
 }


### PR DESCRIPTION
Selector for Safari 9+ should work fine. https://browserstrangeness.bitbucket.io/css_hacks.html?#webkit I don't have issues with desktop and my Android, but I am afraid that iOS Chrome will be broken now because there is no selector only for Safari which wouldn't work in iOS version of Chrome too.

If someone with iPhone would confirm that the iOS Chrome is broken now, then probably the only option is to restyle the map only for Safari using JS (somewhere in `map.js`)???
http://browserhacks.com/#hack-462504c4ab517b400419d1b3d73d943a