### PR TITLE
[WIP] Add a language preferences to the feed - UI part

### DIFF
--- a/c2corg_ui/static/js/feed.js
+++ b/c2corg_ui/static/js/feed.js
@@ -4,6 +4,7 @@ goog.provide('app.feedDirective');
 goog.require('app');
 goog.require('app.Api');
 goog.require('app.Authentication');
+// goog.require('app.PreferencesController');
 goog.require('app.utils');
 
 
@@ -24,6 +25,7 @@ app.module.directive('appFeed', app.feedDirective);
 
 
 /**
+ * @param {angular.$cookies} $cookies Cookies service.
  * @param {app.Authentication} appAuthentication
  * @param {app.Api} appApi Api service.
  * @param {app.Lang} appLang Lang service.
@@ -33,13 +35,19 @@ app.module.directive('appFeed', app.feedDirective);
  * @ngInject
  * @struct
  */
-app.FeedController = function(appAuthentication, appApi, appLang, imageUrl, ngeoLocation) {
+app.FeedController = function($cookies, appAuthentication, appApi, appLang, imageUrl, ngeoLocation) {
 
   /**
    * @type {app.Api}
    * @public
    */
   this.api = appApi;
+
+  /**
+   * @type {angular.$cookies}
+   * @private
+   */
+  this.cookies_ = $cookies;
 
   /**
    * @type {app.Authentication}
@@ -130,7 +138,12 @@ app.FeedController = function(appAuthentication, appApi, appLang, imageUrl, ngeo
  */
 app.FeedController.prototype.getDocumentsFromFeed = function() {
   this.busy = true;
-  this.api.readFeed(this.nextToken, this.lang_.getLang(), this.userId, this.isPersonal).then(function(response) {
+  console.log('cookie is ', this.cookies_.get('preferred_lang'));
+  console.log('interface lang is ', this.lang_.getLang());
+
+  var lang = this.cookies_.get('preferred_lang') || this.lang_.getLang();
+  console.log('lang');
+  this.api.readFeed(this.nextToken, lang, this.userId, this.isPersonal).then(function(response) {
     this.handleFeed(response);
   }.bind(this), function() { // Error msg is shown in the api service
     this.busy = false;

--- a/c2corg_ui/static/js/langservice.js
+++ b/c2corg_ui/static/js/langservice.js
@@ -78,6 +78,10 @@ app.Lang = function($cookies, gettextCatalog, ngeoGetBrowserLanguage, langs,
     this.cookies_.get('interface_lang') ||
     this.ngeoGetBrowserLanguage_(this.langs_) || 'fr'
   );
+  // this.updatePreferredLang(
+  //   this.cookies_.get('preferred_lang') ||
+  //   this.ngeoGetBrowserLanguage_(this.langs_) || 'fr'
+  // );
 };
 
 

--- a/c2corg_ui/static/js/preferences.js
+++ b/c2corg_ui/static/js/preferences.js
@@ -54,7 +54,7 @@ app.PreferencesController = function($scope, $cookies, appAuthentication, appApi
 
   /**
    * @type {Array.<string>}
-   * @public
+   * @export
    */
   this.lang_preferences = [];
 
@@ -84,7 +84,7 @@ app.PreferencesController = function($scope, $cookies, appAuthentication, appApi
       this.followed_only = data.followed_only;
       this.lang_preferences = data.lang_preferences;
 
-      console.log('data jsou po otevr. stranky ...', data);
+      console.log('data after page load ...', data);
 
       this.scope_.$watch(function() {
         return this.followed_only;
@@ -137,19 +137,10 @@ app.PreferencesController.prototype.updateLanguages = function(language) {
     'expires': d
   });
 
-  console.log('aktualni preference v Cookie a ulozeni', this.lang_preferences);
+  console.log('preferences now saved to cookie', this.lang_preferences);
 
   this.save_();
 };
-
-//
-// /**
-//  * @return {string}
-//  * @public
-//  */
-// app.PreferencesController.prototype.getLanguagePreference = function() {
-//   return this.lang_preferences || 'es';
-// };
 
 
 /**
@@ -184,7 +175,7 @@ app.PreferencesController.prototype.removeArea = function(id) {
  * @private
  */
 app.PreferencesController.prototype.save_ = function() {
-  console.log('...saving lang. preference ...' , this.lang_preferences);
+  console.log('...saving language preference ...' , this.lang_preferences);
   var data = {
     'lang_preferences': this.lang_preferences,
     'activities': this.activities,

--- a/c2corg_ui/static/js/preferences.js
+++ b/c2corg_ui/static/js/preferences.js
@@ -23,6 +23,7 @@ app.preferencesDirective = function() {
 app.module.directive('appPreferences', app.preferencesDirective);
 
 /**
+ * @param {angular.$cookies} $cookies Cookies service.
  * @param {angular.Scope} $scope Scope.
  * @param {app.Authentication} appAuthentication
  * @param {app.Api} appApi Api service.
@@ -30,7 +31,7 @@ app.module.directive('appPreferences', app.preferencesDirective);
  * @constructor
  * @ngInject
  */
-app.PreferencesController = function($scope, appAuthentication, appApi,
+app.PreferencesController = function($scope, $cookies, appAuthentication, appApi,
     authUrl) {
 
   /**
@@ -40,10 +41,22 @@ app.PreferencesController = function($scope, appAuthentication, appApi,
   this.scope_ = $scope;
 
   /**
+   * @type {angular.$cookies}
+   * @private
+   */
+  this.cookies_ = $cookies;
+
+  /**
    * @type {app.Api}
    * @private
    */
   this.api_ = appApi;
+
+  /**
+   * @type {Array.<string>}
+   * @public
+   */
+  this.lang_preferences = [];
 
   /**
    * @type {Array.<string>}
@@ -69,6 +82,9 @@ app.PreferencesController = function($scope, appAuthentication, appApi,
       this.activities = data.activities;
       this.areas = data.areas;
       this.followed_only = data.followed_only;
+      this.lang_preferences = data.lang_preferences;
+
+      console.log('data jsou po otevr. stranky ...', data);
 
       this.scope_.$watch(function() {
         return this.followed_only;
@@ -98,6 +114,42 @@ app.PreferencesController.prototype.updateActivities = function(activity) {
   }
   this.save_();
 };
+
+
+/**
+ * @param {string} language
+ * @export
+ */
+app.PreferencesController.prototype.updateLanguages = function(language) {
+  if (this.lang_preferences.indexOf(language) > -1) {
+    this.lang_preferences = this.lang_preferences.filter(function(item) {
+      return item !== language;
+    });
+  } else {
+    this.lang_preferences.push(language);
+  }
+
+  console.log('inserting cookie', this.lang_preferences.join(','));
+  var d = new Date();
+  d.setFullYear(d.getFullYear() + 1); // today + 1 year
+  this.cookies_.put('preferred_lang', this.lang_preferences.join(','), {
+    'path': '/',
+    'expires': d
+  });
+
+  console.log('aktualni preference v Cookie a ulozeni', this.lang_preferences);
+
+  this.save_();
+};
+
+//
+// /**
+//  * @return {string}
+//  * @public
+//  */
+// app.PreferencesController.prototype.getLanguagePreference = function() {
+//   return this.lang_preferences || 'es';
+// };
 
 
 /**
@@ -132,7 +184,9 @@ app.PreferencesController.prototype.removeArea = function(id) {
  * @private
  */
 app.PreferencesController.prototype.save_ = function() {
+  console.log('...saving lang. preference ...' , this.lang_preferences);
   var data = {
+    'lang_preferences': this.lang_preferences,
     'activities': this.activities,
     'areas': this.areas,
     'followed_only': this.followed_only

--- a/c2corg_ui/static/js/whatsnewfeed.js
+++ b/c2corg_ui/static/js/whatsnewfeed.js
@@ -19,6 +19,7 @@ app.module.directive('appWhatsnewFeed', app.whatsnewFeedDirective);
 
 /**
  * @param {!angular.Scope} $scope Scope.
+ * @param {angular.$cookies} $cookies Cookies service.
  * @param {app.Authentication} appAuthentication
  * @param {app.Api} appApi Api service.
  * @param {app.Lang} appLang Lang service.
@@ -28,9 +29,9 @@ app.module.directive('appWhatsnewFeed', app.whatsnewFeedDirective);
  * @extends {app.FeedController}
  * @ngInject
  */
-app.WhatsnewFeedController = function($scope, appAuthentication, appApi, appLang, imageUrl, ngeoLocation) {
+app.WhatsnewFeedController = function($scope, $cookies, appAuthentication, appApi, appLang, imageUrl, ngeoLocation) {
 
-  goog.base(this, appAuthentication, appApi, appLang, imageUrl, ngeoLocation);
+  goog.base(this, $cookies, appAuthentication, appApi, appLang, imageUrl, ngeoLocation);
 
   /**
    * @type {number}

--- a/c2corg_ui/templates/preferences.html
+++ b/c2corg_ui/templates/preferences.html
@@ -1,5 +1,5 @@
 <%!
-from c2corg_common.attributes import activities
+from c2corg_common.attributes import activities, default_langs
 %>
 <%inherit file="base.html"/>
 <%namespace file="helpers/common.html" import="show_title, generate_empty_list_items"/>
@@ -26,7 +26,7 @@ from c2corg_common.attributes import activities
       <div class="preferences-areas">
         <h3 translate class="green-text">Areas</h3>
         <app-simple-search app-select="prefCtrl.addArea(doc)" dataset="a"></app-simple-search>
-        <p translate ng-show="prefCtrl.areas.length == 0">Select the region of your interest by typing in the fied.</p>
+        <p translate ng-show="prefCtrl.areas.length == 0">Select the region of your interest by typing in the field.</p>
         <div class="list areas" ng-show="prefCtrl.areas.length > 0">
           <div class="list-item areas new-item"
                ng-repeat="area in prefCtrl.areas">
@@ -36,6 +36,22 @@ from c2corg_common.attributes import activities
           ${generate_empty_list_items(5)}
         </div>
       </div>
+
+      <div class="preferences-langs">
+        <h3 translate class="green-text">langs</h3>
+        <p translate ng-show="prefCtrl.lang_preferences.length == 0">Filter the document languages of your interest by selecting them.</p>
+        <div class="form-group full full-group">
+          <ul class="types">
+            <li ng-repeat="lang in ${default_langs}" ng-click="prefCtrl.updateLanguages(lang)">
+              <div class="checkbox">
+                <input type="checkbox" ng-model="prefCtrl.lang_preferences" ng-checked="prefCtrl.lang_preferences.indexOf(lang) > -1">
+                <span>{{lang | translate}} {{lang}}</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+
 
       <div class="preferences-activities section associations ">
         <h3 class="green-text text-left" translate>activities</h3>

--- a/c2corg_ui/templates/preferences.html
+++ b/c2corg_ui/templates/preferences.html
@@ -44,7 +44,7 @@ from c2corg_common.attributes import activities, default_langs
           <ul class="types">
             <li ng-repeat="lang in ${default_langs}" ng-click="prefCtrl.updateLanguages(lang)">
               <div class="checkbox">
-                <input type="checkbox" ng-model="prefCtrl.lang_preferences" ng-checked="prefCtrl.lang_preferences.indexOf(lang) > -1">
+                <input type="checkbox" ng-checked="prefCtrl.lang_preferences.indexOf(lang) > -1">
                 <span>{{lang | translate}} {{lang}}</span>
               </div>
             </li>


### PR DESCRIPTION
related to issue https://github.com/c2corg/v6_ui/issues/1382

requires API part https://github.com/c2corg/v6_api/pull/642 to test 

STILL WIP!


Few notes to look at later -
- since language preference is an `ArrayOfEnum`, it makes sense to enable some kind of "sorting" on UI preferences setting page (I have IT+ES enabled and I want to see IT if both locales are available). Right now there are only simple checkboxes and language preference is chosen on API automatically