### PR TITLE
use another (shorter) translation key for float button help on mobile

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -563,7 +563,7 @@
       <div class="float-button float-favorites" tooltip-placement="left" uib-tooltip="{{'Add images' | translate}}"
            ng-click="uplCtrl.openModal()" ng-if="userCtrl.hasEditRights('${doctype}', ${options})">
         <span class="glyphicon glyphicon-picture"></span>
-        <p class="float-button-text" translate>Add images</p>
+        <p class="float-button-text" translate>Images</p>
       </div>
     % endif
 


### PR DESCRIPTION
Should be e.g. 'Images' instead.
Currently it is - in french - 'Ajouter des images' so only 'Ajouter' is displayed.