### PR TITLE
Add context help on activities label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ LIBS_JS_FILES += \
     node_modules/angular-gettext/dist/angular-gettext.min.js \
     node_modules/angular-messages/angular-messages.min.js \
     node_modules/angular-cookies/angular-cookies.min.js \
+    node_modules/angular-sanitize/angular-sanitize.min.js \
     node_modules/corejs-typeahead/dist/typeahead.bundle.min.js \
     node_modules/moment/min/moment.min.js \
     node_modules/moment-timezone/builds/moment-timezone-with-data.min.js \

--- a/c2corg_ui/static/js/appmodule.js
+++ b/c2corg_ui/static/js/appmodule.js
@@ -26,5 +26,6 @@ app.module = angular.module('app', [
   'ngFileUpload',
   'slug',
   'vcRecaptcha',
-  'infinite-scroll'
+  'infinite-scroll',
+  'ngSanitize'
 ]);

--- a/c2corg_ui/static/js/contexthelp.js
+++ b/c2corg_ui/static/js/contexthelp.js
@@ -1,0 +1,82 @@
+goog.provide('app.contextHelpDirective');
+goog.provide('app.ContextHelpModalController');
+
+goog.require('app');
+
+/**
+ * This directive is used to display a contextual help modal dialog.
+ * @param {ui.bootstrap.$modal} $uibModal modal from angular bootstrap.
+ * @param {angular.$templateCache} $templateCache service.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ */
+app.contextHelpDirective = function($uibModal, $templateCache) {
+  return {
+    restrict: 'A',
+    link: function(scope, element, attrs) {
+      element.append(' <span class="glyphicon glyphicon-info-sign context-help-sign">');
+      element.on('click', function() {
+        $uibModal.open({
+          controller: 'AppContextHelpModalController',
+          controllerAs: 'contextHelpModalCtrl',
+          templateUrl: '/static/partials/contexthelpmodal.html',
+          'windowClass': 'context-help-modal',
+          resolve: {
+            content: function() {
+              var templateUrl = attrs['contextHelpContentUrl'];
+              if (templateUrl) {
+                return app.utils.getTemplate(templateUrl, $templateCache);
+              } else {
+                return attrs['contextHelpContent'];
+              }
+            },
+            title: function() {
+              return attrs['contextHelpTitle'];
+            }
+          }
+        });
+      });
+    }
+  };
+};
+
+
+app.module.directive('appContextHelp', app.contextHelpDirective);
+
+
+/**
+ * We have to use a secondary controller for the modal so that we can inject
+ * uibModalInstance which is not available from the first level controller.
+ * @param {ui.bootstrap.modalInstance} $uibModalInstance modal from angular bootstrap
+ * @param {string} content
+ * @param {string} title
+ * @constructor
+ * @ngInject
+ * @returns {app.ContextHelpModalController}
+ */
+app.ContextHelpModalController = function($uibModalInstance, content, title) {
+  /**
+   * @type {string}
+   * @export
+   */
+  this.content = content;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.title = title;
+
+  /**
+   * @type {ui.bootstrap.modalInstance} $uibModalInstance angular bootstrap
+   * @private
+   */
+  this.modalInstance_ = $uibModalInstance;
+};
+
+app.ContextHelpModalController.prototype.close = function() {
+  this.modalInstance_.close();
+};
+
+
+app.module.controller('AppContextHelpModalController', app.ContextHelpModalController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -26,6 +26,7 @@ goog.require('app.baselayerSelectorDirective');
 goog.require('app.blockAccountDirective');
 goog.require('app.cardDirective');
 goog.require('app.constants');
+goog.require('app.contextHelpDirective');
 goog.require('app.deleteAssociationDirective');
 goog.require('app.deleteDocumentDirective');
 goog.require('app.diffMapDirective');

--- a/c2corg_ui/static/partials/contexthelp/activities.html
+++ b/c2corg_ui/static/partials/contexthelp/activities.html
@@ -1,0 +1,20 @@
+<p translate>Type d'activités : dans une liste ou un document, passez la souris sur les pictogrammes pour connaître leur signification.</p>
+<p translate>Un document peut être associé à une ou plusieurs activités :</p>
+<ul>
+  <li translate>ski, surf : randonnée à ski et/ou surf</li>
+  <li translate>raquette : randonnée en raquettes</li>
+  <li translate>alpinisme neige, glace, mixte : alpinisme sur neige, glace ou mixte (en haute montagne)</li>
+  <li translate>rocher haute montagne : alpinisme sur rocher, grandes voies en montagne (équipées ou non)</li>
+  <li translate>escalade : bloc, voies d'une ou plusieurs longueurs en falaise (équipées ou non)</li>
+  <li translate>cascade : cascade de glace hors haute montagne, dry-tooling</li>
+  <li translate>randonnée pédestre / trail : randonnée pédestre et trail en terrain montagneux (et non en plaine), sur sentier balisé ou non, ou hors sentier</li>
+  <li translate>parapente montagne : descente en parapente après une montée à pied ou à ski (vol rando, paralpinisme)</li>
+</ul>
+<p translate>La différence entre les activités escalade et rocher haute montagne se fait principalement sur l'altitude du sommet de la voie, mais pas sur l'équipement. En Europe, les règles suivantes s'appliquent :</p>
+<ul>
+  <li translate>altitude < 2100m : escalade</li>
+  <li translate>altitude entre 2100m et 2400m : escalade ou rocher haute montagne, mais majoritairement escalade</li>
+  <li translate>altitude entre 2400m et 2700m : escalade ou rocher haute montagne, mais majoritairement rocher haute montagne</li>
+  <li translate>altitude > 2700m : rocher haute montagne</li>
+  <li translate>Pour une altitude entre 2100m et 2700m, les 2 activités peuvent être sélectionnées en cas de doute.</li>
+</ul>

--- a/c2corg_ui/static/partials/contexthelpmodal.html
+++ b/c2corg_ui/static/partials/contexthelpmodal.html
@@ -1,0 +1,10 @@
+<div class="modal-header">
+  <button class="btn gray-btn glyphicon glyphicon-remove" type="button" ng-click="contextHelpModalCtrl.close()"></button>
+  <h3 class="modal-title" id="modal-title">{{::contextHelpModalCtrl.title}}</h3>
+</div>
+<div class="modal-body" id="modal-body">
+  <div ng-bind-html="::contextHelpModalCtrl.content"></div>
+</div>
+<div class="modal-footer">
+  <button class="btn gray-btn" type="button" ng-click="contextHelpModalCtrl.close()"><span translate>Close</span></button>
+</div>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -92,6 +92,7 @@ closure_library_path = settings.get('closure_library_path')
     <script src="${request.static_path('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-messages/angular-messages.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/angular-cookies/angular-cookies.js' % node_modules_path)}"></script>
+    <script src="${request.static_path('%s/angular-sanitize/angular-sanitize.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/closure/goog/base.js' % closure_library_path)}"></script>
     <script src="${request.static_path('%s/corejs-typeahead/dist/typeahead.bundle.js' % node_modules_path)}"></script>
     <script src="${request.static_path('%s/ng-infinite-scroll/build/ng-infinite-scroll.js' % node_modules_path)}"></script>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -90,7 +90,10 @@ updating_doc = outing_id and outing_lang
 
             ## ACTIVITIES
             <div class="form-group full" id="outing-activities" ng-init="activities = ${activities}">
-              <label><span translate>activities</span> *</label>
+              <label app-context-help
+                context-help-title="{{'activities' | translate}}"
+                context-help-content-url="/static/partials/contexthelp/activities.html"
+                ><span translate>activities</span> *</label>
               <div class="route-activities">
                 <div ng-repeat="activity in activities" class="activity">
                   <div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -28,6 +28,7 @@
 @import "variables.less";
 @import "markdowneditor.less";
 @import "icon-date.less";
+@import "context-help.less";
 
 html, body{
   padding: 0;

--- a/less/context-help.less
+++ b/less/context-help.less
@@ -1,0 +1,19 @@
+.context-help-modal {
+  vertical-align: center;
+  .modal-dialog {
+    margin-top: 10px;
+    .modal-header button {
+      float: right;
+    }
+    .modal-body {
+      max-height: ~"calc(100vh - 150px)";
+      overflow-y: auto;
+    }
+  }
+}
+[app-context-help] {
+  cursor: help;
+  .context-help-sign {
+    color: @gray;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "angular-moment": "1.0.0",
     "angular-recaptcha": "4.0.3",
+    "angular-sanitize": "1.5.8",
     "angular-ui-bootstrap": "1.3.3",
     "async": "1.5.2",
     "blueimp-load-image": "2.6.1",


### PR DESCRIPTION
Relate #1096

Add new directive ``app-context-help`` for openning contextual help in modal dialog.

For adding more contextual help, you shoud :
 
* Add the ``app-context-help`` directive on the label, example: 
```
<label app-context-help
                context-help-title="{{'activities' | translate}}"
                context-help-content="<b>Ceci est un test</b>">
                <span translate>activities</span> *
              </label>
```

For longer help texts, it possible to use a partial/template that will be placed in the $templateCache (this will reduce the network traffic):
```
<label app-context-help
                context-help-content-url="/static/partials/contexthelp/activities.html"
                context-help-title="{{'activities' | translate}}">
                <span translate>activities</span> *
              </label>
```
And the corresponding template ``c2corg_ui/static/partials/contexthelp/activities.html``: 
```
<p translate>Type d'activités : dans une liste ou un document, passez la souris sur les pictogrammes pour connaître leur signification.</p>
<p translate>Un document peut être associé à une ou plusieurs activités :</p>
<ul>
  <li translate>ski, surf : randonnée à ski et/ou surf</li>
  <li translate>raquette : randonnée en raquettes</li>
...
```

I've added an indicator that there is a context help available:
![image](https://cloud.githubusercontent.com/assets/6095494/25445025/6aacb7b6-2aad-11e7-9003-39d902e6bdc4.png)

Here is the modal dialog on desktop:
![image](https://cloud.githubusercontent.com/assets/6095494/25445052/89ac0086-2aad-11e7-8fb0-1c907e06503b.png)

On mobile:
![image](https://cloud.githubusercontent.com/assets/6095494/25445068/9a88265a-2aad-11e7-8b70-7c0a8d4b8b69.png)
