### PR TITLE
collapsed menu on medium screen

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -1,9 +1,9 @@
-@big: ~"only screen and (min-width: 1400px)";
-@desktop: ~"only screen and (min-width: 1100px) and (max-width: 1399px)";
-@tablet: ~"only screen and (min-width: 769px) and (max-width: 1099px)";
+@big: ~"only screen and (min-width: 1900px)";
+@desktop: ~"only screen and (min-width: 1365px) and (max-width: 1899px)";
+@tablet: ~"only screen and (min-width: 769px) and (max-width: 1366px)";
 @phone: ~"only screen and (max-width: 768px)";
 @phone-max: 768px;
-@tablet-max: 1099px;
+@tablet-max: 1366px;
 @lightgrey: #F0F0F0;
 @C2C-orange: #FFAA45;
 @bg-color1 : #ebe4d1;


### PR DESCRIPTION
Many user conplain that menu take place in desktop (on small and medium screen).

A very simple way to fix is to considere that small screen are a tablet (collapsed menu by defaut).

An other gain that decrease menu size is to give more space for photo (when the PR #1537 is merged)