### PR TITLE
Fix article type field when editing an article

### DIFF
--- a/c2corg_ui/static/js/editing/articleediting.js
+++ b/c2corg_ui/static/js/editing/articleediting.js
@@ -1,0 +1,56 @@
+goog.provide('app.ArticleEditingController');
+
+goog.require('app');
+goog.require('app.DocumentEditingController');
+goog.require('app.Document');
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.Attributes} $attrs Attributes.
+ * @param {angular.$http} $http
+ * @param {Object} $uibModal modal from angular bootstrap.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {app.Lang} appLang Lang service.
+ * @param {app.Authentication} appAuthentication
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {app.Alerts} appAlerts
+ * @param {app.Api} appApi Api service.
+ * @param {string} authUrl Base URL of the authentication page.
+ * @param {app.Document} appDocument
+ * @param {app.Url} appUrl URL service.
+ * @param {!string} imageUrl URL to the article backend.
+ * @constructor
+ * @extends {app.DocumentEditingController}
+ * @ngInject
+ */
+app.ArticleEditingController = function($scope, $element, $attrs, $http,
+        $uibModal, $compile, appLang, appAuthentication, ngeoLocation,
+        appAlerts, appApi, authUrl, appDocument, appUrl, imageUrl) {
+
+  goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
+          appLang, appAuthentication, ngeoLocation, appAlerts, appApi,
+          authUrl, appDocument, appUrl, imageUrl);
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.initialArticleType = null;
+};
+goog.inherits(app.ArticleEditingController, app.DocumentEditingController);
+
+
+/**
+ * @param {appx.Document} data
+ * @return {appx.Document}
+ * @override
+ * @public
+ */
+app.ArticleEditingController.prototype.filterData = function(data) {
+  this.initialArticleType = data['article_type'];
+  return data;
+};
+
+app.module.controller('appArticleEditingController', app.ArticleEditingController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -9,6 +9,7 @@ goog.provide('app.main');
 
 goog.require('app.MainController');
 goog.require('app.AccountController');
+goog.require('app.ArticleEditingController');
 goog.require('app.ImageEditingController');
 goog.require('app.OutingEditingController');
 goog.require('app.XreportEditingController');

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -20,7 +20,7 @@ from c2corg_common.attributes import default_langs, activities, article_categori
   </h1>
 
   <form app-loading app-document-editing="articles" app-document-editing-model="article"
-    app-document-editing-controller-name="appDocumentEditingController"
+    app-document-editing-controller-name="appArticleEditingController"
   % if updating_doc:
     app-document-editing-id="${article_id}" app-document-editing-lang="${article_lang}"
   % endif
@@ -93,17 +93,16 @@ from c2corg_common.attributes import default_langs, activities, article_categori
                                'has-success': editForm.article_type.$valid}" ng-init="article_types = ${article_types}">
                 <label><span translate>article_type</span> *</label>
                 % if updating_doc:
-                  <select ng-if="userCtrl.auth.isModerator()" class="form-control"
-                          name="article_type" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option></select>
-                  <select ng-if="userCtrl.auth.isModerator() == false && article.article_type =='collab'"
-                          name="article_type" class="form-control" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types | filter: 'collab'" required><option value=""></option>
-                  </select>
-                  <select ng-if="userCtrl.auth.isModerator() == false && article.article_type =='personal'"
-                          name="article_type" class="form-control" ng-model="article.article_type"
-                          ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option>
-                  </select>
+                  <select ng-if="userCtrl.isModerator()" class="form-control" name="article_type" ng-model="article.article_type"
+                          ng-options="type as mainCtrl.translate(type) for type in article_types" required></select>
+                  <div ng-if="!userCtrl.isModerator()">
+                    <select class="form-control" ng-model="article.article_type" ng-if="editCtrl.initialArticleType != 'collab'"
+                      ng-options="type as mainCtrl.translate(type) for type in article_types"></select>
+                    <div ng-if="editCtrl.initialArticleType == 'collab'">
+                      <input type="text" disabled class="form-control" value="{{'collab' | translate}}" />
+                      <input type="hidden" ng-model="article.article_type" />
+                    </div>
+                  </div>
                 % else:
                   <select class="form-control" ng-model="article.article_type"
                           name="article_type" ng-options="type as mainCtrl.translate(type) for type in article_types" required><option value=""></option></select>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1613

Use a similar approach to the image type selector in image editing form:
https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/templates/image/edit.html#L152-L156
https://github.com/c2corg/v6_ui/blob/master/c2corg_ui/static/js/editing/imageediting.js#L73

What it does:
* create an editing controller extension for article in order to store the initial article type (at form loading time)
* remove empty options for article type when editing an article (it is no longer "possible" to set the type to no value)
* when the initial type was "collaborative", display a fixed (disabled) text input with the translated collaborative type
* when the initial type was not "collaborative" (ie. "personal"), both collaborative and personal types are available until the form is submitted.
* moderators can change to whatever type at any time
