### PR TITLE
Form feedback rework

### DIFF
--- a/c2corg_ui/templates/area/edit.html
+++ b/c2corg_ui/templates/area/edit.html
@@ -38,20 +38,26 @@ from c2corg_common.attributes import default_langs, area_types
           <div class="content">
 
             ## TITLE
-            <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>title</span> *</label>
+            <div id="title-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>title</span> *</label>
               <input type="text" name="title" ng-model="area.locales[0].title" ng-minlength="3" class="form-control" required />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-                <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched && editForm.title.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if area_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${area_lang}')}}">
               % else:
@@ -59,17 +65,23 @@ from c2corg_common.attributes import default_langs, area_types
               % endif
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="area.locales[0].lang"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
             <div class="form-group half half-group">
-
-              <div ng-class="{ 'has-success': area.area_type}" ng-init="area_types = ${area_types}">
-                <label><span translate>area_type</span> *</label>
-                <select class="form-control" ng-model="area.area_type" ng-options="type as mainCtrl.translate(type) for type in area_types"><option value=""></option></select>
-                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="area.area_type"></span>
+              <div ng-class="{ 'has-feedback': editForm.area_type.$touched,
+                               'has-error': editForm.area_type.$touched && editForm.area_type.$invalid,
+                               'has-success': editForm.area_type.$valid}"
+                   ng-init="area_types = ${area_types}">
+                <label ng-class="{ 'control-label': editForm.area_type.$touched && editForm.area_type.$invalid }"><span translate>area_type</span> *</label>
+                <select name="area_type" class="form-control" ng-model="area.area_type" ng-options="type as mainCtrl.translate(type) for type in area_types" required><option value=""></option></select>
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.area_type.$valid"></span>
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.area_type.$invalid && editForm.area_type.$touched"></span>
+                <div class="help-block" ng-messages="editForm.area_type.$error" ng-if="editForm.area_type.$touched && editForm.area_type.$invalid">
+                  <p ng-message="required" translate>This field is required.</p>
+                </div>
               </div>
 
             </div>
@@ -110,4 +122,3 @@ from c2corg_common.attributes import default_langs, area_types
   ${show_save_confirmation_modal(updating_doc)}
   ${show_preview_container()}
 </section>
-

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -35,35 +35,43 @@ from c2corg_common.attributes import default_langs, activities, article_categori
           <div class="content">
 
             ## TITLE
-            <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>title</span> *</label>
+            <div id="title-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.lang.$invalid }"><span translate>title</span> *</label>
               <input type="text" name="title" ng-model="article.locales[0].title" ng-minlength="3" class="form-control" required />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-                <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched && editForm.title.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if article_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${article_lang}')}}">
               % else:
               <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="article.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="article.locales[0].lang"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
             ## ACTIVITIES
             <div class="form-group data full" id="route-activities" ng-init="activities = ${activities}"
-                 ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid, 'has-success': editForm.activities.$valid }">
+                 ng-class="{ 'has-feedback': editForm.activites.$touched,
+                             'has-error': editForm.activities.$touched && editForm.activities.$invalid,
+                             'has-success': editForm.activities.$valid }">
               <label><span translate>activities</span> *</label>
               <div class="route-activities">
                 <div ng-repeat="activity in activities" class="activity">
@@ -78,23 +86,31 @@ from c2corg_common.attributes import default_langs, activities, article_categori
             </div>
 
             <div class="form-group half half-group">
-              <div ng-class="{ 'has-success': article.article_type}" ng-init="article_types = ${article_types}">
+              <div ng-class="{ 'has-feedback': editForm.article_type.$touched,
+                               'has-error': editForm.article_type.$touched && editForm.article_type.$invalid,
+                               'has-success': editForm.article_type.$valid}" ng-init="article_types = ${article_types}">
                 <label><span translate>article_type</span> *</label>
                 % if updating_doc:
-                  <select ng-if="userCtrl.auth.isModerator()" class="form-control" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types" ><option value=""></option></select>
+                  <select ng-if="userCtrl.auth.isModerator()" class="form-control"
+                          name="article_type" ng-model="article.article_type"
+                          ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option></select>
                   <select ng-if="userCtrl.auth.isModerator() == false && article.article_type =='collab'"
-                          class="form-control" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types | filter: 'collab'" ><option value=""></option>
+                          name="article_type" class="form-control" ng-model="article.article_type"
+                          ng-options="type as mainCtrl.translate(type) for type in article_types | filter: 'collab'" required><option value=""></option>
                   </select>
                   <select ng-if="userCtrl.auth.isModerator() == false && article.article_type =='personal'"
-                          class="form-control" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types" ><option value=""></option>
+                          name="article_type" class="form-control" ng-model="article.article_type"
+                          ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option>
                   </select>
                 % else:
-                  <select class="form-control" ng-model="article.article_type" ng-options="type as mainCtrl.translate(type) for type in article_types" ><option value=""></option></select>
+                  <select class="form-control" ng-model="article.article_type"
+                          name="article_type" ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option></select>
                 % endif
-                  <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="article.article_type"></span>
+                  <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.article_type.$valid"></span>
+                  <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.article_type.$touched && editForm.article_type.$invalid"></span>
+                  <div class="help-block" ng-messages="editForm.article_type.$error" ng-if="editForm.article_type.$touched && editForm.article_type.$invalid">
+                    <p ng-message="required" translate>This field is required.</p>
+                  </div>
               </div>
             </div>
 

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -12,17 +12,21 @@ from pyramid.settings import asbool
       <h1 translate>Login</h1>
 
       <form name="loginForm" novalidate ng-submit="authCtrl.login()">
-        <div id="login-username-group" class="form-group" ng-class="{ 'has-error': loginForm.username.$touched && loginForm.username.$invalid }">
-          <label translate>Username</label>
+        <div id="login-username-group" class="form-group"
+             ng-class="{ 'has-feedback has-error': loginForm.username.$touched && loginForm.username.$invalid }">
+          <label ng-class="{ 'control-label': loginForm.username.$touched && loginForm.username.$invalid }" translate>Username</label>
           <input type="text" name="username" ng-model="login.username" class="form-control" required />
-          <div class="help-block" ng-messages="loginForm.username.$error" ng-if="loginForm.username.$touched">
+          <span ng-show="loginForm.username.$touched && loginForm.username.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="loginForm.username.$error" ng-if="loginForm.username.$touched && loginForm.username.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
-        <div id="login-password-group" class="form-group" ng-class="{ 'has-error': loginForm.password.$touched && loginForm.password.$invalid }">
-          <label translate>Password</label>
+        <div id="login-password-group" class="form-group"
+             ng-class="{ 'has-feedback has-error': loginForm.password.$touched && loginForm.password.$invalid }">
+          <label ng-class="{ 'control-label': loginForm.password.$touched && loginForm.password.$invalid }" translate>Password</label>
           <input type="password" name="password" ng-model="login.password" class="form-control" required />
-          <div class="help-block" ng-messages="loginForm.password.$error" ng-if="loginForm.password.$touched">
+          <span ng-show="loginForm.password.$touched && loginForm.password.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="loginForm.password.$error" ng-if="loginForm.password.$touched && loginForm.password.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
@@ -33,7 +37,7 @@ from pyramid.settings import asbool
         </div>
         <p>
           <button type="submit" class="btn blue-btn" ng-disabled="loginForm.$invalid" translate>Login</button>
-          <button type="button" class="btn gray-btn" 
+          <button type="button" class="btn gray-btn"
                   ng-click="authCtrl.uiStates.showRequestChangePasswordForm = true;
                                      authCtrl.uiStates.showRegisterForm = false;
                                      authCtrl.uiStates.showChangePasswordForm = false;
@@ -43,7 +47,7 @@ from pyramid.settings import asbool
       </form>
 
       <p ng-hide="authCtrl.uiStates.showRegisterForm">
-        <button type="button" class="btn orange-btn" 
+        <button type="button" class="btn orange-btn"
                 ng-click="authCtrl.uiStates.showRegisterForm = true;
                                    authCtrl.uiStates.showLoginForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
@@ -57,41 +61,67 @@ from pyramid.settings import asbool
       <h1 translate>Register</h1>
 
       <form name="registerForm" novalidate ng-submit="authCtrl.register()">
-        <div id="register-name-group" class="form-group" ng-class="{ 'has-error': registerForm.name.$touched && registerForm.name.$invalid }">
-          <label translate>Fullname</label>
+        <div id="register-name-group" class="form-group"
+             ng-class="{ 'has-feedback': registerForm.name.$touched,
+                         'has-error': registerForm.name.$touched && registerForm.name.$invalid,
+                         'has-success': registerForm.name.$valid }">
+          <label ng-class="{ 'control-label': registerForm.name.$touched && registerForm.name.$invalid }" translate>Fullname</label>
           <input type="text" name="name" ng-model="register.name" class="form-control" required />
-          <div class="help-block" ng-messages="registerForm.name.$error" ng-if="registerForm.name.$touched">
+          <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="registerForm.name.$valid"></span>
+          <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="registerForm.name.$touched && registerForm.name.$invalid"></span>
+          <div class="help-block" ng-messages="registerForm.name.$error" ng-if="registerForm.name.$touched && registerForm.name.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
-        <div id="register-username-group" class="form-group" ng-class="{ 'has-error': registerForm.username.$touched && registerForm.username.$invalid }">
-          <label translate>Username</label>
+        <div id="register-username-group" class="form-group"
+             ng-class="{ 'has-feedback': registerForm.username.$touched,
+                         'has-error': registerForm.username.$touched && registerForm.username.$invalid,
+                         'has-success': registerForm.username.$valid }">
+          <label ng-class="{ 'control-label': registerForm.username.$touched && registerForm.username.$invalid }" translate>Username</label>
           <input type="text" name="username" ng-model="register.username" class="form-control" required />
-          <div class="help-block" ng-messages="registerForm.username.$error" ng-if="registerForm.username.$touched">
+          <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="registerForm.username.$valid"></span>
+          <span ng-show="registerForm.username.$touched && registerForm.username.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="registerForm.username.$error" ng-if="registerForm.username.$touched && registerForm.username.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
-        <div id="register-forum_username-group" class="form-group" ng-class="{ 'has-error': registerForm.forum_username.$touched && registerForm.forum_username.$invalid }">
-          <label translate>Forum username</label>
+        <div id="register-forum_username-group" class="form-group"
+             ng-class="{ 'has-feedback': registerForm.forum_username.$touched,
+                         'has-error': registerForm.forum_username.$touched && registerForm.forum_username.$invalid,
+                         'has-success': registerForm.forum_username.$valid }">
+          <label ng-class="{ 'control-label': registerForm.forum_username.$touched && registerForm.forum_username.$invalid }" translate>Forum username</label>
           ## http://stackoverflow.com/questions/1538512/how-can-i-invert-a-regular-expression-in-javascript: opposite test of /[^a-zA-Z0-9]/
-          <input type="text" name="forum_username" ng-minlength="3" maxlength="25" ng-pattern="/^[\w.-]+$/" ng-model="register.forum_username" class="form-control" required />
-          <div class="help-block" ng-messages="registerForm.forum_username.$error" ng-if="registerForm.forum_username.$touched">
+          <input type="text" name="forum_username" ng-minlength="3" ng-maxlength="25" ng-pattern="/^[\w.-]+$/" ng-model="register.forum_username" class="form-control" required />
+          <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="registerForm.forum_username.$valid"></span>
+          <span ng-show="registerForm.forum_username.$touched && registerForm.forum_username.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="registerForm.forum_username.$error" ng-if="registerForm.forum_username.$touched && registerForm.forum_username.$invalid">
             <p ng-message="required" translate>This field is required.</p>
             <p ng-message="pattern" translate>Only letters, numbers and characters ".-_" are allowed.</p>
             <p ng-message="minlength" translate>This field must be at least 3 characters.</p>
+            <p ng-message="maxlength" translate>This field must be shorter than 25 characters.</p>
           </div>
         </div>
-        <div id="register-password-group" class="form-group" ng-class="{ 'has-error': registerForm.password.$touched && registerForm.password.$invalid }">
-          <label translate>Password</label>
+        <div id="register-password-group" class="form-group"
+             ng-class="{ 'has-feedback': registerForm.password.$touched,
+                         'has-error': registerForm.password.$touched && registerForm.password.$invalid,
+                         'has-success': registerForm.password.$valid }">
+          <label ng-class="{ 'control-label': registerForm.password.$touched && registerForm.title.$invalid }" translate>Password</label>
           <input type="password" name="password" ng-model="register.password" class="form-control" required />
-          <div class="help-block" ng-messages="registerForm.password.$error" ng-if="registerForm.password.$touched">
+          <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="registerForm.password.$valid"></span>
+          <span ng-show="registerForm.password.$touched && registerForm.password.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="registerForm.password.$error" ng-if="registerForm.password.$touched && registerForm.password.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
-        <div id="register-email-group" class="form-group" ng-class="{ 'has-error': registerForm.email.$touched && registerForm.email.$invalid }">
-          <label translate>Email</label>
+        <div id="register-email-group" class="form-group"
+             ng-class="{ 'has-feedback': registerForm.email.$touched,
+                         'has-error': registerForm.email.$touched && registerForm.email.$invalid,
+                         'has-success': registerForm.email.$valid }">
+          <label ng-class="{ 'control-label': registerForm.email.$touched && registerForm.email.$invalid }" translate>Email</label>
           <input type="email" name="email" ng-model="register.email" class="form-control" required />
-          <div class="help-block" ng-messages="registerForm.email.$error" ng-if="registerForm.email.$touched">
+          <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="registerForm.email.$valid"></span>
+          <span ng-show="registerForm.email.$touched && registerForm.email.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="registerForm.email.$error" ng-if="registerForm.email.$touched && registerForm.email.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
@@ -105,7 +135,7 @@ from pyramid.settings import asbool
         </p>
       </form>
       <p ng-hide="!authCtrl.uiStates.showRegisterForm">
-        <button type="button" class="btn orange-btn" 
+        <button type="button" class="btn orange-btn"
                 ng-click="authCtrl.uiStates.showLoginForm = true;
                                    authCtrl.uiStates.showRegisterForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
@@ -119,10 +149,12 @@ from pyramid.settings import asbool
       <h1 translate>Reset password</h1>
 
       <form name="requestChangePasswordForm" novalidate ng-submit="authCtrl.requestPasswordChange()">
-        <div id="register-password-group" class="form-group" ng-class="{ 'has-error': requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid }">
-          <label translate>Email</label>
+        <div id="register-password-group" class="form-group"
+             ng-class="{ 'has-feedback has-error': requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid }">
+          <label ng-class="{ 'control-label': requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid }" translate>Email</label>
           <input type="email" name="email" ng-model="requestChangePassword.email" class="form-control" required />
-          <div class="help-block" ng-messages="requestChangePasswordForm.email.$error" ng-if="requestChangePasswordForm.email.$touched">
+          <span ng-show="requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="requestChangePasswordForm.email.$error" ng-if="requestChangePasswordForm.email.$touched && requestChangePasswordForm.email.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>
@@ -131,14 +163,14 @@ from pyramid.settings import asbool
         </p>
       </form>
       <p>
-        <button type="button" class="btn orange-btn" 
+        <button type="button" class="btn orange-btn"
                 ng-click="authCtrl.uiStates.showLoginForm = true;
                                    authCtrl.uiStates.showRegisterForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
                                    authCtrl.uiStates.showRequestChangePasswordForm = false;" translate>Have an account?
         </button>
-        
-        <button type="button" class="btn orange-btn" 
+
+        <button type="button" class="btn orange-btn"
                 ng-click="authCtrl.uiStates.showRegisterForm = true;
                                    authCtrl.uiStates.showLoginForm = false;
                                    authCtrl.uiStates.showChangePasswordForm = false;
@@ -152,10 +184,12 @@ from pyramid.settings import asbool
       <h1 translate>Change password</h1>
 
       <form name="resetPasswordForm" novalidate ng-submit="authCtrl.validateNewPassword()">
-        <div id="change-password-group" class="form-group" ng-class="{ 'has-error': changePasswordForm.password.$touched && changePasswordForm.password.$invalid }">
-          <label translate>New password</label>
+        <div id="change-password-group" class="form-group"
+             ng-class="{ 'has-feedback has-error': changePasswordForm.password.$touched && changePasswordForm.password.$invalid }">
+          <label ng-class="{ 'control-label': changePasswordForm.password.$touched && changePasswordForm.password.$invalid }" translate>New password</label>
           <input type="password" name="password" ng-model="changePassword.password" class="form-control" required />
-          <div class="help-block" ng-messages="changePasswordForm.password.$error" ng-if="changePasswordForm.password.$touched">
+          <span ng-show="changePasswordForm.password.$touched && changePasswordForm.password.$invalid" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></span>
+          <div class="help-block" ng-messages="changePasswordForm.password.$error" ng-if="changePasswordForm.password.$touched && changePasswordForm.password.$invalid">
             <p ng-message="required" translate>This field is required.</p>
           </div>
         </div>

--- a/c2corg_ui/templates/book/edit.html
+++ b/c2corg_ui/templates/book/edit.html
@@ -34,35 +34,43 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
           <div class="content">
 
             ## TITLE
-            <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>title</span> *</label>
+            <div id="title-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>title</span> *</label>
               <input type="text" name="title" ng-model="book.locales[0].title" ng-minlength="3" class="form-control" required />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-                <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched && editForm.title.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if book_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${book_lang}')}}">
               % else:
               <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="book.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="book.locales[0].lang"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
             ## ACTIVITIES
             <div class="form-group data full" id="route-activities" ng-init="activities = ${activities}"
-                 ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid, 'has-success': editForm.activities.$valid }">
+                 ng-class="{ 'has-feedback': editForm.activities.$touched,
+                             'has-error': editForm.activities.$touched && editForm.activities.$invalid,
+                             'has-success': editForm.activities.$valid }">
               <label><span translate>activities</span> *</label>
               <div class="route-activities">
                 <div ng-repeat="activity in activities" class="activity">
@@ -113,40 +121,54 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
             ## publication_date
             <div class="form-group half half-group">
               <label translate>publication_date</label>
-              <input type="text" name="publication_date" minlength="0" ng-model="book.publication_date" class="form-control" />
+              <input type="text" name="publication_date"ng-model="book.publication_date" class="form-control" />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="book.publication_date"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.publication_date.$invalid && editForm.publication_date.$touched"></span>
             </div>
 
             ## nb_pages
-            <div class="data half half-group form-group" ng-class="{ 'has-error': editForm.nb_pages.$touched && editForm.nb_pages.$invalid,'has-success': book.nb_pages }">
+            <div class="data half half-group form-group"
+                 ng-class="{ 'has-feedback': editForm.nb_pages.$touched,
+                             'has-error': editForm.nb_pages.$touched && editForm.nb_pages.$invalid,
+                             'has-success': editForm.nb_pages.$valid && book.nb_pages}">
               <label translate>nb_pages</label>
               <div class="input-group">
-                <input type="number" min="0" name="height_diff_access" ng-model="book.nb_pages" class="form-control" />
+                <input type="number" min="0" max="9999" name="nb_pages" ng-model="book.nb_pages" class="form-control" />
                 <span class="input-group-addon">#</span>
               </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="book.nb_pages"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.nb_pages.$valid && book.nb_pages"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.nb_pages.$invalid && editForm.nb_pages.$touched"></span>
+              <div class="help-block" ng-messages="editForm.nb_pages.$error" ng-if="editForm.nb_pages.$touched && editForm.nb_pages.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
+              </div>
             </div>
 
             ## isbn
-            <div class="form-group half half-group">
+            <div class="form-group half half-group"
+                 ng-class="{ 'has-feedback': editForm.isbn.$touched,
+                             'has-error': editForm.isbn.$touched && editForm.isbn.$invalid,
+                             'has-success': editForm.isbn.$valid && book.isbn }">
               <label translate>isbn</label>
               <input type="text" ng-minlength="9" ng-maxlength="17" name="isbn" ng-model="book.isbn" class="form-control" />
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="book.isbn"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.isbn.$valid && book.isbn"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.isbn.$invalid && editForm.isbn.$touched"></span>
-              <div class="help-block" ng-messages="editForm.isbn.$error">
-                <p ng-message="text" class="label label-danger" style="{{ (editForm.isbn.$invalid && editForm.isbn.$touched) ? 'display:inline' : '' }}" translate>This field must be a valid number.</p>
+              <div class="help-block" ng-messages="editForm.isbn.$error" ng-if="editForm.isbn.$touched && editForm.isbn.$invalid">
+                <p ng-message="minlength" translate>This field must be a valid ISBN.</p>
+                <p ng-message="maxlength" translate>This field must be a valid ISBN.</p>
               </div>
             </div>
 
             ## url
-            <div class="form-group half half-group">
+            <div class="form-group half half-group"
+                 ng-class="{ 'has-feedback': editForm.url.$touched,
+                             'has-error': editForm.url.$touched && editForm.url.$invalid,
+                             'has-success': editForm.url.$valid && book.url}">
               <label translate>url</label>
               <input type="url" name="url" ng-model="book.url" ng-minlength="6" class="form-control" />
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="book.url"></span>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.url.$valid && book.url"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.url.$invalid && editForm.url.$touched"></span>
-              <div class="help-block" ng-messages="editForm.isbn.$error">
-                <p ng-message="text" class="label label-danger" style="{{ (editForm.url.$invalid && editForm.url.$touched) ? 'display:inline' : '' }}" translate>This field must be a valid url.</p>
+              <div class="help-block" ng-messages="editForm.url.$error" ng-if="editForm.url.$touched && editForm.url.$invalid">
+                <p ng-message="url" translate>This field must be a valid url.</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -60,8 +60,11 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if image_lang:
               <input disabled class="form-control" value="{{mainCtrl.translate('${image_lang}')}}">
               % else:
@@ -69,8 +72,8 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
               % endif
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.locales[0].lang"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
@@ -165,50 +168,58 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
           <div class="content" id="edit-maps">
 
             ## ELEVATION
-            <div id="elevation-group" class="form-group data third" ng-class="{ 'has-success': image.elevation}">
-              <label translate>elevation</label>
+            <div id="elevation-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.elevation.$touched,
+                             'has-error': editForm.elevation.$touched && editForm.elevation.$invalid,
+                             'has-success': editForm.elevation.$valid && image.elevation}">
+              <label ng-class="{ 'control-label': editForm.elevation.$touched && editForm.elevation.$invalid }" translate>elevation</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" max="9999" name="elevation" ng-model="image.elevation" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.elevation"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && image.elevation"></span>
-              <div class="help-block" ng-messages="editForm.elevation.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$touched && editForm.elevation.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation.$error" ng-if="editForm.elevation.$touched && editForm.elevation.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
               </div>
             </div>
 
             ## LONGITUDE
-            <div id="longitude-group" class="form-group data third" ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
-                                      'has-success': editForm.longitude.$valid && image.lonlat.longitude}">
-              <label><span translate>longitude</span></label>
+            <div id="longitude-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.longitude.$touched,
+                             'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
+                             'has-success': editForm.longitude.$valid && waypoint.lonlat.longitude}">
+              <label ng-class="{ 'control-label': editForm.longitude.$touched && editForm.longitude.$invalid }"><span translate>longitude</span></label>
               <div class="input-group">
                 <input type="number" name="longitude" ng-model="image.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" min="-180" max="180" />
                 <span class="input-group-addon">°E</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && image.lonlat.longitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.longitude.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
+              <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$touched && editForm.longitude.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -180° and 180°.</p>
+                <p ng-message="max" translate>This field must be between -180° and 180°.</p>
               </div>
             </div>
 
             ## LATITUDE
-            <div id="latitude-group" class="form-group data third" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
-                                      'has-success': editForm.latitude.$valid && image.lonlat.latitude}">
-              <label><span translate>Latitude</span></label>
+            <div id="latitude-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.latitude.$touched,
+                             'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
+                             'has-success': editForm.latitude.$valid && waypoint.lonlat.latitude}">
+              <label ng-class="{ 'control-label': editForm.latitude.$touched && editForm.latitude.$invalid }"><span translate>Latitude</span></label>
               <div class="input-group">
                 <input type="number" name="latitude" ng-model="image.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" min="-90" max="90" />
                 <span class="input-group-addon">°N</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="image.lonlat.latitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.latitude.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+              <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$invalid && editForm.latitude.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" translate>This field must be between -90° and 90°.</p>
               </div>
             </div>
 
@@ -240,49 +251,58 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
             </div>
 
             ## FOCAL LENGTH
-            <div class="form-group half" ng-class="{ 'has-error': editForm.focal_length.$invalid, 'has-success': editForm.focal_length.$valid && image.focal_length }">
-              <label translate>focal_length</label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.focal_length.$touched,
+                             'has-error': editForm.focal_length.$invalid,
+                             'has-success': editForm.focal_length.$valid && image.focal_length }">
+              <label ng-class="{ 'control-label': editForm.focal_length.$touched && editForm.focal_length.$invalid }" translate>focal_length</label>
               <div class="input-group">
                 <input type="number" min="1" name="focal_length" ng-model="image.focal_length" class="form-control">
                 <span class="input-group-addon">mm</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.focal_length.$valid && image.focal_length"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.focal_length.$invalid && editForm.focal_length.$touched"></span>
-              <div class="help-block" ng-messages="editForm.focal_length.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.focal_length.$invalid && editForm.focal_length.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.focal_length.$error" ng-if="editForm.focal_length.$invalid && editForm.focal_length.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## EXPOSURE TIME
-            <div class="form-group half" ng-class="{ 'has-error': editForm.exposure_time.$invalid || editCtrl.exposureError, 'has-success': editForm.exposure_time.$valid && image.exposure_time}">
-              <label translate>exposure_time</label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.exposure_time.$touched,
+                             'has-error': editForm.exposure_time.$invalid || editCtrl.exposureError,
+                             'has-success': editForm.exposure_time.$valid && image.exposure_time}">
+              <label ng-class="{ 'control-label': editForm.exposure_time.$touched && editForm.exposure_time.$invalid }" translate>exposure_time</label>
               <span ng-bind-html="editCtrl.convertExposureTime(image.exposure_time)"></span>
               <div class="input-group flex">
-                <input type="number" min="0" max="30" name="exposure_time" ng-model="image.exposure_time" ng-change="editCtrl.convertExposureTime(image.exposure_time)" class="form-control"
+                <input type="number" min="0" max="30" step="any" name="exposure_time" ng-model="image.exposure_time" ng-change="editCtrl.convertExposureTime(image.exposure_time)" class="form-control"
                        uib-tooltip="{{'You can type 0.003125 and it will be converted to 1/320s' | translate}}">
                 <input type="text" disabled class="form-control" value="{{image.exposure_time_converted}}">
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.exposure_time.$valid && image.exposure_time"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.exposure_time.$invalid && editForm.exposure_time.$touched"></span>
-              <div class="help-block" ng-messages="editForm.exposure_time.$error || editCtrl.exposureError">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.exposure_time.$invalid) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p class="label label-danger" style="{{editCtrl.exposureError ? 'display:inline' : ''}}"><span translate>This field must be a number</span> > 0 <span translate>and</span> < 30</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.exposure_time.$invalid) ? 'display:inline' : ''}}"><span translate>This field must be a number</span> > 0 <span translate>and</span> < 30</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.exposure_time.$invalid) ? 'display:inline' : ''}}"><span translate>This field must be a number</span> > 0 <span translate>and</span> < 30</p>
+              <div class="help-block" ng-messages="editForm.exposure_time.$error || editCtrl.exposureError" ng-if="editForm.exposure_time.$invalid && editForm.exposure_time.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min"><span translate>This field must be a number</span> > 0 <span translate>and</span> < 30</p>
+                <p ng-message="max"><span translate>This field must be a number</span> > 0 <span translate>and</span> < 30</p>
               </div>
             </div>
 
             ## ISO
-            <div class="form-group half" ng-class="{ 'has-error': editForm.iso_speed.$invalid, 'has-success': editForm.iso_speed.$valid && image.iso_speed }">
-              <label translate>iso_speed</label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.iso_speed.$touched,
+                             'has-error': editForm.iso_speed.$invalid,
+                             'has-success': editForm.iso_speed.$valid && image.iso_speed }">
+              <label ng-class="{ 'control-label': editForm.iso_speed.$touched && editForm.exposure_time.$invalid }" translate>iso_speed</label>
               <div class="input-group">
                 <span class="input-group-addon">ISO</span>
                 <input type="number" min="1" name="iso_speed" ng-model="image.iso_speed" class="form-control">
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.iso_speed.$valid && image.iso_speed"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.iso_speed.$invalid && editForm.iso_speed.$touched"></span>
-              <div class="help-block" ng-messages="editForm.iso_speed.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.iso_speed.$invalid && editForm.iso_speed.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.iso_speed.$error" ng-if="editForm.iso_speed.$invalid && editForm.iso_speed.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min"><span translate>This field must be a number</span> > 0</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -87,8 +87,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## ACTIVITIES
-            <div class="form-group full" id="outing-activities" ng-init="activities = ${activities}"
-                 ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid, 'has-success': editForm.activities.$valid }">
+            <div class="form-group full" id="outing-activities" ng-init="activities = ${activities}">
               <label><span translate>activities</span> *</label>
               <div class="route-activities">
                 <div ng-repeat="activity in activities" class="activity">
@@ -125,7 +124,7 @@ updating_doc = outing_id and outing_lang
             </section>
 
             ## ROUTE DESCRIPTION
-            <div class="full form-group" ng-class="{'has-success': outing.locales[0].route_description}">
+            <div class="full form-group">
               <label translate>route_description</label>
               <textarea class="form-control" ng-model="outing.locales[0].route_description" placeholder="{{'describe route_conditions' | translate}}"></textarea>
             </div>
@@ -137,79 +136,96 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## PARTIAL TRIP
-            <div class="form-group half" ng-class="{'has-success': outing.partial_trip != undefined}">
+            <div class="form-group half">
               <label translate>partial_trip</label>
               <input type="checkbox" ng-model="outing.partial_trip" ng-checked="outing.partial_trip == true">
               <span ng-click="editCtrl.pushToArray(outing, 'partial_trip', !outing.partial_trip, $event)"></span>
             </div>
 
             ## LENGTH TOTAL
-            <div id="length_total-group" class="half form-group" ng-class="{ 'has-error': editForm.length_total.$touched && editForm.length_total.$invalid,'has-success': outing.length_total }">
-              <label translate>length_total</label>
+            <div id="length_total-group" class="half form-group"
+                 ng-class="{ 'has-feedback': editForm.length_total.$touched,
+                             'has-error': editForm.length_total.$touched && editForm.length_total.$invalid,
+                             'has-success': outing.length_total }">
+              <label ng-class="{ 'control-label': editForm.length_total.$touched && editForm.length_total.$invalid }" translate>length_total</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="length_total" ng-model="outing.length_total" class="form-control" />
+                <input type="number" min="0" minlength="1" step="any" name="length_total" ng-model="outing.length_total" class="form-control" />
                 <span class="input-group-addon">km</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.length_total.$valid && outing.length_total"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.length_total.$invalid && outing.length_total"></span>
-              <div class="help-block" ng-messages="editForm.length_total.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.length_total.$invalid && editForm.length_total.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.length_total.$touched && editForm.length_total.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.length_total.$error" ng-if="editForm.length_total.$touched && editForm.length_total.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ELEVATION MIN
-            <div id="elevation_min-group" class="half remain form-group" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid,'has-success': outing.elevation_min }">
-              <label translate>elevation_min</label>
+            <div id="elevation_min-group" class="half remain form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_min.$touched,
+                             'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid,
+                             'has-success': outing.elevation_min }">
+              <label ng-class="{ 'control-label': editForm.elevation_min.$touched && editForm.elevation_min.$invalid }" translate>elevation_min</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_min" ng-model="outing.elevation_min" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_min" ng-model="outing.elevation_min" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_min.$valid && outing.elevation_min"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$invalid && outing.elevation_min"></span>
-              <div class="help-block" ng-messages="editForm.elevation_min.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$touched && editForm.elevation_min.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_min.$error" ng-if="editForm.elevation_min.$touched && editForm.elevation_min.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ELEVATION MAX
-            <div id="elevation_max-group" class="half remain form-group" ng-class="{ 'has-error': editForm.elevation_max.$touched && editForm.elevation_max.$invalid,'has-success': outing.elevation_max }">
-              <label translate>elevation_max</label>
+            <div id="elevation_max-group" class="half remain form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_max.$touched,
+                             'has-error': editForm.elevation_max.$touched && editForm.elevation_max.$invalid,
+                             'has-success': outing.elevation_max }">
+              <label ng-class="{ 'control-label': editForm.elevation_max.$touched && editForm.elevation_max.$invalid }" translate>elevation_max</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_max" ng-model="outing.elevation_max" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_max" ng-model="outing.elevation_max" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_max.$valid && outing.elevation_max"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_max.$invalid && outing.elevation_max"></span>
-              <div class="help-block" ng-messages="editForm.elevation_max.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_max.$invalid && editForm.elevation_max.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_max.$touched && editForm.elevation_max.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_max.$error" ng-if="editForm.elevation_max.$touched && editForm.elevation_max.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF UP
-            <div id="height_diff_up-group" class="half remain form-group" ng-class="{ 'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid,'has-success': outing.height_diff_up }">
-              <label translate>height_diff_up</label>
+            <div id="height_diff_up-group" class="half remain form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_up.$touched,
+                             'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid,
+                             'has-success': outing.height_diff_up }">
+              <label ng-class="{ 'control-label': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid }" translate>height_diff_up</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="height_diff_up" ng-model="outing.height_diff_up" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_diff_up.$valid && outing.height_diff_up"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_up.$invalid && outing.height_diff_up"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_up.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_up.$invalid && editForm.height_diff_up.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.height_diff_up.$error" ng-if="editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF DOWN
-            <div id="height_diff_down-group" class="half remain form-group" ng-class="{ 'has-error': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid,'has-success': outing.height_diff_down }">
-              <label translate>height_diff_down</label>
-              <div class="input-group">
+            <div id="height_diff_down-group" class="half remain form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_down.$touched,
+                             'has-error': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid,
+                             'has-success': outing.height_diff_down }">
+              <label ng-class="{ 'control-label': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid }" translate>height_diff_down</label>
+              <div ng-class="{ 'control-label': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid }" class="input-group">
                 <input type="number" min="0" minlength="1" name="height_diff_down" ng-model="outing.height_diff_down" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_diff_down.$valid && outing.height_diff_down"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_down.$invalid && outing.height_diff_down"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_down.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_down.$invalid && editForm.height_diff_down.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.height_diff_down.$error" ng-if="editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
             <section class="section associations" ng-if="outing.associations.waypoints.length > 0">
@@ -233,7 +249,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## CONDITIONS LEVELS
-            <div class="full form-group" ng-class="{'has-success': outing.condition_levels}"
+            <div class="full form-group"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1 ">
               <label translate>conditions_levels</label>
               <table class="table table-striped conditions-levels" ng-if="outing.locales[0].conditions_levels[0]">
@@ -276,32 +292,40 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## ELEVATION UP SNOW
-            <div id="elevation_up_snow-group" class="half form-group" ng-class="{ 'has-error': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid,'has-success': outing.elevation_up_snow }"
+            <div id="elevation_up_snow-group" class="half form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_up_snow.$touched,
+                             'has-error': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid,
+                             'has-success': outing.elevation_up_snow }"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('mountain_climbing') > -1  || outing.activities.indexOf('snow_ice_mixed') > -1">
-              <label translate>elevation_up_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid }" translate>elevation_up_snow</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_up_snow" ng-model="outing.elevation_up_snow" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_up_snow" ng-model="outing.elevation_up_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_up_snow.$valid && outing.elevation_up_snow"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_up_snow.$invalid && outing.elevation_up_snow"></span>
-              <div class="help-block" ng-messages="editForm.elevation_up_snow.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_up_snow.$invalid && editForm.elevation_up_snow.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_up_snow.$error" ng-if="editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ELEVATION DOWN SNOW
-            <div id="elevation_down_snow-group" class="half form-group" ng-class="{ 'has-error': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid,'has-success': outing.elevation_down_snow }"
+            <div id="elevation_down_snow-group" class="half form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_down_snow.$touched,
+                             'has-error': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid,
+                             'has-success': outing.elevation_down_snow }"
                  ng-if="outing.activities.indexOf('snow_ice_mixed') > -1 || outing.activities.indexOf('mountain_climbing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('skitouring') > -1">
-              <label translate>elevation_down_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid }" translate>elevation_down_snow</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_down_snow" ng-model="outing.elevation_down_snow" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_down_snow" ng-model="outing.elevation_down_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_down_snow.$valid && outing.elevation_down_snow"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_down_snow.$invalid && outing.elevation_down_snow"></span>
-              <div class="help-block" ng-messages="editForm.elevation_down_snow.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_down_snow.$invalid && editForm.elevation_down_snow.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_down_snow.$error" ng-if="editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
@@ -311,9 +335,6 @@ updating_doc = outing_id and outing_lang
               <label translate>snow_quantity</label>
               <select class="form-control" ng-model="outing.snow_quantity" ng-options="rat as mainCtrl.translate(rat) for rat in ${condition_ratings}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.snow_quantity"></span>
-              <div class="help-block" ng-messages="editForm.snow_quantity.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.snow_quantity.$invalid && editForm.snow_quantity.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-              </div>
             </div>
 
             ## SNOW QUALITY
@@ -322,9 +343,6 @@ updating_doc = outing_id and outing_lang
               <label translate>snow_quality</label>
               <select class="form-control" ng-model="outing.snow_quality" ng-options="rat as mainCtrl.translate(rat) for rat in ${condition_ratings}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.snow_quality"></span>
-              <div class="help-block" ng-messages="editForm.snow_quality.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.snow_quality.$invalid && editForm.snow_quality.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
-              </div>
             </div>
 
             ## GLACIER RATING
@@ -410,16 +428,19 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## ELEVATION ACCESS
-            <div id="elevation_access-group" class="half form-group" ng-class="{ 'has-error': editForm.elevation_access.$touched && editForm.elevation_access.$invalid,'has-success': outing.elevation_access }">
-              <label translate>elevation_access</label>
+            <div id="elevation_access-group" class="half form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_access.$touched,
+                             'has-error': editForm.elevation_access.$touched && editForm.elevation_access.$invalid,'has-success': outing.elevation_access }">
+              <label ng-class="{ 'control-label': editForm.elevation_access.$touched && editForm.elevation_access.$invalid }" translate>elevation_access</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_access" ng-model="outing.elevation_access" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_access" ng-model="outing.elevation_access" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_access.$valid && outing.elevation_access"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_access.$invalid && outing.elevation_access"></span>
-              <div class="help-block" ng-messages="editForm.elevation_access.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_access.$invalid && editForm.elevation_access.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_access.$touched && editForm.elevation_access.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_access.$error" ng-if="editForm.elevation_access.$touched && editForm.elevation_access.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
@@ -450,25 +471,35 @@ updating_doc = outing_id and outing_lang
           <div class="content collapse in">
 
             ## TITLE
-            <div class="form-group" id="title-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>outing title</span> *</label>
-              <input type="text" name="title" ng-model="outing.locales[0].title" ng-minlength="3"class="form-control" required/>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-                <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+            <div class="form-group" id="title-group"
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>outing title</span> *</label>
+              <input type="text" name="title" ng-model="outing.locales[0].title" ng-minlength="3" class="form-control" required/>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid && outing.title"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$touched && editForm.title.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$touched && editForm.title.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if outing_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${outing_lang}')}}">
+                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid && outing.lang"></span>
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$invalid && outing.lang"></span>
               % else:
                 <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="outing.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
@@ -503,16 +534,20 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## NUMBER OF PARTICIPANTS
-            <div id="participants-group" class="form-group half" ng-class="{'has-success': outing.participant_count, 'has-error': editForm.participant_count.$touched && editForm.participant_count.$invalid }">
-              <label translate>participant_count</label>
+            <div id="participants-group" class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.participant_count.$touched,
+                             'has-success': outing.participant_count,
+                             'has-error': editForm.participant_count.$touched && editForm.participant_count.$invalid }">
+              <label ng-class="{ 'control-label': editForm.participant_count.$touched && editForm.particpant_count.$invalid }" translate>participant_count</label>
               <div class="input-group">
-                <input type="number" min="1" name="participant_count" ng-model="outing.participant_count" class="form-control" />
+                <input type="number" min="1" max="9999" name="participant_count" ng-model="outing.participant_count" class="form-control" />
                 <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
               </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.participant_count"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.participant_count.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.participant_count.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.participant_count.$invalid && editForm.participant_count.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.participant_count.$valid && outing.participant_count"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.participant_count.$touched && editForm.participant_count.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.participant_count.$error" ng-if="editForm.participant_count.$touched && editForm.participant_count.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/profile/edit.html
+++ b/c2corg_ui/templates/profile/edit.html
@@ -38,7 +38,7 @@ from c2corg_common.attributes import activities, user_categories
               </div>
 
               <br>
-              
+
               ## LANGUAGE
               <div>
                 <label translate>lang</label>
@@ -91,9 +91,10 @@ from c2corg_common.attributes import activities, user_categories
 
             ## LONGITUDE
             <div id="longitude-group" class="form-group data third"
-                 ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
+                 ng-class="{ 'has-feedback': editForm.longitude.$touched,
+                             'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
                              'has-success': editForm.longitude.$valid && profile.lonlat.longitude}">
-              <label translate>longitude</label>
+              <label ng-class="{ 'control-label': editForm.longitude.$touched && editForm.longitude.$invalid }" translate>longitude</label>
               <div class="input-group">
                 <input type="number" name="longitude" ng-model="profile.lonlat.longitude" ng-change="editCtrl.updateMap()"
                        class="form-control" min="-180" max="180" />
@@ -103,24 +104,19 @@ from c2corg_common.attributes import activities, user_categories
                     ng-show="editForm.longitude.$valid && profile.lonlat.longitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback"
                     ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.longitude.$error">
-                <p ng-message="number" class="label label-danger"
-                   style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger"
-                   style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be between -180° and 180°.</p>
-                <p ng-message="max" class="label label-danger"
-                   style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be between -180° and 180°.</p>
+              <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$invalid && editForm.longitude.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -180° and 180°.</p>
+                <p ng-message="max" translate>This field must be between -180° and 180°.</p>
               </div>
             </div>
 
             ## LATITUDE
             <div id="latitude-group" class="form-group data third"
-                 ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
+                 ng-class="{ 'has-feedback': editForm.latitude.$touched,
+                             'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
                              'has-success': editForm.latitude.$valid && profile.lonlat.latitude}">
-              <label translate>Latitude</label>
+              <label ng-class="{ 'control-label': editForm.latitude.$touched && editForm.latitude.$invalid }" translate>Latitude</label>
               <div class="input-group">
                 <input type="number" name="latitude" ng-model="profile.lonlat.latitude" ng-change="editCtrl.updateMap()"
                        class="form-control" min="-90" max="90" />
@@ -129,16 +125,10 @@ from c2corg_common.attributes import activities, user_categories
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="profile.lonlat.latitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback"
                     ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.latitude.$error">
-                <p ng-message="number" class="label label-danger"
-                   style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger"
-                   style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be between -90° and 90°.</p>
-                <p ng-message="max" class="label label-danger"
-                   style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}"
-                   translate>This field must be between -90° and 90°.</p>
+              <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$invalid && editForm.latitude.$touched">
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" translate>This field must be between -90° and 90°.</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -59,22 +59,28 @@ updating_doc = route_id and route_lang
 
           <div class="content" id="title-edit">
             ## TITLE
-          <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-            <label><span translate>title</span> *</label>
+          <div id="title-group" class="form-group"
+               ng-class="{ 'has-feedback': editForm.title.$touched,
+                           'has-error': editForm.title.$touched && editForm.title.$invalid,
+                           'has-success': editForm.title.$touched && editForm.title.$valid }">
+            <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>title</span> *</label>
             <span uib-tooltip="{{mainCtrl.translate('main waypoint title')}}"/><input type="text" name="main_waypoint_title"
               ng-model="route.main_waypoint_title" ng-show="route.main_waypoint_title" class="form-control" disabled></span>
             <input type="text" name="title" ng-model="route.locales[0].title" ng-minlength="3" class="form-control" required />
             <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
             <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-            <div class="help-block" ng-messages="editForm.title.$error">
-              <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-              <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+            <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$invalid && editForm.title.$touched">
+              <p ng-message="required" translate>This field is required.</p>
+              <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
             </div>
           </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if route_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${route_lang}')}}">
               % else:
@@ -82,8 +88,8 @@ updating_doc = route_id and route_lang
               % endif
                 <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.locales[0].lang"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
@@ -139,7 +145,7 @@ updating_doc = route_id and route_lang
             </div>
 
             ## CLIMBING OUTDOOR TYPE
-            <div ng-if="route.activities.indexOf('rock_climbing') > -1" class="form-group data half" ng-class="{ 'has-success': route.climbing_outdoor_type}">
+            <div ng-if="route.activities.indexOf('rock_climbing') > -1" class="form-group data half">
               <label translate>climbing_outdoor_type</label>
               <select class="form-control" ng-model="route.climbing_outdoor_type" ng-options="type as mainCtrl.translate(type) for type in ${climbing_outdoor_types}"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.climbing_outdoor_type"></span>
@@ -200,162 +206,198 @@ updating_doc = route_id and route_lang
           <div class="content" id="numbers-edit">
 
             ## ELEVATION MIN
-            <div id="elevation_min-group" class="data half form-group" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid,'has-success': route.elevation_min }">
-              <label translate>elevation_min</label>
+            <div id="elevation_min-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_min.$touched,
+                             'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid,
+                             'has-success': route.elevation_min }">
+              <label ng-class="{ 'control-label': editForm.elevation_min.$touched && editForm.elevation_min.$invalid }" translate>elevation_min</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_min" ng-model="route.elevation_min" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_min" ng-model="route.elevation_min" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.elevation_min"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$invalid && route.elevation_min"></span>
-              <div class="help-block" ng-messages="editForm.elevation_min.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$touched && editForm.elevation_min.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_min.$error" ng-if="editForm.elevation_min.$touched && editForm.elevation_min.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ELEVATION MAX
-            <div id="elevation_max-group" class="data half form-group" ng-class="{ 'has-error': editForm.elevation_max.$touched && editForm.elevation_max.$invalid,'has-success': route.elevation_max }">
-              <label translate>elevation_max</label>
+            <div id="elevation_max-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.elevation_max.$touched,
+                             'has-error': editForm.elevation_max.$touched && editForm.elevation_max.$invalid,
+                             'has-success': route.elevation_max }">
+              <label ng-class="{ 'control-label': editForm.elevation_max.$touched && editForm.elevation_max.$invalid }" translate>elevation_max</label>
               <div class="input-group">
-                <input type="number" min="0" minlength="1" name="elevation_max" ng-model="route.elevation_max" class="form-control" />
+                <input type="number" min="0" max="9999" minlength="1" name="elevation_max" ng-model="route.elevation_max" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.elevation_max"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_max.$invalid && route.elevation_max"></span>
-              <div class="help-block" ng-messages="editForm.elevation_max.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_max.$invalid && editForm.elevation_max.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_max.$touched && editForm.elevation_max.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.elevation_max.$error" ng-if="editForm.elevation_max.$touched && editForm.elevation_max.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF UP
-            <div id="height_diff_up-group" class="data half form-group" ng-class="{ 'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid,'has-success': route.height_diff_up }">
-              <label translate>height_diff_up</label>
+            <div id="height_diff_up-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_up.$touched,
+                             'has-error': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid,
+                             'has-success': route.height_diff_up }">
+              <label ng-class="{ 'control-label': editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid }" translate>height_diff_up</label>
               <div class="input-group">
                 <input type="number" min="0" name="height_diff_up" ng-model="route.height_diff_up" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.height_diff_up"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_up.$invalid && editForm.height_diff_up.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_up.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_up.$invalid && editForm.height_diff_up.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_diff_up.$error" ng-if="editForm.height_diff_up.$touched && editForm.height_diff_up.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF DOWN
-            <div id="height_diff_down-group" class="data half form-group" ng-class="{ 'has-error': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid,'has-success': route.height_diff_down }">
-              <label translate>height_diff_down</label>
+            <div id="height_diff_down-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_down.$touched,
+                             'has-error': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid,
+                             'has-success': route.height_diff_down }">
+              <label ng-class="{ 'control-label': editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid }" translate>height_diff_down</label>
               <div class="input-group">
                 <input type="number" min="0" name="height_diff_down" ng-model="route.height_diff_down" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.height_diff_down"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_down.$invalid && editForm.height_diff_down.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_down.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_down.$invalid && editForm.height_diff_down.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_diff_down.$error" ng-if="editForm.height_diff_down.$touched && editForm.height_diff_down.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF ACCESS
-            <div id="height_diff_access-group" class="data half form-group" ng-class="{ 'has-error': editForm.height_diff_access.$touched && editForm.height_diff_access.$invalid,'has-success': route.height_diff_access }">
-              <label translate>height_diff_access</label>
+            <div id="height_diff_access-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_access.$touched,
+                             'has-error': editForm.height_diff_access.$touched && editForm.height_diff_access.$invalid,
+                             'has-success': route.height_diff_access }">
+              <label ng-class="{ 'control-label': editForm.height_diff_access.$touched && editForm.height_diff_access.$invalid }" translate>height_diff_access</label>
               <div class="input-group">
                 <input type="number" min="0" name="height_diff_access" ng-model="route.height_diff_access" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.height_diff_access"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_access.$invalid && editForm.height_diff_access.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_access.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_access.$invalid && editForm.height_diff_access.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_diff_access.$error" ng-if="editForm.height_diff_access.$touched && editForm.height_diff_access.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT DIFF DIFFICULTIES
-            <div id="height_diff_difficulties-group" class="data half form-group" ng-class="{ 'has-error': editForm.height_diff_difficulties.$touched && editForm.height_diff_difficulties.$invalid,'has-success': route.height_diff_difficulties }">
-              <label translate>height_diff_difficulties</label>
+            <div id="height_diff_difficulties-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.height_diff_difficulties.$touched,
+                             'has-error': editForm.height_diff_difficulties.$touched && editForm.height_diff_difficulties.$invalid,
+                             'has-success': route.height_diff_difficulties }">
+              <label ng-class="{ 'control-label': editForm.height_diff_difficulties.$touched && editForm.height_diff_difficulties.$invalid }" translate>height_diff_difficulties</label>
               <div class="input-group">
                 <input type="number" min="0" name="height_diff_difficulties" ng-model="route.height_diff_difficulties" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.height_diff_difficulties"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_diff_difficulties.$invalid && editForm.height_diff_difficulties.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_diff_difficulties.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_diff_difficulties.$invalid && editForm.height_diff_difficulties.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_diff_difficulties.$error" ng-if="editForm.height_diff_difficulties.$touched && editForm.height_diff_difficulties.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## DIFFICULTIES HEIGHT
-            <div id="difficulties_height-group" class="data half form-group" ng-class="{ 'has-error': editForm.difficulties_height.$touched && editForm.difficulties_height.$invalid,'has-success': route.difficulties_height }"
+            <div id="difficulties_height-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.difficulties_height.$touched,
+                             'has-error': editForm.difficulties_height.$touched && editForm.difficulties_height.$invalid,
+                             'has-success': route.difficulties_height }"
                  ng-if="route.activities.indexOf('via_ferrata') > -1 || route.activities.indexOf('ice_climbing') > -1 || route.activities.indexOf('rock_climbing') > -1 || route.activities.indexOf('mountain_climbing') > -1 || route.activities.indexOf('snow_ice_mixed') > -1">
-              <label translate>difficulties_height</label>
+              <label ng-class="{ 'control-label': editForm.difficulties_height.$touched && editForm.difficulties_height.$invalid }" translate>difficulties_height</label>
               <div class="input-group">
-                <input type="number" min="0" name="difficulties_height" ng-model="route.difficulties_height" class="form-control" />
+                <input type="number" min="0" max="9999" name="difficulties_height" ng-model="route.difficulties_height" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.difficulties_height"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.difficulties_height.$invalid && editForm.difficulties_height.$touched"></span>
-              <div class="help-block" ng-messages="editForm.difficulties_height.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.difficulties_height.$invalid && editForm.difficulties_height.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.difficulties_height.$error" ng-if="editForm.difficulties_height.$touched && editForm.difficulties_height.$invalid">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ROUTE LENGTH
-            <div id="route_length-group" class="data half form-group" ng-class="{ 'has-error': editForm.route_length.$touched && editForm.route_length.$invalid,'has-success': route.route_length }"
+            <div id="route_length-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.route_length.$touched,
+                             'has-error': editForm.route_length.$touched && editForm.route_length.$invalid,
+                             'has-success': route.route_length }"
                  ng-if="route.activities.indexOf('skitouring') > -1 || route.activities.indexOf('snow_ice_mixed') > -1 || route.activities.indexOf('hiking') > -1 || route.activities.indexOf('snowshoeing') > -1
                            || route.activities.indexOf('via_ferrata') > -1 || route.activities.indexOf('mountain_biking') > -1 || route.activities.indexOf('mountain_climbing') > -1">
-              <label translate>route_length</label>
+              <label ng-class="{ 'control-label': editForm.route_length.$touched && editForm.route_length.$invalid }" translate>route_length</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="route_length" ng-model="route.route_length" class="form-control" />
                 <span class="input-group-addon">km</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.route_length"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.route_length.$invalid && editForm.route_length.$touched"></span>
-              <div class="help-block" ng-messages="editForm.route_length.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.route_length.$invalid && editForm.route_length.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.route_length.$error" ng-if="editForm.route_length.$touched && editForm.route_length.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
            ## MTB LENGTH ASPHALT
-            <div id="mtb_length_asphalt-group" class="data half form-group" ng-class="{ 'has-error': editForm.mtb_length_asphalt.$touched && editForm.mtb_length_asphalt.$invalid,'has-success': route.mtb_length_asphalt }"
+            <div id="mtb_length_asphalt-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.mtb_length_asphalt.$touched,
+                             'has-error': editForm.mtb_length_asphalt.$touched && editForm.mtb_length_asphalt.$invalid,
+                             'has-success': route.mtb_length_asphalt }"
                  ng-if="route.activities.indexOf('mountain_biking') > -1">
-              <label translate>mtb_length_asphalt</label>
+              <label ng-class="{ 'control-label': editForm.mtb_length_asphalt.$touched && editForm.mtb_length_asphalt.$invalid }" translate>mtb_length_asphalt</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="mtb_length_asphalt" ng-model="route.mtb_length_asphalt" class="form-control" />
                 <span class="input-group-addon">km</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.mtb_length_asphalt"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.mtb_length_asphalt.$invalid && editForm.mtb_length_asphalt.$touched"></span>
-              <div class="help-block" ng-messages="editForm.mtb_length_asphalt.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.mtb_length_asphalt.$invalid && editForm.mtb_length_asphalt.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.mtb_length_asphalt.$error" ng-if="editForm.mtb_length_asphalt.$touched && editForm.mtb_length_asphalt.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## MTB LENGTH TRAIL
-            <div id="mtb_length_trail-group" class="data half form-group" ng-class="{ 'has-error': editForm.mtb_length_trail.$touched && editForm.mtb_length_trail.$invalid,'has-success':route.mtb_length_trail}"
+            <div id="mtb_length_trail-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.mtb_length_trail.$touched,
+                             'has-error': editForm.mtb_length_trail.$touched && editForm.mtb_length_trail.$invalid,
+                             'has-success': route.mtb_length_trail }"
                  ng-if="route.activities.indexOf('mountain_biking') > -1">
-              <label translate>mtb_length_trail</label>
+              <label ng-class="{ 'control-label': editForm.mtb_length_trail.$touched && editForm.mtb_length_trail.$invalid }" translate>mtb_length_trail</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="mtb_length_trail" ng-model="route.mtb_length_trail" class="form-control" />
                 <span class="input-group-addon">km</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.mtb_length_trail"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.mtb_length_trail.$invalid && editForm.mtb_length_trail.$touched"></span>
-              <div class="help-block" ng-messages="editForm.mtb_length_trail.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.mtb_length_trail.$invalid && editForm.mtb_length_trail.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.mtb_length_trail.$error" ng-if="editForm.mtb_length_trail.$touched && editForm.mtb_length_trail.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## MTB HEIGHT DIFF PORTAGES
-            <div id="mtb_height_diff_portages-group" class="data half form-group" ng-class="{ 'has-error': editForm.mtb_height_diff_portages.$touched && editForm.mtb_height_diff_portages.$invalid,'has-success': route.mtb_height_diff_portages }"
+            <div id="mtb_height_diff_portages-group" class="data half form-group"
+                 ng-class="{ 'has-feedback': editForm.mtb_height_diff_portages.$touched,
+                             'has-error': editForm.mtb_height_diff_portages.$touched && editForm.mtb_height_diff_portages.$invalid,
+                             'has-success': route.mtb_height_diff_portages }"
                  ng-if="route.activities.indexOf('mountain_biking') > -1">
-              <label translate>mtb_height_diff_portages</label>
+              <label ng-class="{ 'control-label': editForm.mtb_height_diff_portages.$touched && editForm.mtb_height_diff_portages.$invalid }" translate>mtb_height_diff_portages</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="mtb_height_diff_portages" ng-model="route.mtb_height_diff_portages" class="form-control" />
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.mtb_height_diff_portages"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.mtb_height_diff_portages.$invalid && editForm.mtb_height_diff_portages.$touched"></span>
-              <div class="help-block" ng-messages="editForm.mtb_height_diff_portages.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.mtb_height_diff_portages.$invalid && editForm.mtb_height_diff_portages.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.mtb_height_diff_portages.$error" ng-if="editForm.mtb_height_diff_portages.$touched && editForm.mtb_height_diff_portages.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -75,21 +75,25 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## TITLE
             <div id="title-group" class="form-group data full"
-                 ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>title</span> *</label>
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$touched && editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>title</span> *</label>
               <input type="text" name="title" ng-model="waypoint.locales[0].title" class="form-control" required ng-minlength="3" />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p class="label label-danger" ng-message="required" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p class="label label-danger" ng-message="minlength" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : ''}}" translate>Title must have at least 3 characters.</p>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$invalid && editForm.title.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
             <div id="lang-group" class="form-group"
-                 ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid }">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if waypoint_lang:
               <input class="form-control" disabled value="{{mainCtrl.translate('${waypoint_lang}')}}">
               % else:
@@ -97,22 +101,25 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
                       ng-model="waypoint.locales[0].lang" class="form-control" required><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.lang.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$invalid && editForm.lang.$touched"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p class="label label-danger" ng-message="required" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$invalid && editForm.lang.$touched">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
               % endif
             </div>
 
-              ## WAYPOINT TYPE
-              <div id="waypoint_type-group" class="form-group data half" ng-class="{ 'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid, 'has-success': editForm.waypoint_type.$valid }">
-                <label><span translate>waypoint_type</span> *</label>
-                <select name="waypoint_type" ng-change="progressBarCtrl.updateMaxSteps(waypoint.waypoint_type)" ng-options="type as mainCtrl.translate(type) for type in ['${"','".join(waypoint_types) |n}'] | translate" ng-model="waypoint.waypoint_type" class="form-control " required><option value=""></option></select>
-                <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.waypoint_type.$valid"></span>
-                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched"></span>
-                <div class="help-block" ng-messages="editForm.waypoint_type.$error">
-                  <p class="label label-danger" ng-message="required" style="{{ (editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                </div>
+            ## WAYPOINT TYPE
+            <div id="waypoint_type-group" class="form-group data half"
+                 ng-class="{ 'has-feedback': editForm.waypoint_type.$touched,
+                             'has-error': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid,
+                             'has-success': editForm.waypoint_type.$valid }">
+              <label ng-class="{ 'control-label': editForm.waypoint_type.$touched && editForm.waypoint_type.$invalid }"><span translate>waypoint_type</span> *</label>
+              <select name="waypoint_type" ng-change="progressBarCtrl.updateMaxSteps(waypoint.waypoint_type)" ng-options="type as mainCtrl.translate(type) for type in ['${"','".join(waypoint_types) |n}'] | translate" ng-model="waypoint.waypoint_type" class="form-control " required><option value=""></option></select>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.waypoint_type.$valid"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched"></span>
+              <div class="help-block" ng-messages="editForm.waypoint_type.$error" ng-if="editForm.waypoint_type.$invalid && editForm.waypoint_type.$touched">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
+            </div>
 
           </div>
         </section>
@@ -124,85 +131,101 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
           <div class="content" id="edit-maps">
 
             ## ELEVATION
-            <div id="elevation-group" class="form-group data third" ng-if="type != 'climbing_indoor' " ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid, 'has-success': editForm.elevation.$valid && waypoint.elevation }">
-              <label><span translate>elevation</span> *</label>
+            <div id="elevation-group" class="form-group data third"
+                 ng-if="type != 'climbing_indoor' "
+                 ng-class="{ 'has-feedback': editForm.elevation.$touched,
+                             'has-error': editForm.elevation.$touched && editForm.elevation.$invalid,
+                             'has-success': editForm.elevation.$valid && waypoint.elevation }">
+              <label ng-class="{ 'control-label': editForm.elevation.$touched && editForm.elevation.$invalid }"><span translate>elevation</span> *</label>
               <div class="input-group">
                 <input type="number" name="elevation" min="0" ng-model="waypoint.elevation" class="form-control" ng-required="type != 'climbing_indoor'" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation.$valid && waypoint.elevation"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && editForm.elevation.$touched"></span>
-              <div class="help-block" ng-messages="editForm.elevation.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be lower than 9999 m.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.elevation.$error" ng-if="editForm.elevation.$invalid && editForm.elevation.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ELEVATION MIN
-            <div id="elevation_min-group" ng-if="type == 'access'" class="form-group data third" ng-class="{ 'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid, 'has-success': waypoint.elevation_min}">
-              <label translate>elevation_min</label>
+            <div id="elevation_min-group" ng-if="type == 'access'"
+                 class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.elevation_min.$touched,
+                             'has-error': editForm.elevation_min.$touched && editForm.elevation_min.$invalid,
+                             'has-success': waypoint.elevation_min }">
+              <label ng-class="{ 'control-label': editForm.elevation_min.$touched && editForm.elevation_min.$invalid }" translate>elevation_min</label>
               <div class="input-group">
                 <input type="number" name="elevation_min" min="0" ng-model="waypoint.elevation_min" class="form-control" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation_min.$valid && elevation.elevation_min"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation_min.$invalid && editForm.elevation_min.$touched"></span>
-              <div class="help-block" ng-messages="editForm.elevation_min.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="max"class="label label-danger"  style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be lower than 9999 m.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation_min.$invalid && editForm.elevation_min.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.elevation_min.$error" ng-if="editForm.elevation_min.$invalid && editForm.elevation_min.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ##  PROMINENCE
-            <div id="prominence-group" ng-if="type == 'summit'" class="form-group data third" ng-class="{ 'has-error': editForm.prominence.$touched && editForm.prominence.$invalid,
-                      'has-success': editForm.prominence.$valid && waypoint.prominence }">
-              <label><span translate>prominence</span></label>
+            <div id="prominence-group" ng-if="type == 'summit'"
+                 class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.prominence.$touched,
+                             'has-error': editForm.prominence.$touched && editForm.prominence.$invalid,
+                             'has-success': editForm.prominence.$valid && waypoint.prominence }">
+              <label ng-class="{ 'control-label': editForm.prominence.$touched && editForm.prominence.$invalid }"><span translate>prominence</span></label>
               <div class="input-group">
-                <input type="number" name="prominence" min="0" ng-model="waypoint.prominence" class="form-control"/>
+                <input type="number" name="prominence" min="0" max="9999" ng-model="waypoint.prominence" class="form-control"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.prominence.$valid && waypoint.prominence"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.prominence.$invalid && editForm.prominence.$touched"></span>
-              <div class="help-block" ng-messages="editForm.prominence.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.prominence.$invalid && editForm.prominence.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.prominence.$error" ng-if="editForm.prominence.$invalid && editForm.prominence.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
              ## LONGITUDE
-            <div id="longitude-group" class="form-group data third" ng-class="{ 'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
-                                      'has-success': editForm.longitude.$valid && waypoint.lonlat.longitude}">
-              <label><span translate>longitude</span> *</label>
+            <div id="longitude-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.longitude.$touched,
+                             'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
+                             'has-success': editForm.longitude.$valid && waypoint.lonlat.longitude}">
+              <label ng-class="{ 'control-label': editForm.longitude.$touched && editForm.longitude.$invalid }"><span translate>longitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="longitude" ng-model="waypoint.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-180" max="180" />
                 <span class="input-group-addon">°E</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && waypoint.lonlat.longitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.longitude.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.longitude.$invalid && editForm.longitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
+              <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$invalid && editForm.longitude.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -180° and 180°.</p>
+                <p ng-message="max" translate>This field must be between -180° and 180°.</p>
               </div>
             </div>
 
             ## LATITUDE
-            <div id="latitude-group" class="form-group data third" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
-                                      'has-success': editForm.latitude.$valid && waypoint.lonlat.latitude}">
-              <label><span translate>Latitude</span> *</label>
+            <div id="latitude-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.latitude.$touched,
+                             'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
+                             'has-success': editForm.latitude.$valid && waypoint.lonlat.latitude}">
+              <label ng-class="{ 'control-label': editForm.latitude.$touched && editForm.latitude.$invalid }"><span translate>Latitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="latitude" ng-model="waypoint.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-90" max="90" />
                 <span class="input-group-addon">°N</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.lonlat.latitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.latitude.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.latitude.$invalid && editForm.latitude.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+              <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$invalid && editForm.latitude.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" translate>This field must be between -90° and 90°.</p>
               </div>
             </div>
 
@@ -298,9 +321,8 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             </div>
 
             ## WEATHER STATION TYPES
-            <div class="form-group data half" ng-if="type == 'weather_station'"
-                 ng-class="{ 'has-error': editForm.weather_station_types.$touched && editForm.weather_station_types.$invalid, 'has-success': editForm.weather_station_types.$valid }">
-              <label><span translate>weather_station_types</span></label>
+            <div class="form-group data half" ng-if="type == 'weather_station'">
+              <label ng-class="{ 'control-label': editForm.weather_station_types.$touched && editForm.weather_station_types.$invalid }"><span translate>weather_station_types</span></label>
               <ul class="types">
                 <li ng-repeat="type in ${weather_station_types}" ng-click="editCtrl.pushToArray(waypoint, 'weather_station_types', type, $event)">
                   <div class="checkbox"><input type="checkbox" ng-checked="waypoint.weather_station_types.indexOf(type) > - 1"><span>{{type | translate}}</span></div>
@@ -329,8 +351,8 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             </div>
 
             ## ORIENTATION
-            <div class="form-group data half" ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor'].indexOf(type) > -1"
-                 ng-class="{ 'has-error': editForm.orientations.$touched && editForm.orientations.$invalid,'has-success': editForm.orientations.$valid }">
+            <div class="form-group data half"
+                 ng-if="['paragliding_takeoff', 'paragliding_landing', 'climbing_outdoor'].indexOf(type) > -1">
               <label><span translate>orientations</span></label>
               ${show_orientations('editCtrl', 'waypoint')}
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.orientations.$valid"></span>
@@ -355,128 +377,167 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
           <div class="content" id="edit-numbers">
 
             ## LENGTH
-            <div id="length-group" class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
-                 ng-class="{ 'has-error': editForm.length.$touched && editForm.length.$invalid, 'has-success': editForm.length.$valid && waypoint.length  }">
-              <label translate>length</label>
+            <div id="length-group" class="form-group data half"
+                 ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
+                 ng-class="{ 'has-feedback': editForm.length.$touched,
+                             'has-error': editForm.length.$touched && editForm.length.$invalid,
+                             'has-success': editForm.length.$valid && waypoint.length  }">
+              <label ng-class="{ 'control-label': editForm.length.$touched && editForm.length.$invalid }" translate>length</label>
               <div class="input-group">
                 <input type="number" name="length" min="0" ng-model="waypoint.length" class="form-control" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.length.$valid && waypoint.length"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.length.$invalid && editForm.length.$touched"></span>
-              <div class="help-block" ng-messages="editForm.length.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.length.$invalid && editForm.length.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.length.$error" ng-if="editForm.length.$invalid && editForm.length.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## SLOPE
-            <div id="slope-group" class="form-group data half" ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
-                 ng-class="{ 'has-error': editForm.slope.$touched && editForm.slope.$invalid, 'has-success': editForm.slope.$valid && waypoint.slope }">
-              <label translate>slope</label>
+            <div id="slope-group" class="form-group data half"
+                 ng-if="type == 'paragliding_takeoff' || type == 'paragliding_landing'"
+                 ng-class="{ 'has-feedback': editForm.slope.$touched,
+                             'has-error': editForm.slope.$touched && editForm.slope.$invalid,
+                             'has-success': editForm.slope.$valid && waypoint.slope }">
+              <label ng-class="{ 'control-label': editForm.slope.$touched && editForm.slope.$invalid }" translate>slope</label>
               <div class="input-group">
-                <input type="number" name="slope" min="0" ng-model="waypoint.slope" class="form-control" max="9999"/>
+                <input type="number" name="slope" min="0" ng-model="waypoint.slope" class="form-control" max="99"/>
                 <span class="input-group-addon">&deg;</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.slope.$valid && waypoint.slope"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.slope.$invalid && editForm.slope.$touched"></span>
-              <div class="help-block" ng-messages="editForm.slope.$error">
-                <p ng-message="number" style="{{ (editForm.slope.$invalid && editForm.slope.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.slope.$error" ng-if="editForm.slope.$invalid && editForm.slope.$touched">
+                <p ng-message="max" translate>This field must be lower than 99°.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
 
             ## HEIGHT MAX
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.height_max.$touched && editForm.height_max.$invalid,
-                                      'has-success': editForm.height_max.$valid && waypoint.height_max}">
-              <label><span translate>height_max</span></label>
+            <div class="form-group data half"
+                 ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-feedback': editForm.height_max.$touched,
+                             'has-error': editForm.height_max.$touched && editForm.height_max.$invalid,
+                             'has-success': editForm.height_max.$valid && waypoint.height_max}">
+              <label ng-class="{ 'control-label': editForm.height_max.$touched && editForm.height_max.$invalid }"><span translate>height_max</span></label>
               <div class="input-group">
                 <input type="number" name="height_max" min="0" ng-model="waypoint.height_max" class="form-control" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_max.$valid && waypoint.height_max"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_max.$invalid && editForm.height_max.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_max.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_max.$invalid && editForm.height_max.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_max.$error" ng-if="editForm.height_max.$invalid && editForm.height_max.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT MIN
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.height_min.$touched && editForm.height_min.$invalid,'has-success': editForm.height_min.$valid && waypoint.height_min}">
-              <label><span translate>height_min</span></label>
+            <div class="form-group data half"
+                 ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-feedback': editForm.height_min.$touched,
+                             'has-error': editForm.height_min.$touched && editForm.height_min.$invalid,
+                             'has-success': editForm.height_min.$valid && waypoint.height_min}">
+              <label ng-class="{ 'control-label': editForm.height_min.$touched && editForm.height_min.$invalid }"><span translate>height_min</span></label>
               <div class="input-group">
                 <input type="number" name="height_min" min="0" ng-model="waypoint.height_min" class="form-control" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_min.$valid && waypoint.height_min"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_min.$invalid && editForm.height_min.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_min.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_min.$invalid && editForm.height_min.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_min.$error" ng-if="editForm.height_min.$invalid && editForm.height_min.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## HEIGHT MEDIAN
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.height_median.$touched && editForm.height_median.$invalid, 'has-success': editForm.height_median.$valid && waypoint.height_median }">
-              <label><span translate>height_median</span></label>
+            <div class="form-group data half"
+                 ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-feedback': editForm.height_median.$touched,
+                             'has-error': editForm.height_median.$touched && editForm.height_median.$invalid,
+                             'has-success': editForm.height_median.$valid && waypoint.height_median }">
+              <label ng-class="{ 'control-label': editForm.height_median.$touched && editForm.height_median.$invalid }"><span translate>height_median</span></label>
               <div class="input-group">
                 <input type="number" name="height_median" min="0" ng-model="waypoint.height_median" class="form-control" max="9999"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.height_median.$valid && waypoint.height_median"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.height_median.$invalid && editForm.height_median.$touched"></span>
-              <div class="help-block" ng-messages="editForm.height_median.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.height_median.$invalid && editForm.height_median.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.height_median.$error" ng-if="editForm.height_median.$invalid && editForm.height_median.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## ROUTES QUANTITY
-            <div class="form-group data half" ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
-                 ng-class="{ 'has-error': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid, 'has-success': waypoint.routes_quantity }">
-              <label><span translate>routes_quantity</span></label>
+            <div class="form-group data half"
+                 ng-if="type == 'climbing_outdoor' || type == 'climbing_indoor'"
+                 ng-class="{ 'has-feedback': editForm.routes_quantity.$touched,
+                             'has-error': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid,
+                             'has-success': waypoint.routes_quantity }">
+              <label ng-class="{ 'control-label': editForm.routes_quantity.$touched && editForm.routes_quantity.$invalid }"><span translate>routes_quantity</span></label>
               <input type="number" name="routes_quantity" min="0" ng-model="waypoint.routes_quantity" class="form-control" max="9999"/>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.routes_quantity.$valid && waypoint.routes_quantity"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.routes_quantity.$invalid && editForm.routes_quantity.$touched"></span>
-              <div class="help-block" ng-messages="editForm.routes_quantity.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.routes_quantity.$invalid && editForm.routes_quantity.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.routes_quantity.$error" ng-if="editForm.routes_quantity.$invalid && editForm.routes_quantity.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## CAPACITY
-            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut', 'bivouac', 'shelter'].indexOf(type) > -1"
-                 ng-class="{ 'has-error': editForm.capacity.$touched && editForm.capacity.$invalid, 'has-success': editForm.capacity.$valid && waypoint.capacity }">
-              <label translate>capacity</label>
+            <div class="form-group data half"
+                 ng-if="['gite', 'camp_site', 'hut', 'bivouac', 'shelter'].indexOf(type) > -1"
+                 ng-class="{ 'has-feedback': editForm.capacity.$touched,
+                             'has-error': editForm.capacity.$touched && editForm.capacity.$invalid,
+                             'has-success': editForm.capacity.$valid && waypoint.capacity }">
+              <label ng-class="{ 'control-label': editForm.capacity.$touched && editForm.capacity.$invalid }" translate>capacity</label>
               <div class="input-group">
-                <input type="number" name="capacity" ng-model="waypoint.capacity"class="form-control" min="0" />
+                <input type="number" name="capacity" ng-model="waypoint.capacity"class="form-control" min="0" max="9999" />
                 <span class="input-group-addon glyphicon glyphicon-user"></span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.capacity"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.capacity.$invalid && editForm.capacity.$touched"></span>
-              <div class="help-block" ng-messages="editForm.capacity.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.capacity.$invalid && editForm.capacity.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.capacity.$error" ng-if="editForm.capacity.$invalid && editForm.capacity.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## CUSTODIANSHIP
-            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut'].indexOf(type) > -1" ng-class="{'has-success': waypoint.custodianship}">
-              <label><span translate>custodianship</span> <span ng-if="type == 'gite' || type == 'camp_site' || type == 'hut'">*</span></label>
+            <div class="form-group data half"
+                 ng-if="['gite', 'camp_site', 'hut'].indexOf(type) > -1"
+                 ng-class="{ 'has-feedback': editForm.custodianship.$touched,
+                             'has-error': editForm.custodianship.$touched && editForm.custodianship.$invalid,
+                             'has-success': waypoint.custodianship }">
+              <label ng-class="{ 'control-label': editForm.custodianship.$touched && editForm.custodianship.$invalid }"><span translate>custodianship</span> <span ng-if="type == 'gite' || type == 'camp_site' || type == 'hut'">*</span></label>
               <select class="form-control" name="custodianship" ng-options="type as mainCtrl.translate(type) for type in ${custodianship_types}" ng-model="waypoint.custodianship" ng-required="type == 'gite' || type == 'hut' || type == 'camp_site'"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.custodianship"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.custodianship.$invalid && editForm.custodianship.$touched"></span>
+              <div class="help-block" ng-messages="editForm.custodianship.$error" ng-if="editForm.custodianship.$invalid && editForm.custodianship.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+              </div>
             </div>
 
             ## CAPACITY STAFFED
-            <div class="form-group data half" ng-if="['gite', 'camp_site', 'hut'].indexOf(type) > -1"
-                 ng-class="{ 'has-error': editForm.capacity_staffed.$touched && editForm.capacity_staffed.$invalid, 'has-success': editForm.capacity_staffed.$valid && waypoint.capacity_staffed }">
-              <label translate>capacity_staffed</label>
+            <div class="form-group data half"
+                 ng-if="['gite', 'camp_site', 'hut'].indexOf(type) > -1"
+                 ng-class="{ 'has-feedback': editForm.capacity_staffed.$touched,
+                             'has-error': editForm.capacity_staffed.$touched && editForm.capacity_staffed.$invalid,
+                             'has-success': editForm.capacity_staffed.$valid && waypoint.capacity_staffed }">
+              <label ng-class="{ 'control-label': editForm.capacity_staffed.$touched && editForm.capacity_staffed.$invalid }" translate>capacity_staffed</label>
               <div class="input-group">
-                <input type="number" name="capacity_staffed" ng-model="waypoint.capacity_staffed"class="form-control" min="0" />
+                <input type="number" name="capacity_staffed" ng-model="waypoint.capacity_staffed"class="form-control" min="0" max="9999" />
                 <span class="input-group-addon glyphicon glyphicon-user"></span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.capacity_staffed.$valid && waypoint.capacity_staffed"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.capacity_staffed.$invalid && editForm.capacity_staffed.$touched"></span>
-              <div class="help-block" ng-messages="editForm.capacity_staffed.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.capacity_staffed.$invalid && editForm.capacity_staffed.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.capacity_staffed.$error" ng-if="editForm.capacity_staffed.$invalid && editForm.capacity_staffed.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
            </div>
 
@@ -548,7 +609,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
         ## TRANSPORTS
         <section class="section transports" ng-if="type == 'access'">
           <h2 class="heading show-phone" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#edit-transports">
-            <span><span translate>transport</span> & <span translate>access</span></span></h2>
+            <span><span translate>transport</span> &amp; <span translate>access</span></span></h2>
           <div class="content" id="edit-transports">
 
             ## SNOW CLEARANCE RATINGS
@@ -677,11 +738,18 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
             ## URL
             <div class="form-group data half"
-                 ng-if="['climbing_indoor', 'local_product', 'gite' , 'webcam', 'local_product', 'camp_site', 'hut', 'weather_station', 'climbing_indoor', 'climbing_outdoor'].indexOf(type) > -1"ng-class="{'has-success': waypoint.url}">
-              <label><span translate>url</span> <span ng-if="type == 'webcam' || type == 'weather_station'">*</span></label>
-              <input type="text" name="message" ng-model="waypoint.url" class="form-control" ng-required="['webcam', 'weather_station']. indexOf(type) > -1"/>
+                 ng-if="['climbing_indoor', 'local_product', 'gite' , 'webcam', 'local_product', 'camp_site', 'hut', 'weather_station', 'climbing_indoor', 'climbing_outdoor'].indexOf(type) > -1"
+                 ng-class="{ 'has-feedback': editForm.url.$touched,
+                             'has-error': editForm.url.$touched && editForm.url.$invalid,
+                             'has-success':  (type == 'webcam' || type == 'weather_station') && editForm.url.$valid || waypoint.url }">
+              <label ng-class="{ 'control-label': editForm.url.$touched && editForm.url.$invalid }"><span translate>url</span> <span ng-if="type == 'webcam' || type == 'weather_station'">*</span></label>
+              <input type="url" name="url" ng-model="waypoint.url" class="form-control" ng-required="['webcam', 'weather_station']. indexOf(type) > -1"/>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="(type == 'webcam' || type == 'weather_station') && editForm.url.$valid || waypoint.url"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.url.$invalid && editForm.url.$touched"></span>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="waypoint.url"></span>
+              <div class="help-block" ng-messages="editForm.url.$error" ng-if="editForm.url.$invalid && editForm.url.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="url" translate>This field must be a valid url.</p>
+              </div>
             </div>
 
             ## PHONE

--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -57,35 +57,40 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
           <div class="content">
 
             ## TITLE
-            <div id="title-group" class="form-group" ng-class="{ 'has-error': editForm.title.$touched && editForm.title.$invalid, 'has-success': editForm.title.$valid }">
-              <label><span translate>title</span> *</label>
+            <div id="title-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.title.$touched,
+                             'has-error': editForm.title.$touched && editForm.title.$invalid,
+                             'has-success': editForm.title.$valid }">
+              <label ng-class="{ 'control-label': editForm.title.$touched && editForm.title.$invalid }"><span translate>title</span> *</label>
               <input type="text" name="title" ng-model="xreport.locales[0].title" ng-minlength="3" class="form-control" required />
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.title.$valid"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.title.$invalid && editForm.title.$touched"></span>
-              <div class="help-block" ng-messages="editForm.title.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
-                <p ng-message="minlength" class="label label-danger" style="{{ (editForm.title.$invalid && editForm.title.$touched) ? 'display:inline' : '' }}" translate>Title must have at least 3 characters.</p>
+              <div class="help-block" ng-messages="editForm.title.$error" ng-if="editForm.title.$invalid && editForm.title.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="minlength" translate>Title must have at least 3 characters.</p>
               </div>
             </div>
 
             ## LANGUAGE
-            <div id="lang-group" class="form-group" ng-class="{ 'has-error': editForm.lang.$touched && editForm.lang.$invalid, 'has-success': editForm.lang.$valid}">
-              <label><span translate>lang</span> *</label>
+            <div id="lang-group" class="form-group"
+                 ng-class="{ 'has-feedback': editForm.lang.$touched,
+                             'has-error': editForm.lang.$touched && editForm.lang.$invalid,
+                             'has-success': editForm.lang.$valid}">
+              <label ng-class="{ 'control-label': editForm.lang.$touched && editForm.lang.$invalid }"><span translate>lang</span> *</label>
               % if xreport_lang:
                 <input disabled class="form-control" value="{{mainCtrl.translate('${xreport_lang}')}}">
               % else:
-              <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="xreport.locales[0].lang" class="form-control" required><option value=""></option></select>
+                <select name="lang" ng-options="lang as mainCtrl.translate(lang) for lang in ['${"','".join(default_langs) |n}'] | translate" ng-model="xreport.locales[0].lang" class="form-control" required><option value=""></option></select>
               % endif
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].lang"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.lang.$touched && editForm.lang.$invalid"></span>
-              <div class="help-block" ng-messages="editForm.lang.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lang.$invalid && editForm.lang.$touched) ? 'display:inline' : '' }}" translate>This field is required.</p>
+              <div class="help-block" ng-messages="editForm.lang.$error" ng-if="editForm.lang.$touched && editForm.lang.$invalid">
+                <p ng-message="required" translate>This field is required.</p>
               </div>
             </div>
 
             ## ACTIVITIES
-            <div class="form-group data full" id="route-activities" ng-init="activities = ${activities}"
-                 ng-class="{ 'has-error': editForm.activities.$touched && editForm.activities.$invalid, 'has-success': editForm.activities.$valid }">
+            <div class="form-group data full" id="route-activities" ng-init="activities = ${activities}">
               <label><span translate>activities</span> *</label>
               <div class="route-activities">
                 <div ng-repeat="activity in activities" class="activity">
@@ -108,54 +113,60 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
           <div class="content" id="edit-maps">
 
             ## ELEVATION
-            <div id="elevation-group" class="form-group data third" ng-if="type != 'climbing_indoor' " ng-class="{ 'has-error': editForm.elevation.$touched && editForm.elevation.$invalid, 'has-success': editForm.elevation.$valid && xreport.elevation }">
-              <label><span translate>elevation</span> *</label>
+            <div id="elevation-group" class="form-group data third" ng-if="type != 'climbing_indoor' "
+                 ng-class="{ 'has-feedback': editForm.elevation.$touched,
+                             'has-error': editForm.elevation.$touched && editForm.elevation.$invalid,
+                             'has-success': editForm.elevation.$valid && xreport.elevation }">
+              <label ng-class="{ 'control-label': editForm.elevation.$touched && editForm.elevation.$invalid }" translate>elevation</label>
               <div class="input-group">
-                <input type="number" name="elevation" min="0" ng-model="xreport.elevation" class="form-control" max="9999"/>
+                <input type="number" name="elevation" min="0" max="9999" ng-model="xreport.elevation" class="form-control"/>
                 <span class="input-group-addon">m</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.elevation.$valid && xreport.elevation"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.elevation.$invalid && editForm.elevation.$touched"></span>
-              <div class="help-block" ng-messages="editForm.elevation.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be lower than 9999 m.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.elevation.$invalid && editForm.elevation.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
+              <div class="help-block" ng-messages="editForm.elevation.$error" ng-if="editForm.elevation.$invalid && editForm.elevation.$touched">
+                <p ng-message="max" translate>This field must be lower than 9999 m.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## LONGITUDE
-            <div id="lon-group" class="form-group data third" ng-class="{ 'has-error': editForm.lon.$touched && editForm.lon.$invalid,
-                                      'has-success': editForm.longitude.$valid && xreport.lonlat.longitude}">
-              <label><span translate>Longitude</span> *</label>
+            <div id="lon-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.longitude.$touched,
+                             'has-error': editForm.longitude.$touched && editForm.longitude.$invalid,
+                             'has-success': editForm.longitude.$valid && xreport.lonlat.longitude}">
+              <label ng-class="{ 'control-label': editForm.longitude.$touched && editForm.longitude.$invalid }"><span translate>Longitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="longitude" ng-model="xreport.lonlat.longitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-180" max="180" />
                 <span class="input-group-addon">°E</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && xreport.lonlat.longitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.longitude.$invalid && editForm.longitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.longitude.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lon.$invalid && editForm.lon.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.lon.$invalid && editForm.lon.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.lon.$invalid && editForm.lon.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.lon.$invalid && editForm.lon.$touched) ? 'display:inline' : ''}}" translate>This field must be between -180° and 180°.</p>
+              <div class="help-block" ng-messages="editForm.longitude.$error" ng-if="editForm.longitude.$invalid && editForm.longitude.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -180° and 180°.</p>
+                <p ng-message="max" translate>This field must be between -180° and 180°.</p>
               </div>
             </div>
 
             ## LATITUDE
-            <div id="lat-group" class="form-group data third" ng-class="{ 'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
-                                      'has-success': editForm.latitude.$valid && xreport.lonlat.latitude}">
-              <label><span translate>Latitude</span> *</label>
+            <div id="lat-group" class="form-group data third"
+                 ng-class="{ 'has-feedback': editForm.latitude.$touched,
+                             'has-error': editForm.latitude.$touched && editForm.latitude.$invalid,
+                             'has-success': editForm.latitude.$valid && xreport.lonlat.latitude}">
+              <label ng-class="{ 'control-label': editForm.latitude.$touched && editForm.latitude.$invalid }"><span translate>Latitude</span> *</label>
               <div class="input-group">
                 <input type="number" name="latitude" ng-model="xreport.lonlat.latitude" ng-change="editCtrl.updateMap()" class="form-control" required min="-90" max="90" />
                 <span class="input-group-addon">°N</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="editForm.longitude.$valid && xreport.lonlat.latitude"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.latitude.$invalid && editForm.latitude.$touched"></span>
-              <div class="help-block" ng-messages="editForm.latitude.$error">
-                <p ng-message="required" class="label label-danger" style="{{ (editForm.lat.$invalid && editForm.lat.$touched) ? 'display:inline' : ''}}" translate>This field is required.</p>
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.lat.$invalid && editForm.lat.$touched) ? 'display:inline' : ''}}" translate>This field must be a number.</p>
-                <p ng-message="min" class="label label-danger" style="{{ (editForm.lat.$invalid && editForm.lat.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
-                <p ng-message="max" class="label label-danger" style="{{ (editForm.lat.$invalid && editForm.lat.$touched) ? 'display:inline' : ''}}" translate>This field must be between -90° and 90°.</p>
+              <div class="help-block" ng-messages="editForm.latitude.$error" ng-if="editForm.latitude.$invalid && editForm.latitude.$touched">
+                <p ng-message="required" translate>This field is required.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
+                <p ng-message="min" translate>This field must be between -90° and 90°.</p>
+                <p ng-message="max" translate>This field must be between -90° and 90°.</p>
               </div>
             </div>
 
@@ -185,7 +196,7 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
           <div class="content collapse in">
 
             ## DATE
-            <div class="date form-group" ng-init="openDateStart = false" ng-class="{ 'has-error': editForm.date.$touched && editForm.date.$invalid,'has-success': xreport.date }">
+            <div class="date form-group" ng-init="openDateStart = false">
               <label><span translate>date</span> *</label>
               <div class="input-group" ng-model="xreport.date" uib-datepicker-popup="dd MM yyyy" is-open="openDateStart">
                 <input type="text" disabled class="form-control" value="{{xreport.date | amDateFormat:'Do MMMM YYYY' }}"/>
@@ -205,30 +216,36 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
             </div>
 
             ## nb_participants
-            <div class="form-group half" ng-class="{ 'has-error': editForm.nb_participants.$touched && editForm.nb_participants.$invalid,'has-success': xreport.nb_participants }">
-              <label translate>nb_participants</label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.nb_participants.$touched,
+                             'has-error': editForm.nb_participants.$touched && editForm.nb_participants.$invalid,
+                             'has-success': xreport.nb_participants }">
+              <label ng-class="{ 'control-label': editForm.nb_participants.$touched && editForm.nb_participants.$invalid }" translate>nb_participants</label>
               <div class="input-group">
                 <input class="form-control" type="number" min="0" max="1000" minlength="1" name="nb_participants" ng-model="xreport.nb_participants"/>
                 <span class="input-group-addon" translate>persons</span>
               </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.nb_participants"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.xreport.nb_participants.$invalid && xreport.nb_participants"></span>
-              <div class="help-block" ng-messages="editForm.xreport.nb_participants.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.xreport.nb_participants.$invalid && editForm.xreport.nb_participants.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.nb_participants && editForm.xreport.nb_participants.$valid"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.nb_participants.$touched && editForm.nb_participants.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.nb_participants.$error" ng-if="editForm.nb_participants.$touched && editForm.nb_participants.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
             ## nb_impacted
-            <div class="form-group half" ng-class="{ 'has-error': editForm.nb_impacted.$touched && editForm.nb_impacted.$invalid,'has-success': xreport.nb_impacted }">
-              <label translate>nb_impacted</label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.nb_impacted.$touched,
+                             'has-error': editForm.nb_impacted.$touched && editForm.nb_impacted.$invalid,
+                             'has-success': xreport.nb_impacted }">
+              <label ng-class="{ 'control-label': editForm.nb_impacted.$touched && editForm.nb_impacted.$invalid }" translate>nb_impacted</label>
               <div class="input-group">
                 <input class="form-control" type="number" min="0" max="1000" minlength="1" name="nb_impacted" ng-model="xreport.nb_impacted"/>
                 <span class="input-group-addon" translate>persons</span>
               </div>
-              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.nb_impacted"></span>
-              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.xreport.nb_impacted.$invalid && xreport.nb_impacted"></span>
-              <div class="help-block" ng-messages="editForm.xreport.nb_impacted.$error">
-                <p ng-message="number" class="label label-danger" style="{{ (editForm.xreport.nb_impacted.$invalid && editForm.xreport.nb_impacted.$touched) ? 'display:inline' : '' }}" translate>This field must be a number.</p>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.nb_impacted && editForm.nb_impacted.$valid"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.nb_impacted.$touched && editForm.nb_impacted.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.nb_impacted.$error" ng-if="editForm.nb_impacted.$touched && editForm.nb_impacted.$invalid">
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 
@@ -271,11 +288,20 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
           <div class="content">
 
             ## age
-            <div class="form-group half" ng-class="{ 'has-error': editForm.age.$touched && editForm.age.$invalid, 'has-success': editForm.age.$valid && xreport.age }">
-              <label><span translate>age</span></label>
+            <div class="form-group half"
+                 ng-class="{ 'has-feedback': editForm.age.$touched,
+                             'has-error': editForm.age.$touched && editForm.age.$invalid,
+                             'has-success': editForm.age.$valid && xreport.age }">
+              <label ng-class="{ 'control-label': xreport.age && editForm.nb_impacted.$invalid }"><span translate>age</span></label>
               <div class="input-group">
-                <input type="number" name="age" min="0" ng-model="xreport.age" class="form-control" max="100"/>
+                <input type="number" name="age" min="0" max="99" ng-model="xreport.age" class="form-control"/>
 ##                   <span class="input-group-addon">years</span>
+              </div>
+              <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.age"></span>
+              <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.xreport.age.$touched && editForm.xreport.age.$invalid"></span>
+              <div class="help-block" ng-messages="editForm.xreport.age.$error" ng-if="editForm.xreport.age.$touched && editForm.xreport.age.$invalid">
+                <p ng-message="number" translate>This field must be lower than 99.</p>
+                <p ng-message="number" translate>This field must be a number.</p>
               </div>
             </div>
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -337,16 +337,18 @@ app-pagination.areas, app-pagination.articles app-pagination.books {
   }
 }
 
-.help-block {
+div.help-block {
   position: absolute;
-  margin-top: -5px;
-  margin-bottom: 0;
+  margin-top: 0;
+  margin-top: 0;
 
   p {
-    display: none;
     font-size: 1em;
-    color: white !important;
   }
+}
+
+#register-captcha-group {
+  padding-top: 5px;
 }
 
 .line-separator{

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -328,7 +328,7 @@
   }
   .form-control-feedback {
     position: relative;
-    top: -34px;
+    top: -34px !important;
     left: -moz-calc(~"100% + 5px");
     left: -webkit-calc(~"100% + 5px");
     left: -o-calc(~"100% + 5px");
@@ -506,7 +506,7 @@
 #title-group {
   flex-basis: 74%;
   margin-right: 3% !important;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
 }
 #lang-group {
   margin: 0 !important;


### PR DESCRIPTION
* Ensure feedback is displayed in login and signin forms
* Rework feedback in topoguide forms: use consistent coloring
* Ensure all feedbacks have enough place to be displayed
* Re-tested every field, added some more constraints, corrected some typos

See #1525 and #1526