### PR TITLE
Add protect/unprotect document tool

### DIFF
--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -699,6 +699,36 @@ app.Api.prototype.unblockAccount = function(userId) {
 
 
 /**
+ * @param {number} documentId
+ * @return {!angular.$q.Promise<!angular.$http.Response>}
+ */
+app.Api.prototype.protectDocument = function(documentId) {
+  var data = {'document_id': documentId};
+  var promise = this.postJson_('/documents/protect', data);
+  promise.catch(function(response) {
+    var msg = this.alerts_.gettext('Protecting document failed:');
+    this.alerts_.addErrorWithMsg(msg, response);
+  }.bind(this));
+  return promise;
+};
+
+
+/**
+ * @param {number} documentId
+ * @return {!angular.$q.Promise<!angular.$http.Response>}
+ */
+app.Api.prototype.unprotectDocument = function(documentId) {
+  var data = {'document_id': documentId};
+  var promise = this.postJson_('/documents/unprotect', data);
+  promise.catch(function(response) {
+    var msg = this.alerts_.gettext('Unprotecting document failed:');
+    this.alerts_.addErrorWithMsg(msg, response);
+  }.bind(this));
+  return promise;
+};
+
+
+/**
  * @param {number} sourceDocumentId
  * @param {number} targetDocumentId
  * @return {!angular.$q.Promise<!angular.$http.Response>}

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -49,6 +49,7 @@ goog.require('app.mergeDocumentsDirective');
 goog.require('app.paginationDirective');
 goog.require('app.preferencesDirective');
 goog.require('app.progressBarDirective');
+goog.require('app.protectDocumentDirective');
 goog.require('app.protectedUrlBtnDirective');
 goog.require('app.searchFiltersDirective');
 goog.require('app.sidemenu');

--- a/c2corg_ui/static/js/protectdocument.js
+++ b/c2corg_ui/static/js/protectdocument.js
@@ -1,0 +1,98 @@
+goog.provide('app.protectDocumentDirective');
+goog.provide('app.ProtectDocumentController');
+
+goog.require('app');
+goog.require('app.Alerts');
+goog.require('app.Api');
+goog.require('app.Authentication');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ */
+app.protectDocumentDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'appProtectDocumentController',
+    controllerAs: 'protectCtrl',
+    templateUrl: '/static/partials/protectdocument.html'
+  };
+};
+app.module.directive('appProtectDocument', app.protectDocumentDirective);
+
+
+/**
+ * @param {app.Authentication} appAuthentication
+ * @param {app.Api} appApi Api service.
+ * @param {app.Alerts} appAlerts
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {appx.Document} documentData Data set as module value in the HTML.
+ * @constructor
+ * @ngInject
+ * @struct
+ */
+app.ProtectDocumentController = function(appAuthentication, appApi,
+    appAlerts, gettextCatalog, documentData) {
+
+  /**
+   * @type {app.Api}
+   * @private
+   */
+  this.api_ = appApi;
+
+  /**
+   * @type {app.Authentication}
+   * @private
+   */
+  this.auth_ = appAuthentication;
+
+  /**
+   * @type {app.Alerts}
+   * @private
+   */
+  this.appAlerts_ = appAlerts;
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {appx.Document}
+   * @export
+   */
+  this.documentData = documentData;
+};
+
+
+/**
+ * @export
+ */
+app.ProtectDocumentController.prototype.protect = function() {
+  if (this.auth_.isModerator()) {
+    this.api_.protectDocument(this.documentData.document_id).then(function(response) {
+      this.documentData['protected'] = true;
+      this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
+          'Document is now protected'
+      ));
+    }.bind(this));
+  }
+};
+
+
+/**
+ * @export
+ */
+app.ProtectDocumentController.prototype.unprotect = function() {
+  if (this.auth_.isModerator()) {
+    this.api_.unprotectDocument(this.documentData.document_id).then(function(response) {
+      this.documentData['protected'] = false;
+      this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
+          'Document is no longer protected'
+      ));
+    }.bind(this));
+  }
+};
+
+app.module.controller('appProtectDocumentController', app.ProtectDocumentController);

--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -113,10 +113,15 @@ app.UserController.prototype.logout = function() {
 /**
  * @param {string} doctype
  * @param {Object} options
+ * @param {boolean=} opt_protected
  * @return {boolean}
  * @export
  */
-app.UserController.prototype.hasEditRights = function(doctype, options) {
+app.UserController.prototype.hasEditRights = function(doctype, options,
+    opt_protected) {
+  if (opt_protected && !this.isModerator()) {
+    return false;
+  }
   return this.auth.hasEditRights(doctype, options);
 };
 

--- a/c2corg_ui/static/partials/protectdocument.html
+++ b/c2corg_ui/static/partials/protectdocument.html
@@ -1,0 +1,2 @@
+<a ng-if="!protectCtrl.documentData['protected']" ng-click="protectCtrl.protect()" translate>Protect document</a>
+<a ng-if="protectCtrl.documentData['protected']" ng-click="protectCtrl.unprotect()" translate>Unprotect document</a>

--- a/c2corg_ui/templates/area/edit.html
+++ b/c2corg_ui/templates/area/edit.html
@@ -7,7 +7,7 @@ from c2corg_common.attributes import default_langs, area_types
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons,
-    show_save_confirmation_modal"/>
+    show_save_confirmation_modal, show_protected_warning"/>
 
 <%block name="pagetitle">
 <title ng-init="id = ${area_id if area_id else 0}" ng-bind="id ?
@@ -29,6 +29,8 @@ from c2corg_common.attributes import default_langs, area_types
     app-document-editing-id="${area_id}" app-document-editing-lang="${area_lang}"
   % endif
     class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
+
+    ${show_protected_warning('area')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -55,6 +55,7 @@ area['doctype'] = 'areas'
 
   module.value('documentData', {
     "document_id": ${area.get('document_id')},
+    "protected": ${'true' if area.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "a",
     "topic_id": ${dumps(locale.get('topic_id'))},

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -8,7 +8,7 @@ from c2corg_common.attributes import default_langs, activities, article_categori
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons,
   show_editing_associated_waypoints, show_editing_associated_routes, show_editing_associated_outings,
-  show_editing_associated_articles, show_editing_associated_books"/>
+  show_editing_associated_articles, show_editing_associated_books, show_protected_warning"/>
 
 <%block name="pagetitle"><title ng-init="id = ${article_id if article_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an article') : mainCtrl.page_title('Creating an article')">${show_title('Create/edit article')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -25,6 +25,8 @@ from c2corg_common.attributes import default_langs, activities, article_categori
     app-document-editing-id="${article_id}" app-document-editing-lang="${article_lang}"
   % endif
     class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
+
+    ${show_protected_warning('article')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -33,6 +33,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
 <%block name="moduleConstantsValues">
   module.value('documentData', {
     "document_id": ${article.get('document_id')},
+    "protected": ${'true' if article.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "c",
     "article_type": "${article.get('article_type')}",

--- a/c2corg_ui/templates/book/edit.html
+++ b/c2corg_ui/templates/book/edit.html
@@ -6,8 +6,10 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
   updating_doc = book_id and book_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons,
-    show_editing_associated_waypoints, show_editing_associated_routes, show_editing_associated_articles"/>
+<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal,
+    show_preview_container, show_editing_buttons, show_editing_associated_waypoints,
+    show_editing_associated_routes, show_editing_associated_articles,
+    show_protected_warning"/>
 
 <%block name="pagetitle"><title ng-init="id = ${book_id if book_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a book') : mainCtrl.page_title('Creating a book')">${show_title('Create/edit book')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -24,6 +26,8 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
     app-document-editing-id="${book_id}" app-document-editing-lang="${book_lang}"
   % endif
     class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+
+    ${show_protected_warning('book')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -36,6 +36,7 @@ other_langs, missing_langs = get_lang_lists(book, lang)
 <%block name="moduleConstantsValues">
   module.value('documentData', {
     "document_id": ${book.get('document_id')},
+    "protected": ${'true' if book.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "b",
     "topic_id": ${dumps(locale.get('topic_id'))},

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -156,3 +156,9 @@
     </button>
   </div>
 </%def>
+
+<%def name="show_protected_warning(model)">\
+  <article class="protected-warning" ng-show="${model}.protected">
+    <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;<span translate>This document is protected and can be edited by moderators only.</span>
+  </article>
+</%def>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -580,7 +580,7 @@
         <span class="glyphicon glyphicon-th-list"></span>
         <p class="float-button-text" translate>More</p>
       </div>
-      <ul class="dropdown-menu"  role="menu">
+      <ul class="dropdown-menu" role="menu">
         <li><a href="${request.route_path(doctype + '_history', id=doc_id, lang=doc_lang)}" translate>History</a></li>
         % if other_langs:
         <li ng-click="detailsCtrl.openModal('#other-langs')"><a translate>View in other lang</a></li>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -541,6 +541,7 @@
       doctype = get_doc_type(doc['type'])
       doc_id = doc['document_id']
       users = dumps(doc['associations']['users']) if 'users' in doc['associations'] else None
+      protected = 'true' if doc.get('protected') else 'false'
 
       if doctype == 'images':
           options = {"imageType": image["image_type"], "imageCreator": image["creator"]["user_id"]}
@@ -552,7 +553,7 @@
           options = {"users": users}
   %>
   <div class="float-buttons">
-      <div ng-if="userCtrl.hasEditRights('${doctype}', ${options})"
+      <div ng-if="userCtrl.hasEditRights('${doctype}', ${options}, ${protected})"
        tooltip-placement="left" uib-tooltip="{{'Edit' | translate}}" class="float-button float-edit"
        protected-url-btn url="${request.route_path(doctype + '_edit', id=doc_id, lang=doc_lang)}">
         <span class="glyphicon glyphicon-edit"></span>
@@ -585,9 +586,10 @@
         <li ng-click="detailsCtrl.openModal('#other-langs')"><a translate>View in other lang</a></li>
         % endif
         % if missing_langs:
-        <li ng-if="userCtrl.hasEditRights('${doctype}', ${options})"
+        <li ng-if="userCtrl.hasEditRights('${doctype}', ${options}, ${protected})"
             ng-click="detailsCtrl.openModal('#missing-langs')"><a translate>Translate into an other lang</a></li>
         % endif
+        <li ng-if="userCtrl.isModerator()" app-protect-document></li>
         <li ng-if="userCtrl.isModerator()"
             ng-click="detailsCtrl.openModal('#merge-documents-dialog')"><a translate>Merge with other document</a></li>
         % if doctype != 'areas':

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -8,8 +8,8 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
 <%namespace file="../helpers/common.html" import="show_title"/>
 
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
-    show_editing_associated_routes, show_editing_associated_outings, show_preview_container, show_save_confirmation_modal,
-    show_editing_buttons"/>
+    show_editing_associated_routes, show_editing_associated_outings, show_preview_container,
+    show_save_confirmation_modal, show_editing_buttons, show_protected_warning"/>
 
 <%block name="pagetitle">
 <title ng-init="id = ${image_id if image_id else 0}" ng-bind="id ?
@@ -45,6 +45,8 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
         <button class="btn btn-primary next" type="button" ng-if="progressBarCtrl.nextStep <=  progressBarCtrl.maxSteps" ng-click="progressBarCtrl.step(progressBarCtrl.nextStep, 'image', 'forwards')"><span class="glyphicon glyphicon-triangle-right"></span></button>
       </div>
     </app-progress-bar>
+
+    ${show_protected_warning('image')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -13,7 +13,7 @@ updating_doc = outing_id and outing_lang
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
     show_editing_associated_routes,show_preview_container, show_save_confirmation_modal,
-    show_editing_buttons"/>
+    show_editing_buttons, show_protected_warning"/>
 
 <%block name="pagetitle"><title ng-init="id=${outing_id if outing_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an outing') : mainCtrl.page_title('Creating an outing')">${show_title('Create/edit outing')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -48,6 +48,8 @@ updating_doc = outing_id and outing_lang
         <button class="btn btn-primary next" type="button" ng-if="progressBarCtrl.nextStep <= progressBarCtrl.maxSteps" ng-click="progressBarCtrl.step(progressBarCtrl.nextStep, 'outing', 'forwards')"><span class="glyphicon glyphicon-triangle-right"></span></button>
       </div>
     </app-progress-bar>
+
+    ${show_protected_warning('outing')}
 
     <section class="editing outing">
       <div class="step step-1">

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -69,6 +69,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   module.value('documentData', {
     "document_id": ${outing.get('document_id')},
+    "protected": ${'true' if outing.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "o",
     "activities": ${dumps(outing.get('activities')) | n},

--- a/c2corg_ui/templates/profile/edit.html
+++ b/c2corg_ui/templates/profile/edit.html
@@ -3,7 +3,8 @@ from c2corg_common.attributes import activities, user_categories
 %>
 <%inherit file="../base.html"/>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons"/>
+<%namespace file="../helpers/edit.html" import="show_preview_container, show_editing_buttons,
+    show_protected_warning"/>
 
 <%block name="pagetitle">
 <title ng-bind="mainCtrl.page_title('Editing a profile')">${show_title('Editing a profile')}</title>
@@ -21,6 +22,8 @@ from c2corg_common.attributes import activities, user_categories
     app-document-editing-controller-name="appDocumentEditingController"
     app-document-editing-id="${user_id}" app-document-editing-lang="${profile_lang}"
     class="document-editing" name="editForm" novalidate ng-submit="editCtrl.submitForm(editForm.$valid)">
+
+    ${show_protected_warning('profile')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/profile/view.html
+++ b/c2corg_ui/templates/profile/view.html
@@ -28,6 +28,7 @@
 
   module.value('documentData', {
     "document_id": ${profile.get('document_id')},
+    "protected": ${'true' if profile.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "u"
   });

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -14,7 +14,7 @@ updating_doc = route_id and route_lang
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
     show_editing_associated_routes, show_editing_associated_articles,
     show_editing_associated_books, show_preview_container, show_editing_buttons,
-    show_save_confirmation_modal"/>
+    show_save_confirmation_modal, show_protected_warning"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
 
 <%block name="pagetitle"><title ng-init="id=${route_id if route_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a route') : mainCtrl.page_title('Creating a route')">${show_title('Create/edit route')}</title></%block>
@@ -49,6 +49,8 @@ updating_doc = route_id and route_lang
         <button class="btn btn-primary next" type="button" ng-if="progressBarCtrl.nextStep <= progressBarCtrl.maxSteps" ng-click="progressBarCtrl.step(progressBarCtrl.nextStep, 'route', 'forwards')"><span class="glyphicon glyphicon-triangle-right"></span></button>
       </div>
     </app-progress-bar>
+
+    ${show_protected_warning('route')}
 
     <section class="editing route">
 

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -74,6 +74,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   module.value('documentData', {
     "document_id": ${route.get('document_id')},
+    "protected": ${'true' if route.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "r",
     "title": ${dumps(get_title(locale)) | n},

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -12,7 +12,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 <%namespace file="../helpers/common.html" import="show_title"/>
 <%namespace file="../helpers/edit.html" import="show_editing_associated_waypoints,
     show_editing_associated_routes, show_preview_container,
-    show_editing_buttons, show_save_confirmation_modal"/>
+    show_editing_buttons, show_save_confirmation_modal, show_protected_warning"/>
 <%namespace file="../helpers/orientations.svg" import="show_orientations"/>
 
 <%block name="pagetitle">
@@ -65,6 +65,8 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
       </span>
 
     </app-progress-bar>
+
+    ${show_protected_warning('waypoint')}
 
     <section class="editing">
       <div class="step step-1">

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -70,6 +70,7 @@ waypoint['doctype'] = 'waypoints'
 
   module.value('documentData', {
     "document_id": ${waypoint.get('document_id')},
+    "protected": ${'true' if waypoint.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "w",
     "topic_id": ${dumps(locale.get('topic_id'))},

--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -9,8 +9,10 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
   updating_doc = xreport_id and xreport_lang
 %>
 <%namespace file="../helpers/common.html" import="show_title"/>
-<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container, show_editing_buttons,
-  show_editing_associated_waypoints, show_editing_associated_routes, show_editing_associated_outings, show_editing_associated_articles"/>
+<%namespace file="../helpers/edit.html" import="show_save_confirmation_modal, show_preview_container,
+  show_editing_buttons, show_editing_associated_waypoints, show_editing_associated_routes,
+  show_editing_associated_outings, show_editing_associated_articles,
+  show_protected_warning"/>
 
 <%block name="pagetitle"><title ng-init="id = ${xreport_id if xreport_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a report') : mainCtrl.page_title('Creating a report')">${show_title('Create/edit report')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
@@ -27,7 +29,6 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
     app-document-editing-id="${xreport_id}" app-document-editing-lang="${xreport_lang}"
   % endif
     class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
-
 
     ## PROGRESS BAR
     <app-progress-bar>
@@ -46,6 +47,8 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
         <button class="btn btn-primary next" type="button" ng-if="progressBarCtrl.nextStep <= progressBarCtrl.maxSteps" ng-click="progressBarCtrl.step(progressBarCtrl.nextStep, 'xreport', 'forwards')"><span class="glyphicon glyphicon-triangle-right"></span></button>
       </div>
     </app-progress-bar>
+
+    ${show_protected_warning('xreport')}
 
     <section class="editing">
 

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -61,6 +61,7 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
 
   module.value('documentData', {
     "document_id": ${xreport.get('document_id')},
+    "protected": ${'true' if xreport.get('protected') else 'false'},
     "lang": "${lang}",
     "type": "x",
     "topic_id": ${dumps(locale.get('topic_id'))},

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -428,6 +428,16 @@
       }
     }
   }
+
+  .protected-warning {
+    margin: 5px 5px 10px 20px;
+    padding: 5px;
+    border: 1px solid red;
+    background-color: rgba(255, 0, 0, 0.2);
+    color: white;
+    font-weight: bold;
+    text-align: center;
+  }
 }
 
 .section {

--- a/less/floatbuttons.less
+++ b/less/floatbuttons.less
@@ -120,5 +120,9 @@
       bottom: 55px;
       position: absolute;
     }
+
+    a {
+      cursor: pointer;
+    }
   }
 }


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/239

TODO:

* [x] add a "protect" (resp. "unprotect") action in the "plus" button (after the "merge" and "delete" actions) - only for moderators
* [x] this new action should call the protect/unprotect API service, see https://github.com/c2corg/v6_api/issues/217
* ~~display a warning in the document if it is protected? (a bit like the disclaimer in archived versions of a document? https://www.camptocamp.org/waypoints/37355/fr/1305265)~~
* [x] hide the "edit" button for non moderators
* [x] disable the editing form (or display a warning) for non moderators