### PR TITLE
Add mardown editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ endif
 LIBS_JS_FILES += \
     node_modules/jquery/dist/jquery.min.js \
     node_modules/bootstrap-slider/dist/bootstrap-slider.min.js \
+    node_modules/bootstrap-markdown/js/bootstrap-markdown.js \
     node_modules/angular/angular.min.js \
     node_modules/bootstrap/dist/js/bootstrap.min.js \
     c2corg_ui/static/lib/angular-bootstrap/ui-bootstrap-custom-1.3.2.min.js \
@@ -53,6 +54,7 @@ LIBS_JS_FILES += \
 # CSS files of dependencies that are concatenated into a single file
 LIBS_CSS_FILES += \
     node_modules/bootstrap-slider/dist/css/bootstrap-slider.css \
+    node_modules/bootstrap-markdown/css/bootstrap-markdown.min.css \
     node_modules/slick-carousel/slick/slick.css \
     node_modules/photoswipe/dist/photoswipe.css \
     node_modules/photoswipe/dist/default-skin/default-skin.css \

--- a/build.json
+++ b/build.json
@@ -10,6 +10,7 @@
     "closure_entry_point": "app.main",
     "externs": [
       "c2corg_ui/externs/appx.js",
+      "c2corg_ui/externs/bootstrap-markdown.js",
       "c2corg_ui/externs/bootstrap-slider.js",
       "c2corg_ui/externs/angular-moment.js",
       "c2corg_ui/externs/vcrecaptcha.js",

--- a/c2corg_ui/externs/bootstrap-markdown.js
+++ b/c2corg_ui/externs/bootstrap-markdown.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Externs for bootstrap-markdown
+ *
+ * @externs
+ */
+
+/**
+ * @type {Object}
+ */
+var bootstrapMarkdown;
+
+/**
+ * @typedef {{
+ *   __localize: function(string),
+ *   showEditor: function(),
+ *   showPreview: function(),
+ *   hidePreview: function(),
+ *   isDirty: function(),
+ *   getContent: function(),
+ *   parseContent: function(),
+ *   setContent: function(string),
+ *   findSelection: function(string),
+ *   getSelection: function(),
+ *   setSelection: function(number, number),
+ *   replaceSelection: function(string),
+ *   getNextTab: function(),
+ *   setNextTab: function(number, number),
+ *   enableButtons: function(string),
+ *   disableButtons: function(string),
+ *   showButtons: function(string),
+ *   hideButtons: function(string)
+ * }}
+ */
+bootstrapMarkdown.Markdown;
+
+/**
+ * @typedef {{
+ *   defaults: Object,
+ *   messages: Array<Array<string>>
+ * }}
+ */
+$.fn.markdown;
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   toggle: boolean,
+ *   title: string,
+ *   hotkey: string,
+ *   icon: (string|Object),
+ *   callback: function(bootstrapMarkdown.Markdown),
+ * }}
+ */
+bootstrapMarkdown.ButtonConfig;
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   data: Array<bootstrapMarkdown.ButtonConfig>
+ * }}
+ */
+bootstrapMarkdown.ButtonGroupConfig;
+
+/**
+ * @typedef {{
+ *  additionalButtons: Array<Array<bootstrapMarkdown.ButtonGroupConfig>>,
+ *  autofocus: boolean,
+ *  savable: boolean,
+ *  hideable: boolean,
+ *  width: (string|number),
+ *  height: (string|number),
+ *  resize: string,
+ *  iconlibrary: string,
+ *  language: string,
+ *  footer: (string|function(bootstrapMarkdown.Markdown)),
+ *  fullscreen: Object,
+ *  hiddenButtons: (Array|string),
+ *  disabledButtons: (Array|string),
+ *  dropZoneOptions: Object,
+ *  onShow: function(bootstrapMarkdown.Markdown),
+ *  onPreview: function(bootstrapMarkdown.Markdown),
+ *  onSave: function(bootstrapMarkdown.Markdown),
+ *  onChange: function(bootstrapMarkdown.Markdown),
+ *  onFocus: function(bootstrapMarkdown.Markdown),
+ *  onBlur: function(bootstrapMarkdown.Markdown)
+ * }}
+ */
+bootstrapMarkdown.MarkdownConfig;
+
+/**
+ * @param {bootstrapMarkdown.MarkdownConfig} options
+ * @return {!jQuery}
+ */
+$.prototype.markdown = function(options) {};

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -44,6 +44,7 @@ goog.require('app.loadingDirective');
 goog.require('app.mailinglistsDirective');
 goog.require('app.mapDirective');
 goog.require('app.mapSearchDirective');
+goog.require('app.markdownEditorDirective');
 goog.require('app.mergeDocumentsDirective');
 goog.require('app.paginationDirective');
 goog.require('app.preferencesDirective');

--- a/c2corg_ui/static/js/markdowneditor.js
+++ b/c2corg_ui/static/js/markdowneditor.js
@@ -1,0 +1,157 @@
+goog.provide('app.markdownEditorDirective');
+
+goog.require('app');
+
+
+/**
+ * This directive is used on textarea elements to display a markdown editor.
+ * Inspired from https://github.com/ghiscoding/angular-markdown-editor
+ * @return {angular.Directive} The directive specs.
+ */
+app.markdownEditorDirective = function($rootScope, $compile, gettextCatalog, textFormatingUrl) {
+
+  var gettext = function(str) {
+    return str;
+  };
+
+  var messages = {
+    'Bold': gettext('Bold'),
+    'Italic': gettext('Italic'),
+    'Heading': gettext('Heading'),
+    'URL/Link': gettext('URL/Link'),
+    'Image': gettext('Image'),
+    'List': gettext('List'),
+    'Preview': gettext('Preview'),
+    'strong text': gettext('strong text'),
+    'emphasized text': gettext('emphasized text'),
+    'heading text': gettext('heading text'),
+    'enter link description here': gettext('enter link description here'),
+    'Insert Hyperlink': gettext('Insert Hyperlink'),
+    'enter image description here': gettext('enter image description here'),
+    'Insert Image Hyperlink': gettext('Insert Image Hyperlink'),
+    'enter image title here': gettext('enter image title here'),
+    'list text here': gettext('list text here')
+  };
+  angular.forEach(messages, function(value, key) {
+    messages[key] = '{{\'' + value + '\'|translate}}';
+  });
+  $.fn.markdown.messages['angular'] = messages;
+
+  var createHeadingCallback = function(prefix) {
+    return function(e) {
+      // Append/remove prefix surround the selection
+      var chunk, cursor, selected = e.getSelection(),
+          content = e.getContent(),
+          pointer, prevChar;
+
+      if (selected.length === 0) {
+        // Give extra word
+        chunk = e.__localize('heading text');
+      } else {
+        chunk = selected.text + '\n';
+      }
+
+      // transform selection and set the cursor into chunked text
+      if (
+        (
+          pointer = prefix.length + 1,
+          content.substr(selected.start - pointer, pointer) === prefix + ' '
+        ) ||
+        (
+          pointer = prefix.length,
+          content.substr(selected.start - pointer, pointer) === prefix
+        )
+      ) {
+        e.setSelection(selected.start - pointer, selected.end);
+        e.replaceSelection(chunk);
+        cursor = selected.start - pointer;
+      } else if (
+        selected.start > 0 &&
+        (
+          prevChar = content.substr(selected.start - 1, 1),
+          !!prevChar && prevChar != '\n'
+        )
+      ) {
+        e.replaceSelection('\n\n' + prefix + ' ' + chunk);
+        cursor = selected.start + prefix.length + 3;
+      } else {
+        // Empty string before element
+        e.replaceSelection(prefix + ' ' + chunk);
+        cursor = selected.start + prefix.length + 1;
+      }
+
+      // Set the cursor
+      e.setSelection(cursor, cursor + chunk.length);
+    };
+  };
+
+  /** @type Array<Array<bootstrapMarkdown.ButtonGroupConfig>> */
+  var additionalButtons = [[
+    {
+      name: 'groupFont',
+      data: [{
+        name: 'cmdH3',
+        title: 'Heading',
+        hotkey: 'Ctrl+H',
+        icon: 'glyphicon glyphicon-header',
+        callback: createHeadingCallback('##')
+      }]
+    }, {
+      name: 'groupHelp',
+      data: [{
+        name: 'cmdHelp',
+        title: 'Help',
+        icon: 'glyphicon glyphicon-question-sign',
+        callback: function(e) {
+          window.open(textFormatingUrl);
+        }
+      }]
+    }
+  ]];
+
+  return {
+    restrict: 'A',
+    require:  'ngModel',
+    link: function(scope, element, attrs, ngModel) {
+      // Only initialize the $.markdown plugin once.
+      if (!element.hasClass('processed')) {
+        element.addClass('processed');
+
+        /** @type {bootstrapMarkdown.MarkdownConfig} */
+        var options = scope.$eval(attrs['appMarkdownEditor']) || {};
+
+        options.hiddenButtons = (options.hiddenButtons || []).concat([
+          'cmdHeading',
+          'cmdImage',
+          'cmdPreview']);
+
+        // Setup the markdown WYSIWYG.
+        element.markdown($.extend({
+          additionalButtons: additionalButtons,
+          language: 'angular',
+          onChange: function(e) {
+            // When a change occurs, we need to update scope in case the user clicked one of the plugin buttons
+            // (which isn't the same as a keydown event that angular would listen for).
+            ngModel.$setViewValue(e.getContent());
+          },
+          onShow: function(e) {
+            // keep the Markdown Object in $rootScope so that it's available also from anywhere (like in the parent controller)
+            // we will keep this in an object under the ngModel name so that it also works having multiple editor in same controller
+            $rootScope.markdownEditorObjects = $rootScope.markdownEditorObjects || {};
+            $rootScope.markdownEditorObjects[ngModel.$name] = e;
+
+            // Override translations
+            e.__localize = function(string) {
+              return gettextCatalog.getString(string);
+            };
+          }
+        }, options));
+
+        // Compile translations
+        $compile(element.siblings('.md-header'))(scope);
+      }
+    }
+  };
+};
+
+app.module.directive('appMarkdownEditor', ['$rootScope', '$compile', 'gettextCatalog', 'textFormatingUrl', app.markdownEditorDirective]);

--- a/c2corg_ui/templates/area/edit.html
+++ b/c2corg_ui/templates/area/edit.html
@@ -103,13 +103,13 @@ from c2corg_common.attributes import default_langs, area_types
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="area.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="area.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>description</label>
-              <textarea name="description" ng-model="area.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="area.locales[0].description" class="form-control description"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -152,13 +152,13 @@ from c2corg_common.attributes import default_langs, activities, article_categori
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="article.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="article.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>article body</label>
-              <textarea name="description" ng-model="article.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="article.locales[0].description" class="form-control description"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -34,6 +34,7 @@ closure_library_path = settings.get('closure_library_path')
     <link rel="stylesheet" href="${request.static_path('%s/photoswipe/dist/photoswipe.css' % node_modules_path)}">
     <link rel="stylesheet" href="${request.static_path('%s/photoswipe/dist/default-skin/default-skin.css' % node_modules_path)}">
     <link rel="stylesheet" href="${request.static_path('%s/slick-carousel/slick/slick-theme.css' % node_modules_path)}">
+    <link rel="stylesheet" href="${request.static_path('%s/bootstrap-markdown/css/bootstrap-markdown.min.css' % node_modules_path)}">
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build.css')}">
     <link rel="stylesheet" href="${request.static_path('c2corg_ui:static/build/build-print.css')}" media="print">
 % else:
@@ -111,6 +112,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_path('%s/slug/slug.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-debounce/angular-debounce.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/file-saver/FileSaver.js' % node_modules_path)}"></script>
+    <script src="${request.static_path('%s/bootstrap-markdown/js/bootstrap-markdown.js' % node_modules_path)}"></script>
     <script src="${request.route_path('deps.js')}"></script>
     <script src="${request.static_path('c2corg_ui:static/js/main.js')}"></script>
 % else:
@@ -141,6 +143,7 @@ closure_library_path = settings.get('closure_library_path')
          module.constant('imageUrl', '${image_url}');
          module.constant('discourseUrl', '${discourse_url}');
          module.constant('authUrl', '${request.route_path('auth')}');
+         module.constant('textFormatingUrl', '${request.route_path('articles_view_id', id=151910)}');
          module.constant('langs', ['${"','".join(default_langs) |n}']);
          module.constant('mapApiKeys', {
            'ign': '${ign_api_key}',

--- a/c2corg_ui/templates/book/edit.html
+++ b/c2corg_ui/templates/book/edit.html
@@ -197,13 +197,13 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="book.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="book.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>description</label>
-              <textarea name="description" ng-model="book.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="book.locales[0].description" class="form-control description"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -319,13 +319,13 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>description</label>
-              <textarea name="description" ng-model="image.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="image.locales[0].description" class="form-control description"></textarea>
             </div>
 
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="image.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="image.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## AUTHOR

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -126,13 +126,13 @@ updating_doc = outing_id and outing_lang
             ## ROUTE DESCRIPTION
             <div class="full form-group">
               <label translate>route_description</label>
-              <textarea class="form-control" ng-model="outing.locales[0].route_description" placeholder="{{'describe route_conditions' | translate}}"></textarea>
+              <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0].route_description" placeholder="{{'describe route_conditions' | translate}}"></textarea>
             </div>
 
             ## TIMING
             <div class="full form-group">
               <label translate>timing</label>
-              <textarea class="form-control" ng-model="outing.locales[0]['timing']" placeholder="{{'describe timing' | translate}}"></textarea>
+              <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['timing']" placeholder="{{'describe timing' | translate}}"></textarea>
             </div>
 
             ## PARTIAL TRIP
@@ -245,7 +245,7 @@ updating_doc = outing_id and outing_lang
             ## WEATHER
             <div class="full form-group">
               <label translate>weather</label>
-              <textarea class="form-control" ng-model="outing.locales[0]['weather']" placeholder="{{'describe weather' | translate}}"></textarea>
+              <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['weather']" placeholder="{{'describe weather' | translate}}"></textarea>
             </div>
 
             ## CONDITIONS LEVELS
@@ -278,7 +278,7 @@ updating_doc = outing_id and outing_lang
             ## CONDITIONS
             <div class=" full form-group">
               <label translate>conditions</label>
-              <textarea class="form-control" ng-model="outing.locales[0]['conditions']" placeholder="{{'describe conditions' | translate}}"></textarea>
+              <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['conditions']" placeholder="{{'describe conditions' | translate}}"></textarea>
             </div>
 
             ## CONDITION RATING
@@ -374,7 +374,7 @@ updating_doc = outing_id and outing_lang
             <div class="form-group  full"  ng-if="(outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1
                       || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1) && (outing.avalanche_signs != 'no' && outing.avalanche_signs != null) ">
               <label translate>avalanches</label>
-              <textarea class="form-control" ng-model="outing.locales[0]['avalanches']"></textarea>
+              <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['avalanches']"></textarea>
             </div>
 
           </div>
@@ -414,7 +414,7 @@ updating_doc = outing_id and outing_lang
             ## HUT COMMENT
             <div class="form-group  full" ng-class="{'has-success': outing.locales[0].hut_comment}">
               <label translate>hut_comment</label>
-              <textarea class="form-control " ng-model="outing.locales[0].hut_comment"></textarea>
+              <textarea app-markdown-editor class="form-control " ng-model="outing.locales[0].hut_comment"></textarea>
             </div>
 
             ## HUT STATUS
@@ -457,7 +457,7 @@ updating_doc = outing_id and outing_lang
             ## ACCESS COMMENT
             <div class="form-group data full" ng-class="{'has-success': outing.locales[0].access_comment}">
               <label translate>access_comment</label>
-              <textarea class="form-control " ng-model="outing.locales[0].access_comment"></textarea>
+              <textarea app-markdown-editor class="form-control " ng-model="outing.locales[0].access_comment"></textarea>
             </div>
 
           </div>
@@ -554,7 +554,7 @@ updating_doc = outing_id and outing_lang
             ## COMMENT
             <div class=" full form-group">
               <label translate>personal comments</label>
-              <textarea class="form-control description" placeholder="{{'write your comments' | translate}}" ng-model="outing.locales[0]['description']"></textarea>
+              <textarea app-markdown-editor class="form-control description" placeholder="{{'write your comments' | translate}}" ng-model="outing.locales[0]['description']"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/profile/edit.html
+++ b/c2corg_ui/templates/profile/edit.html
@@ -59,13 +59,13 @@ from c2corg_common.attributes import activities, user_categories
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="profile.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="profile.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>description</label>
-              <textarea name="description" ng-model="profile.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="profile.locales[0].description" class="form-control description"></textarea>
             </div>
 
             ## ACTIVITIES

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -652,31 +652,31 @@ updating_doc = route_id and route_lang
             ## SUMMARY
             <div id="summary-group" class="form-group data full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="route.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="route.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group data full">
               <label translate>description</label>
-              <textarea name="description" ng-model="route.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="route.locales[0].description" class="form-control description"></textarea>
             </div>
 
             ## REMARKS
             <div id="remarks-group" class="form-group data full">
               <label translate>remarks</label>
-              <textarea name="remarks" ng-model="route.locales[0].remarks" class="form-control"></textarea>
+              <textarea app-markdown-editor name="remarks" ng-model="route.locales[0].remarks" class="form-control"></textarea>
             </div>
 
             ## ROUTE HISTORY
             <div class="form-group data full">
               <label translate>route_history</label>
-              <textarea name="route_history" ng-model="route.locales[0].route_history" class="form-control"></textarea>
+              <textarea app-markdown-editor name="route_history" ng-model="route.locales[0].route_history" class="form-control"></textarea>
             </div>
 
             ## GEAR LOCALE
             <div id="gear-group" class="form-group data full">
               <label translate>specific gear</label>
-              <textarea name="gear" ng-model="route.locales[0].gear" class="form-control" placeholder="{{'Describe here the gear needed for this route' | translate}}"></textarea>
+              <textarea app-markdown-editor name="gear" ng-model="route.locales[0].gear" class="form-control" placeholder="{{'Describe here the gear needed for this route' | translate}}"></textarea>
             </div>
 
             ## GLACIER GEAR
@@ -693,7 +693,7 @@ updating_doc = route_id and route_lang
             ## EXTERNAL RESOURCES
             <div class="form-group data full">
               <label translate>external_resources</label>
-              <textarea name="external_resources" ng-model="route.locales[0].external_resources" class="form-control" placeholder="{{'Books and websites not already associated to this route' | translate}}"></textarea>
+              <textarea app-markdown-editor name="external_resources" ng-model="route.locales[0].external_resources" class="form-control" placeholder="{{'Books and websites not already associated to this route' | translate}}"></textarea>
             </div>
 
           </div>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -798,14 +798,14 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
             ## SUMMARY
             <div id="summary-group" class="form-group data full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="waypoint.locales[0].summary" class="form-control" placeholder="{{'write a summary' | translate}}"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="waypoint.locales[0].summary" class="form-control" placeholder="{{'write a summary' | translate}}"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group data full">
               <label translate ng-if="type == 'access'">road access</label>
               <label translate ng-if="type != 'access'">description</label>
-              <textarea name="description" ng-model="waypoint.locales[0].description" class="form-control description"
+              <textarea app-markdown-editor name="description" ng-model="waypoint.locales[0].description" class="form-control description"
                 placeholder="{{ type =='access' ? mainCtrl.translate('Describe here the waypoint') : mainCtrl.translate('Describe road access') | translate}}"></textarea>
             </div>
 
@@ -814,7 +814,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate ng-if="type == 'access'">public transportation access</label>
               <label translate ng-if="type == 'hut' || type == 'climbing_indoor' || type == 'climbing_outdoor'">pedestrian access</label>
               <label translate ng-if="type == 'local_product'">road or pedestrian access</label>
-              <textarea name="access" ng-model="waypoint.locales[0].access" class="form-control"
+              <textarea app-markdown-editor name="access" ng-model="waypoint.locales[0].access" class="form-control"
                 placeholder="{{ type == 'access' ? mainCtrl.translate('Describe pt access') :
                   ( (type == 'hut' || type == 'climbing_indoor' || type == 'climbing_outdoor') ?
                     mainCtrl.translate('Describe pedestrian access') :
@@ -827,7 +827,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               <label translate ng-if="type == 'access'">access_period</label>
               <label translate ng-if="type == 'hut' || type == 'gite' || type == 'camp_site'">opening_periods</label>
               <label translate ng-if="type == 'local_product'">opening_hours</label>
-              <textarea name="access_period" ng-model="waypoint.locales[0].access_period" class="form-control"
+              <textarea app-markdown-editor name="access_period" ng-model="waypoint.locales[0].access_period" class="form-control"
                 placeholder="{{ (type == 'hut' || type == 'gite' || type == 'camp_site') ?
                   mainCtrl.translate('Describe opening periods') :
                   (type == 'local_product' ? mainCtrl.translate('Describe opening hours')  : mainCtrl.translate('Describe access period') ) }}">

--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -363,13 +363,13 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
             ## SUMMARY
             <div id="summary-group" class="form-group full">
               <label translate>summary</label>
-              <textarea name="summary" ng-model="xreport.locales[0].summary" class="form-control"></textarea>
+              <textarea app-markdown-editor name="summary" ng-model="xreport.locales[0].summary" class="form-control"></textarea>
             </div>
 
             ## DESCRIPTION
             <div id="description-group" class="form-group full">
               <label translate>description</label>
-              <textarea name="description" ng-model="xreport.locales[0].description" class="form-control description"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="xreport.locales[0].description" class="form-control description"></textarea>
             </div>
 
             ## ASSOCIATED PARTICIPANTS
@@ -407,91 +407,91 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
             ## place
             <div id="place-group" class="form-group full">
               <label translate>place</label>
-              <textarea name="description" ng-model="xreport.locales[0].place" class="form-control"></textarea>
+              <textarea app-markdown-editor name="description" ng-model="xreport.locales[0].place" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].place"></span>
             </div>
 
             ## route_study
             <div id="route_study-group" class="form-group full">
               <label translate>route_study</label>
-              <textarea name="route_study" ng-model="xreport.locales[0].route_study" class="form-control"></textarea>
+              <textarea app-markdown-editor name="route_study" ng-model="xreport.locales[0].route_study" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].route_study"></span>
             </div>
 
             ## conditions
             <div id="conditions-group" class="form-group full">
               <label translate>conditions study</label>
-              <textarea name="conditions" ng-model="xreport.locales[0].conditions" class="form-control"></textarea>
+              <textarea app-markdown-editor name="conditions" ng-model="xreport.locales[0].conditions" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].conditions"></span>
             </div>
 
             ## training
             <div id="training-group" class="form-group full">
               <label translate>training</label>
-              <textarea name="training" ng-model="xreport.locales[0].training" class="form-control"></textarea>
+              <textarea app-markdown-editor name="training" ng-model="xreport.locales[0].training" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].training"></span>
             </div>
 
             ## motivations
             <div id="motivations-group" class="form-group full">
               <label translate>motivations</label>
-              <textarea name="motivations" ng-model="xreport.locales[0].motivations" class="form-control"></textarea>
+              <textarea app-markdown-editor name="motivations" ng-model="xreport.locales[0].motivations" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].motivations"></span>
             </div>
 
             ## group_management
             <div id="group_management-group" class="form-group full">
               <label translate>group_management</label>
-              <textarea name="group_management" ng-model="xreport.locales[0].group_management" class="form-control"></textarea>
+              <textarea app-markdown-editor name="group_management" ng-model="xreport.locales[0].group_management" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].group_management"></span>
             </div>
 
             ## risk
             <div id="risk-group" class="form-group full">
               <label translate>risk</label>
-              <textarea name="risk" ng-model="xreport.locales[0].risk" class="form-control"></textarea>
+              <textarea app-markdown-editor name="risk" ng-model="xreport.locales[0].risk" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].risk"></span>
             </div>
 
             ## time_management
             <div id="time_management-group" class="form-group full">
               <label translate>time_management</label>
-              <textarea name="time_management" ng-model="xreport.locales[0].time_management" class="form-control"></textarea>
+              <textarea app-markdown-editor name="time_management" ng-model="xreport.locales[0].time_management" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].time_management"></span>
             </div>
 
             ## safety
             <div id="safety-group" class="form-group full">
               <label translate>safety</label>
-              <textarea name="safety" ng-model="xreport.locales[0].safety" class="form-control"></textarea>
+              <textarea app-markdown-editor name="safety" ng-model="xreport.locales[0].safety" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].safety"></span>
             </div>
 
             ## reduce_impact
             <div id="reduce_impact-group" class="form-group full">
               <label translate>reduce_impact</label>
-              <textarea name="reduce_impact" ng-model="xreport.locales[0].reduce_impact" class="form-control"></textarea>
+              <textarea app-markdown-editor name="reduce_impact" ng-model="xreport.locales[0].reduce_impact" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].reduce_impact"></span>
             </div>
 
             ## increase_impact
             <div id="increase_impact-group" class="form-group full">
               <label translate>increase_impact</label>
-              <textarea name="increase_impact" ng-model="xreport.locales[0].increase_impact" class="form-control"></textarea>
+              <textarea app-markdown-editor name="increase_impact" ng-model="xreport.locales[0].increase_impact" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].increase_impact"></span>
             </div>
 
             ## modifications
             <div id="modifications-group" class="form-group full">
               <label translate>modifications</label>
-              <textarea name="modifications" ng-model="xreport.locales[0].modifications" class="form-control"></textarea>
+              <textarea app-markdown-editor name="modifications" ng-model="xreport.locales[0].modifications" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].modifications"></span>
             </div>
 
             ## other_comments
             <div id="other_comments-group" class="form-group full">
               <label translate>other_comments</label>
-              <textarea name="other_comments" ng-model="xreport.locales[0].other_comments" class="form-control"></textarea>
+              <textarea app-markdown-editor name="other_comments" ng-model="xreport.locales[0].other_comments" class="form-control"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].other_comments"></span>
             </div>
 

--- a/c2corg_ui/views/document.py
+++ b/c2corg_ui/views/document.py
@@ -347,15 +347,12 @@ class Document(object):
             key_v1, key_v2, caching.CACHE_VERSION)
 
     def _redirect(self, id, lang, slug=None, is_lang_set=False):
-        scheme = self.request.scheme
         if slug is None:
-            location = self.request.route_url(
-                self._API_ROUTE + '_view_id_lang',
-                id=id, lang=lang, _scheme=scheme)
+            location = self.request.route_path(
+                self._API_ROUTE + '_view_id_lang', id=id, lang=lang)
         else:
-            location = self.request.route_url(
-                self._API_ROUTE + '_view',
-                id=id, lang=lang, slug=slug, _scheme=scheme)
+            location = self.request.route_path(
+                self._API_ROUTE + '_view', id=id, lang=lang, slug=slug)
         if is_lang_set:
             raise HTTPMovedPermanently(location=location)
         else:

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -26,6 +26,7 @@
 @import "404.less";
 @import "homepage.less";
 @import "variables.less";
+@import "markdowneditor.less";
 
 
 html, body{

--- a/less/markdowneditor.less
+++ b/less/markdowneditor.less
@@ -1,0 +1,7 @@
+.md-editor {
+    textarea {
+        font-family: inherit;
+        color: #555;
+        background: #f5f5f5;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "async": "1.5.2",
     "blueimp-load-image": "2.6.1",
     "bootstrap": "3.3.6",
+    "bootstrap-markdown": "2.10.0",
     "bootstrap-slider": "7.1.0",
     "closure-util": "1.15.1",
     "moment": "2.15.2",


### PR DESCRIPTION
Relate #305 

* Create new directive ``appMarkdownEditor``
* Apply ``app-markdown-editor`` on every ``textarea`` tag

Note that tooltips and all markdown editor translations are completely handled using angular-gettext and transifex and fully updated using the language selector without reloading the page.