### PR TITLE
Fix month code translating in outing cards

### DIFF
--- a/c2corg_ui/static/partials/cards/outings.html
+++ b/c2corg_ui/static/partials/cards/outings.html
@@ -3,7 +3,7 @@
   <div class="flex wrap-row nowrap grow outing-item-infos">
     <div class="date-icon">
       <span class="day">{{ ::doc['date_end'] | date: 'dd' }}</span>
-      <span class="month">{{ ::doc['date_end'] | date: 'MMM' | translate}}</span>
+      <span class="month">{{ ::doc['date_end'] | date: 'MMM' | lowercase | translate | limitTo: 3}}</span>
       <span class="year">{{ ::doc['date_end'] | date: 'yyyy'}}</span>
     </div>
     <div class="list-item-info">


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1635

It is possible to display the whole month name:

<img width="162" alt="capture d ecran 2017-05-07 a 15 21 28" src="https://cloud.githubusercontent.com/assets/1192331/25781712/577d522a-333d-11e7-9915-f6aa1aba2692.png">

but for long ones it might wrap on 2 lines:

<img width="131" alt="capture d ecran 2017-05-07 a 15 37 15" src="https://cloud.githubusercontent.com/assets/1192331/25781719/693a2e5c-333d-11e7-92ed-2ddb03fdac50.png">

So I have added a ``limitTo: 3`` filter to only show the first 3 letters.

It works fine in the home feed and outings advanced search page:

<img width="250" alt="capture d ecran 2017-05-07 a 15 56 03" src="https://cloud.githubusercontent.com/assets/1192331/25781746/c3294272-333d-11e7-800e-84bce35ae35d.png">

<img width="454" alt="capture d ecran 2017-05-07 a 15 54 57" src="https://cloud.githubusercontent.com/assets/1192331/25781754/cd490260-333d-11e7-8da5-945df03738ca.png">

In the associated outings section of a document page, it seems that the translation does not work (but the lowercase conversion does) ?!

<img width="429" alt="capture d ecran 2017-05-07 a 15 57 07" src="https://cloud.githubusercontent.com/assets/1192331/25781764/f6db6cf8-333d-11e7-88b4-68500e6c132b.png">
