### PR TITLE
Handle vimeo, youtube and dailymotion videos in topoguide documents

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -4,6 +4,7 @@ import html
 
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
 from c2corg_ui.format.img import C2CImageExtension
+from c2corg_ui.format.video import C2CVideoExtension
 from c2corg_ui.format.important import C2CImportantExtension
 from c2corg_ui.format.warning import C2CWarningExtension
 from markdown.extensions.nl2br import Nl2BrExtension
@@ -28,6 +29,7 @@ def _get_markdown_parser():
         extensions = [
             C2CWikiLinkExtension(),
             C2CImageExtension(api_url=_parsers_settings['api_url']),
+            C2CVideoExtension(),
             C2CImportantExtension(),
             C2CWarningExtension(),
             Nl2BrExtension(),

--- a/c2corg_ui/format/video.py
+++ b/c2corg_ui/format/video.py
@@ -1,0 +1,77 @@
+'''
+c2corg video Extension for Python-Markdown
+==============================================
+
+Converts video tags to advanced HTML video tags.
+'''
+
+from markdown.extensions import Extension
+from markdown.inlinepatterns import Pattern
+from markdown.util import etree
+import re
+
+VIDEO_RE = r'\[video\](.*?)\[/video\]'
+
+
+class C2CVideoExtension(Extension):
+
+    def extendMarkdown(self, md, md_globals):  # noqa
+        self.md = md
+
+        pattern = C2CVideo(VIDEO_RE)
+        pattern.md = md
+        # append to end of inline patterns
+        md.inlinePatterns.add('c2cvideo', pattern, "<not_strong")
+
+
+class C2CVideo(Pattern):
+
+    def handleMatch(self, m):  # noqa
+        link = m.group(2).strip()
+
+        # youtube http://www.youtube.com/watch?v=3xMk3RNSbcc(&something)
+        match = re.search(r"https?:\/\/(?:www\.)?youtube\.com/watch\?(?:[=&\w]+&)?v=([-\w]+)(?:&.+)?(?:\#.*)?", link)  # noqa
+        if match:
+            return self._embed('//www.youtube.com/embed/' + match.group(1))
+
+        # youtube short links http://youtu.be/3xMk3RNSbcc
+        match = re.search(r'https?:\/\/(?:www\.)?youtu\.be/([-\w]+)(?:\#.*)?', link)  # noqa
+        if match:
+            return self._embed('//player.vimeo.com/video/' + match.group(1) +
+                               '?title=0&amp;byline=0&amp;portrait=0&amp;color=ff9933')  # noqa
+
+        # dailymotion http://www.dailymotion.com/video/x28z33_chinese-man
+        match = re.search(r"https?://www\.dailymotion\.com/video/([\da-zA-Z]+)_[-&;\w]+(?:\#.*)?", link)  # noqa
+        if match:
+            return self._embed('//www.dailymotion.com/embed/video/' +
+                               match.group(1) +
+                               '?theme=none&amp;wmode=transparent')
+
+        # dailymotion short links http://dai.ly/x5b5r49
+        match = re.search(r"https?://www\.dai\.ly/([\da-zA-Z]+)", link)
+        if match:
+            return self._embed('//www.dailymotion.com/embed/video/' +
+                               match.group(1) +
+                               '?theme=none&amp;wmode=transparent')
+
+        # vimeo http://vimeo.com/8654134
+        match = re.search(r'https?://(?:www\.)?vimeo\.com/(\d+)(?:\#.*)?',
+                          link)
+        if match:
+            return self._embed('//player.vimeo.com/video/' + match.group(1) +
+                               '?title=0&amp;byline=0&amp;portrait=0&amp;color=ff9933')  # noqa
+
+        return self.unescape(m.group(0))
+
+    def _embed(self, link):
+        iframe = etree.Element('iframe')
+        iframe.set('class', 'embed-reponsive-item')
+        iframe.set('src', link)
+        embed = etree.Element('div')
+        embed.set('class', 'embed-responsive embed-responsive-4by3 video')
+        embed.append(iframe)
+        return embed
+
+
+def makeExtension(*args, **kwargs):  # noqa
+    return C2CVideoExtension(*args, **kwargs)

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -844,6 +844,10 @@ app-add-association {
       color: white;
     }
   }
+  .embed-responsive-4by3.video {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 }
 
 .show-phone.elevation {

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -847,6 +847,11 @@ app-add-association {
   .embed-responsive-4by3.video {
     margin-top: 5px;
     margin-bottom: 5px;
+
+    @media (min-width: @phone-max) {
+      width: 560px;
+      padding-bottom: 420px;
+    }
   }
 }
 


### PR DESCRIPTION
Pretty similar (but simplified, too) to what was done previously. Accepts [video] http://xxx [/video] URLs.

(for reference: https://github.com/c2corg/camptocamp.org/blob/72e777075f2e6260b1d2ef563ab0f90c383038ba/web/forums/include/parser.php)

Is there a nicer way to iterate over the regex comparisons?