### PR TITLE
Rename document merging route

### DIFF
--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -707,7 +707,7 @@ app.Api.prototype.mergeDocuments = function(sourceDocumentId, targetDocumentId) 
   var data = {
     'source_document_id': sourceDocumentId,
     'target_document_id': targetDocumentId};
-  var promise = this.postJson_('/document/merge', data);
+  var promise = this.postJson_('/documents/merge', data);
   promise.catch(function(response) {
     var msg = this.alerts_.gettext('Merging documents failed:');
     this.alerts_.addErrorWithMsg(msg, response);


### PR DESCRIPTION
Use ``documents/merge`` instead of ``document/merge`` (plural) to be consistent with specific document type routes (eg. ``waypoints/add``) and document deletion (``documents/delete``).

Requires https://github.com/c2corg/v6_api/pull/636