### PR TITLE
Fix activation of date filter from URL for outings

### DIFF
--- a/c2corg_ui/static/js/search/outingfilters.js
+++ b/c2corg_ui/static/js/search/outingfilters.js
@@ -18,11 +18,6 @@ app.OutingFiltersController = function($scope, ngeoLocation, ngeoDebounce,
 
   goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
 
-  /**
-   * @type {Array.<Date>}
-   * @export
-   */
-  this.dates = [];
 
   /**
    * Start cannot be after today nor end_date.

--- a/c2corg_ui/static/js/search/searchfilters.js
+++ b/c2corg_ui/static/js/search/searchfilters.js
@@ -64,6 +64,12 @@ app.SearchFiltersController = function($scope, ngeoLocation, ngeoDebounce,
   this.scope_ = $scope;
 
   /**
+   * @type {Array.<Date>}
+   * @export
+   */
+  this.dates = [];
+
+  /**
    * @type {ngeo.Location}
    * @public
    */

--- a/c2corg_ui/static/js/search/xreportfilters.js
+++ b/c2corg_ui/static/js/search/xreportfilters.js
@@ -19,12 +19,6 @@ app.XreportFiltersController = function($scope, ngeoLocation, ngeoDebounce,
   goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
 
   /**
-   * @type {Array.<Date>}
-   * @export
-   */
-  this.dates = [];
-
-  /**
    * Start cannot be after today nor end_date.
    * @type {Date}
    * @export


### PR DESCRIPTION
related to https://github.com/c2corg/v6_ui/issues/1295

`this.dates` was undefined in the outing's filter controller (even if it should be defined [here](https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/search/outingfilters.js#L21-L25)) and it caused an error ([here](https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/search/outingfilters.js#L65)) while the date was pushed into it.

I moved `this.dates` to the parent controller and it works fine for both document types.

It is a bit strange because for Xreport this works fine and both controllers are very similar (if not same).

Test -
* Outings http://localhost:6558/outings?debug#date=2016-11-01%252C2017-02-20
* Xreports http://localhost:6558/xreports?debug#date=2016-11-29%252C2017-02-20