### PR TITLE
Prefer EXIF field DateTimeOriginal to get image date

### DIFF
--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -379,7 +379,11 @@ app.ImageUploaderController.prototype.setExifData_ = function(file) {
   var exif = file['exif'];
   var metadata = file['metadata'];
 
-  metadata['date_time'] = this.parseExifDate_(exif);
+  var date = this.parseExifDate_(exif, 'DateTimeOriginal');
+  if (date === null) {
+    date = this.parseExifDate_(exif, 'DateTime');
+  }
+  metadata['date_time'] = date;
   metadata['exposure_time'] = exif['ExposureTime'];
   metadata['iso_speed'] = exif['PhotographicSensitivity'];
   metadata['focal_length'] = exif['FocalLengthIn35mmFilm'];
@@ -390,14 +394,15 @@ app.ImageUploaderController.prototype.setExifData_ = function(file) {
 
 /**
  * @param {Object} exifData Exif data
- * @return {String} Parsed date in ISO format.
+ * @param {string} exifTag Exif tag.
+ * @return {?string} Parsed date in ISO format.
  * @private
  */
-app.ImageUploaderController.prototype.parseExifDate_ = function(exifData) {
-  if (!exifData['DateTime']) {
+app.ImageUploaderController.prototype.parseExifDate_ = function(exifData, exifTag) {
+  if (!exifData[exifTag]) {
     return null;
   }
-  var exifDate = exifData['DateTime'];
+  var exifDate = exifData[exifTag];
   var date = window.moment(exifDate, 'YYYY:MM:DD HH:mm:ss');
   return date.isValid() ? date.format() : null;
 };


### PR DESCRIPTION
Some photos have more than one EXIF field related to the date time. So far we were using `DateTime`, which is the last time the photo was modified. It is better to use `DateTimeOriginal` (if available) which is the time the photo was taken.

Related to https://github.com/c2corg/v6_api/issues/627