### PR TITLE
Add tool to load prefs in advanced search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ LIBS_JS_FILES += \
     c2corg_ui/static/lib/angular-bootstrap/ui-bootstrap-custom-1.3.2.min.js \
     c2corg_ui/static/lib/angular-bootstrap/ui-bootstrap-custom-tpls-1.3.2.min.js \
     node_modules/angular-gettext/dist/angular-gettext.min.js \
-    node_modules/angular-debounce/angular-debounce.js \
     node_modules/angular-messages/angular-messages.min.js \
     node_modules/angular-cookies/angular-cookies.min.js \
     node_modules/corejs-typeahead/dist/typeahead.bundle.min.js \

--- a/build.json
+++ b/build.json
@@ -22,7 +22,6 @@
       "c2corg_ui/externs/angular-1.5.js",
       "c2corg_ui/externs/angular-1.5-q_templated.js",
       "c2corg_ui/externs/angular-1.5-http-promise_templated.js",
-      "c2corg_ui/externs/debounce.js",
       "node_modules/openlayers/externs/bingmaps.js",
       "node_modules/openlayers/externs/closure-compiler.js",
       "node_modules/openlayers/externs/esrijson.js",

--- a/c2corg_ui/externs/debounce.js
+++ b/c2corg_ui/externs/debounce.js
@@ -1,7 +1,0 @@
-
-/**
- * @typedef {
- *  function(function(), number)
- * }
- */
-var debounce;

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -26,6 +26,5 @@ app.module = angular.module('app', [
   'ngFileUpload',
   'slug',
   'vcRecaptcha',
-  'infinite-scroll',
-  'debounce'
+  'infinite-scroll'
 ]);

--- a/c2corg_ui/static/js/loadpreferences.js
+++ b/c2corg_ui/static/js/loadpreferences.js
@@ -113,7 +113,7 @@ app.LoadPreferencesController.prototype.loadPreferences_ = function() {
       this.location_.deleteFragmentParam('bbox');
     }
     this.location_.updateFragmentParams(params);
-    this.scope_.$root.$emit('searchFilterChange');
+    this.scope_.$root.$emit('searchFilterChange', true);
   }
 };
 

--- a/c2corg_ui/static/js/loadpreferences.js
+++ b/c2corg_ui/static/js/loadpreferences.js
@@ -1,0 +1,174 @@
+goog.provide('app.LoadPreferencesController');
+goog.provide('app.loadPreferencesDirective');
+
+goog.require('app');
+
+
+/**
+ * @return {angular.Directive}
+ */
+app.loadPreferencesDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'AppLoadPreferencesController',
+    controllerAs: 'lpCtrl',
+    bindToController: {
+      'module': '@appLoadPreferences',
+      'url': '@appLoadPreferencesUrl'
+    },
+    link: function(scope, el, attr, ctrl) {
+      el.click(function() {
+        ctrl.applyPreferences();
+      });
+    }
+  };
+};
+
+app.module.directive('appLoadPreferences', app.loadPreferencesDirective);
+
+
+/**
+ * @param {angular.Scope} $scope Directive scope.
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {app.Api} appApi Api service.
+ * @constructor
+ * @ngInject
+ * @struct
+ */
+app.LoadPreferencesController = function($scope, ngeoLocation, appApi) {
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {ngeo.Location}
+   * @private
+   */
+  this.location_ = ngeoLocation;
+
+  /**
+   * @type {app.Api}
+   * @private
+   */
+  this.api_ = appApi;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.module;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.url;
+
+  /**
+   * @type {?appx.UserPreferences}
+   * @private
+   */
+  this.preferences_;
+
+  /**
+   * @type {Object}
+   * @private
+   */
+  this.params_ = {};
+};
+
+
+/**
+ * @export
+ */
+app.LoadPreferencesController.prototype.applyPreferences = function() {
+  if (this.preferences_) {
+    this.loadPreferences_();
+  } else {
+    this.api_.readPreferences().then(function(response) {
+      this.preferences_ = /** @type {appx.UserPreferences} */ (response['data']);
+      this.loadPreferences_();
+    }.bind(this));
+  }
+};
+
+
+/**
+ * @private
+ */
+app.LoadPreferencesController.prototype.loadPreferences_ = function() {
+  var params = this.getParams_();
+  if (this.url) {
+    var list = [];
+    for (var param in params) {
+      list.push(param + '=' + params[param]);
+    }
+    window.location = this.url + '#' + list.join('&');
+  } else {
+    this.location_.deleteFragmentParam('offset');
+    if ('a' in params) {
+      this.location_.deleteFragmentParam('bbox');
+    }
+    this.location_.updateFragmentParams(params);
+    this.scope_.$root.$emit('searchFilterChange');
+  }
+};
+
+
+/**
+ * @return {Object}
+ * @private
+ */
+app.LoadPreferencesController.prototype.getParams_ = function() {
+  var params = {};
+  var areas, activities;
+  switch (this.module) {
+    case 'outings':
+    case 'routes':
+    case 'images':
+    case 'xreports':
+      areas = this.getAreas_();
+      activities = this.getActivities_();
+      break;
+    case 'waypoints':
+      areas = this.getAreas_();
+      break;
+    case 'books':
+    case 'articles':
+      activities = this.getActivities_();
+      break;
+    default:
+      break;
+  }
+  if (areas) params['a'] = areas;
+  if (activities) params['act'] = activities;
+  return params;
+};
+
+
+/**
+ * @return {string}
+ * @private
+ */
+app.LoadPreferencesController.prototype.getAreas_ = function() {
+  var data = this.preferences_.areas;
+  var areas = [];
+  for (var i = 0, n = data.length; i < n; i++) {
+    areas.push(data[i].document_id);
+  }
+  return areas.join(',');
+};
+
+
+/**
+ * @return {string}
+ * @private
+ */
+app.LoadPreferencesController.prototype.getActivities_ = function() {
+  return this.preferences_.activities.join(',');
+};
+
+app.module.controller('AppLoadPreferencesController', app.LoadPreferencesController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -41,6 +41,7 @@ goog.require('app.gpxUploadDirective');
 goog.require('app.imageUploaderDirective');
 goog.require('app.langDirective');
 goog.require('app.loadingDirective');
+goog.require('app.loadPreferencesDirective');
 goog.require('app.mailinglistsDirective');
 goog.require('app.mapDirective');
 goog.require('app.mapSearchDirective');

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -274,6 +274,8 @@ app.MapController = function($scope, mapFeatureCollection, ngeoLocation,
 
     this.scope_.$root.$on('searchFeaturesChange',
         this.handleSearchChange_.bind(this));
+    this.scope_.$root.$on('searchFilterClear',
+        this.handleSearchClear_.bind(this));
     this.scope_.$root.$on('cardEnter', function(event, id) {
       this.toggleFeatureHighlight_(id, true);
     }.bind(this));
@@ -739,6 +741,24 @@ app.MapController.prototype.handleSearchChange_ = function(event,
   this.ignoreExtentChange_ = recenter;
   recenter = recenter || !this.enableMapFilter;
   this.showFeatures_(features, recenter);
+};
+
+
+/**
+ * @param {Object} event
+ * @private
+ */
+app.MapController.prototype.handleSearchClear_ = function(event) {
+  if (!this.location_.hasFragmentParam('bbox')) {
+    var mapSize = this.map.getSize();
+    if (mapSize) {
+      var extent = this.view_.calculateExtent(mapSize);
+      extent = extent.map(Math.floor);
+      this.location_.updateFragmentParams({
+        'bbox': extent.join(',')
+      });
+    }
+  }
 };
 
 

--- a/c2corg_ui/static/js/search/advancedsearch.js
+++ b/c2corg_ui/static/js/search/advancedsearch.js
@@ -38,13 +38,12 @@ app.module.directive('appAdvancedSearch', app.advancedSearchDirective);
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {angular.$q} $q Angular promises/deferred service.
- * @param {debounce} debounce debounce.
  * @constructor
  * @struct
  * @ngInject
  */
 app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
-    gettextCatalog, $q, debounce) {
+    gettextCatalog, $q) {
 
   /**
    * @type {angular.Scope}
@@ -130,8 +129,10 @@ app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
     app.utils.detectDocumentIdFilter(this.location_);
 
   // Refresh the results when pagination or criterias have changed:
-  this.scope_.$root.$on(
-      'searchFilterChange', debounce(this.getResults_.bind(this), 700));
+  this.scope_.$root.$on('searchFilterChange', function(event, loadPrefs) {
+    this.recenter_ = loadPrefs || this.recenter_;
+    this.getResults_();
+  }.bind(this));
 
   // Get the initial results when loading the page unless a map is used.
   // In that case wait to get the map extent before triggering the request.

--- a/c2corg_ui/static/js/search/outingfilters.js
+++ b/c2corg_ui/static/js/search/outingfilters.js
@@ -54,7 +54,7 @@ goog.inherits(app.OutingFiltersController, app.SearchFiltersController);
  * @override
  * @public
  */
-app.OutingFiltersController.prototype.getFilterFromPermalink = function(key) {
+app.OutingFiltersController.prototype.setFilterFromPermalink = function(key) {
   if (key in this.config && this.config[key]['type'] === 'date') {
     var val = this.location.getFragmentParam(key);
     if (val === '') {
@@ -67,7 +67,7 @@ app.OutingFiltersController.prototype.getFilterFromPermalink = function(key) {
     this.filters[key] = dates;
     this.updateMinMaxDates_();
   } else {
-    goog.base(this, 'getFilterFromPermalink', key);
+    goog.base(this, 'setFilterFromPermalink', key);
   }
 };
 

--- a/c2corg_ui/static/js/search/xreportfilters.js
+++ b/c2corg_ui/static/js/search/xreportfilters.js
@@ -54,7 +54,7 @@ goog.inherits(app.XreportFiltersController, app.SearchFiltersController);
  * @override
  * @public
  */
-app.XreportFiltersController.prototype.getFilterFromPermalink = function(key) {
+app.XreportFiltersController.prototype.setFilterFromPermalink = function(key) {
   if (key in this.config && this.config[key]['type'] === 'date') {
     var val = this.location.getFragmentParam(key);
     if (val === '') {
@@ -67,7 +67,7 @@ app.XreportFiltersController.prototype.getFilterFromPermalink = function(key) {
     this.filters[key] = dates;
     this.updateMinMaxDates_();
   } else {
-    goog.base(this, 'getFilterFromPermalink', key);
+    goog.base(this, 'setFilterFromPermalink', key);
   }
 };
 

--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -29,6 +29,14 @@
     </div>
   </article>
 
+  <article class="feed-list-item" ng-if="userCtrl.auth.isAuthenticated() && !feedCtrl.userId">
+    <div class="timeline-bullet icon-outings" uib-tooltip="{{'outing'| translate}}" tooltip-placement="left"></div>
+    <div class="list-item vertical-align">
+      <button class="green-btn btn" app-loading app-load-preferences="outings" app-load-preferences-url="/outings"
+              translate>See outings according to my preferences</button>
+    </div>
+  </article>
+
   <article class="feed-list-item" ng-repeat="doc in feedCtrl.documents track by doc.id"
            ng-init="type = feedCtrl.getDocumentType(doc.document.type);">
 

--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -13,10 +13,16 @@
      infinite-scroll-distance="0.7"
      infinite-scroll-disabled="feedCtrl.busy || feedCtrl.error || feedCtrl.feedEnd || feedCtrl.noFeed">
 
-  <article class="feed-list-item" protected-url-btn url="/outings/add" ng-if="!feedCtrl.userId">
+  <article class="feed-list-item" ng-if="!feedCtrl.userId">
     <div class="timeline-bullet icon-outings" uib-tooltip="{{'outing'| translate}}" tooltip-placement="left"></div>
     <div class="list-item vertical-align">
-      <button class="orange-btn btn" translate>add an outing</button>
+      <button class="orange-btn btn" protected-url-btn url="/outings/add" translate>add an outing</button>
+      <button class="green-btn btn" ng-if="userCtrl.auth.isAuthenticated()"
+              app-loading app-load-preferences="outings" app-load-preferences-url="/outings"
+              translate>See outings according to my preferences</button>
+      <a href="/outings" ng-if="!userCtrl.auth.isAuthenticated()">
+        <button class="green-btn btn" translate>See outings</button>
+      </a>
     </div>
   </article>
 
@@ -26,14 +32,6 @@
       <a ng-href="/outings#u={{feedCtrl.userId}}">
         <button class="orange-btn btn" translate>Show this user's outings</button>
       </a>
-    </div>
-  </article>
-
-  <article class="feed-list-item" ng-if="userCtrl.auth.isAuthenticated() && !feedCtrl.userId">
-    <div class="timeline-bullet icon-outings" uib-tooltip="{{'outing'| translate}}" tooltip-placement="left"></div>
-    <div class="list-item vertical-align">
-      <button class="green-btn btn" app-loading app-load-preferences="outings" app-load-preferences-url="/outings"
-              translate>See outings according to my preferences</button>
     </div>
   </article>
 

--- a/c2corg_ui/templates/article/filters.html
+++ b/c2corg_ui/templates/article/filters.html
@@ -45,11 +45,11 @@ activities, article_categories, article_types
         ${add_multiselect('l', default_langs)}
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('articles')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('articles')}
 
   </div>
 </form>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -109,7 +109,6 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_path('%s/photoswipe/dist/photoswipe-ui-default.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-slug/angular-slug.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/slug/slug.js' % node_modules_path)}"></script>
-    <script src="${request.static_path('%s/angular-debounce/angular-debounce.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/file-saver/FileSaver.js' % node_modules_path)}"></script>
     <script src="${request.route_path('deps.js')}"></script>
     <script src="${request.static_path('c2corg_ui:static/js/main.js')}"></script>

--- a/c2corg_ui/templates/book/filters.html
+++ b/c2corg_ui/templates/book/filters.html
@@ -54,11 +54,11 @@ activities, book_types
         ${add_multiselect('l', default_langs)}
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('books')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('books')}
 
   </div>
 </form>

--- a/c2corg_ui/templates/helpers/filters.html
+++ b/c2corg_ui/templates/helpers/filters.html
@@ -15,7 +15,7 @@
   </ul>
 </%def>
 
-<%def name="show_results_buttons()">\
+<%def name="show_results_buttons(module=None)">\
   <div class="filters-bottom-buttons">
     <button class="btn search-filters-btn orange-btn" data-toggle="collapse"
             data-target="#moreFilters" aria-expanded="false">
@@ -23,14 +23,22 @@
     </button>
     <button class="btn blue-btn search-filters-btn" ng-click="filtersCtrl.clear()"
             ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
+    % if module:
+      <button class="btn green-btn search-filters-btn" app-loading app-load-preferences="${module}"
+              ng-show="userCtrl.auth.isAuthenticated()" translate>Load my preferences</button>
+    % endif
   </div>
 </%def>
 
-<%def name="show_filters_buttons()">\
+<%def name="show_filters_buttons(module=None)">\
   <div class="more-filters-btn-container">
     <button class="btn orange-btn more-filters-btn" data-toggle="collapse" data-target="#moreFilters"
       aria-expanded="false" aria-controls="moreFilters" translate>All filters</button>
     <button class="btn blue-btn more-filters-btn" ng-click="filtersCtrl.clear()" ng-cloak
             ng-show="filtersCtrl.filtersNb > 0"><span translate>Clear filters</span> ({{filtersCtrl.filtersNb}})</button>
+    % if module:
+      <button class="btn green-btn more-filters-btn" app-loading app-load-preferences="${module}"
+              ng-show="userCtrl.auth.isAuthenticated()" translate>Load my preferences</button>
+    % endif
   </div>
 </%def>

--- a/c2corg_ui/templates/image/filters.html
+++ b/c2corg_ui/templates/image/filters.html
@@ -46,11 +46,11 @@ from c2corg_common.attributes import default_langs, activities, image_categories
         </div>
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('images')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('images')}
 
   </div>
 </form>

--- a/c2corg_ui/templates/outing/filters.html
+++ b/c2corg_ui/templates/outing/filters.html
@@ -137,11 +137,11 @@ from c2corg_common.attributes import default_langs, quality_types, activities, f
 
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('outings')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('outings')}
 
   </div>
 </form>

--- a/c2corg_ui/templates/route/filters.html
+++ b/c2corg_ui/templates/route/filters.html
@@ -311,11 +311,11 @@ activities = [activity for activity in activities if activity != 'paragliding']
           values-list="['${"','".join(quality_types) |n}']"></app-slider>
       </div>
         
-      ${show_results_buttons()}
+      ${show_results_buttons('routes')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('routes')}
 
   </div>
 

--- a/c2corg_ui/templates/waypoint/filters.html
+++ b/c2corg_ui/templates/waypoint/filters.html
@@ -193,11 +193,11 @@ from c2corg_common.attributes import default_langs, waypoint_types, orientation_
           values-list="['${"','".join(quality_types) |n}']"></app-slider>
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('waypoints')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('waypoints')}
 
   </div>
 </form>

--- a/c2corg_ui/templates/xreport/filters.html
+++ b/c2corg_ui/templates/xreport/filters.html
@@ -105,11 +105,11 @@ activities, event_types, severities, avalanche_levels, avalanche_slopes
 
       </div>
 
-      ${show_results_buttons()}
+      ${show_results_buttons('xreports')}
 
     </div>
 
-    ${show_filters_buttons()}
+    ${show_filters_buttons('xreports')}
 
   </div>
 </form>

--- a/less/feed.less
+++ b/less/feed.less
@@ -6,6 +6,10 @@
   height: 100%;
   background-color: rgba(229, 229, 229, 0.3);
 
+  .btn {
+    white-space: normal;
+  }
+
   .feed-title {
     color: lightslategrey;
     padding-left: @margin-desktop - 1;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "angular": "1.5.8",
     "angular-cookies": "1.5.8",
-    "angular-debounce": "git://github.com/shahata/angular-debounce#0c67aca",
     "angular-gettext": "2.3.4",
     "angular-gettext-tools": "2.2.3",
     "angular-messages": "1.5.8",


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1342

Still some testing and fixes to do:
* [x] make sure the map is recentered on areas when loading areas prefs
* [x] make sure the activities selector is updated and consistent with the loaded prefs
* [x] when filters are cancelled (removing area prefs), make sure the map extent is reset, or at least consistent with the returned results

As for now I have not implemented any storage of the preferences as considered in https://github.com/c2corg/v6_ui/issues/1342#issuecomment-280308466 => prefs are loaded on demand when pushing the "apply my prefs" buttons, in my instance the delay is acceptable. Don't know yet if it could be OK in demo/prod as well.

![capture du 2017-02-22 18-20-16](https://cloud.githubusercontent.com/assets/1192331/23223577/aec87600-f92b-11e6-9a14-8b51d9b04c7c.png)
![capture du 2017-02-22 18-20-42](https://cloud.githubusercontent.com/assets/1192331/23223576/aec7b54e-f92b-11e6-8e45-488142949e6c.png)
