### PR TITLE
[WIP] Add addthis service to the website

### DIFF
--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -164,5 +164,6 @@ closure_library_path = settings.get('closure_library_path')
       ga('send','pageview',{'anonymizeIp':true});
     </script>
     <script src="https://www.google-analytics.com/analytics.js" async defer></script>
+    <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-58abf6b4f3a680cb" async defer></script>
   </body>
 </html>


### PR DESCRIPTION
related to https://github.com/c2corg/v6_ui/issues/1495

The tool should work correctly just by adding one line but I am not sure about the exact styling and use of all other offered possibilities (please explore https://www.addthis.com/get/share).

Note - all styles, layout, visible button settings, etc. can be change on the addthis website with UI. Added script just loads the current configuration.

I can invite anyone to test and change settings of this account or you can create association's account and change `pubid` of the src attribute now.

Todo:
- [ ] add `pubid` key to the config instead of `base.html` ?