### PR TITLE
Add listSwitch directive

### DIFF
--- a/c2corg_ui/static/js/listswitch.js
+++ b/c2corg_ui/static/js/listswitch.js
@@ -1,0 +1,42 @@
+goog.provide('app.ListSwitchController');
+goog.provide('app.listSwitchDirective');
+
+goog.require('app');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ */
+app.listSwitchDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'appListSwitchController',
+    controllerAs: 'switchCtrl',
+    templateUrl: '/static/partials/listswitch.html'
+  };
+};
+app.module.directive('appListSwitch', app.listSwitchDirective);
+
+
+/**
+ * @constructor
+ * @ngInject
+ */
+app.ListSwitchController = function() {
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.showList = false;
+};
+
+
+/**
+ * @export
+ */
+app.ListSwitchController.prototype.toggle = function() {
+  this.showList = !this.showList;
+};
+
+app.module.controller('appListSwitchController', app.ListSwitchController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -41,6 +41,7 @@ goog.require('app.geomDownloadDirective');
 goog.require('app.gpxUploadDirective');
 goog.require('app.imageUploaderDirective');
 goog.require('app.langDirective');
+goog.require('app.listSwitchDirective');
 goog.require('app.loadingDirective');
 goog.require('app.loadPreferencesDirective');
 goog.require('app.mailinglistsDirective');

--- a/c2corg_ui/static/partials/listswitch.html
+++ b/c2corg_ui/static/partials/listswitch.html
@@ -1,0 +1,5 @@
+<button class="btn orange-btn btn-default no-list-btn hidden-xs card-list" ng-click="switchCtrl.toggle()" >
+  <span class="glyphicon glyphicon-globe"></span>
+  <span translate ng-show="!switchCtrl.showList">List Format</span>
+  <span translate ng-show="switchCtrl.showList">Card Format</span>
+</button>

--- a/c2corg_ui/templates/outing/index.html
+++ b/c2corg_ui/templates/outing/index.html
@@ -26,21 +26,14 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
-<div class="documents-list-section-container" ng-class="{'no-map': noMap, 'no-list': noList, 'row-list' : rowList}">
+<div class="documents-list-section-container" ng-class="{'no-map': noMap, 'no-list': noList, 'row-list' : switchCtrl.showList}">
   <section class="documents-list-section">
     <%include file="filters.html" />
 
     <div class="documents-nav-buttons text-center">
       <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
       <app-doctype-selector app-doctype="outings"></app-doctype-selector>
-
-       <button class="btn orange-btn btn-default no-list-btn hidden-xs card-list" ng-init="rowList = false" 
-		ng-click="rowList = !rowList" >
-	  <span class="glyphicon glyphicon-globe"></span>
-	  <span translate ng-show="!rowList">List Format</span>
-	  <span translate ng-show="rowList">Card Format</span>
-	</button>
-
+      <app-list-switch></app-list-switch>
       <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('outings_add')}"
               uib-tooltip="{{'Create a new outing' | translate }}" tooltip-placement="right">
         <span class="glyphicon glyphicon-plus-sign"></span>

--- a/c2corg_ui/templates/route/index.html
+++ b/c2corg_ui/templates/route/index.html
@@ -34,21 +34,14 @@
     <span class="badge" ng-cloak>{{resCounter}}</span>
   </h3>
 </header>
-<div class="documents-list-section-container" ng-class="{'no-map': noMap, 'no-list': noList, 'row-list' : rowList}">
+<div class="documents-list-section-container" ng-class="{'no-map': noMap, 'no-list': noList, 'row-list' : switchCtrl.showList}">
   <section class="documents-list-section">
     <%include file="filters.html" />
 
     <div class="documents-nav-buttons text-center">
       <button class="btn btn-default orange-btn show-documents-filters-phone" translate>Filters</button>
       <app-doctype-selector app-doctype="routes"></app-doctype-selector>
-
-	<button class="btn orange-btn btn-default no-list-btn hidden-xs card-list" ng-init="rowList = false" 
-		ng-click="rowList = !rowList" >
-	  <span class="glyphicon glyphicon-globe"></span>
-	  <span translate ng-show="!rowList">List Format</span>
-	  <span translate ng-show="rowList">Card Format</span>
-	</button>
-
+      <app-list-switch></app-list-switch>
       <button class="btn btn-default orange-btn" protected-url-btn url="${request.route_path('routes_add')}"
               uib-tooltip="{{'Create a new route' | translate }}" tooltip-placement="right">
         <span class="glyphicon glyphicon-plus-sign"></span>


### PR DESCRIPTION
@stef74 I don't think your current approach (adding list switching buttons by hand in all document types list pages) is the good one: it is better to use an AngularJS directive (an HTML template with a controller where you can define actions) once and to reuse it in all appropriate templates.

This is what this PR does.
I'm also working on a way to save the user's choice in the local/sessionStorage as/in the ``userData`` (object passing some user attribute to all pages) from the directive controller, but the code is not ready yet.