### PR TITLE
Add an activity filter in associated routes list

### DIFF
--- a/c2corg_ui/static/js/activityfilter.js
+++ b/c2corg_ui/static/js/activityfilter.js
@@ -1,0 +1,96 @@
+goog.provide('app.ActivityFilterController');
+goog.provide('app.activityFilterDirective');
+
+goog.require('app');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ */
+app.activityFilterDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'appActivityFilterController',
+    controllerAs: 'afilterCtrl',
+    bindToController: {
+      'activities': '<',
+      'documents': '<'
+    },
+    templateUrl: '/static/partials/activityfilter.html'
+  };
+};
+app.module.directive('appActivityFilter', app.activityFilterDirective);
+
+
+/**
+ * @constructor
+ * @struct
+ * @ngInject
+ */
+app.ActivityFilterController = function() {
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.activities;
+
+  /**
+   * @type {Array.<appx.Document>}
+   * @export
+   */
+  this.documents;
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.selectedActivities = [];
+};
+
+
+/**
+ * @param {string} activity Activity to filter to.
+ * @export
+ */
+app.ActivityFilterController.prototype.toggle = function(activity) {
+  if (this.activities.indexOf(activity) != -1) {
+    var index = this.selectedActivities.indexOf(activity);
+    if (index == -1) {
+      // activity is not already selected: add it to selection
+      this.selectedActivities.push(activity);
+    } else {
+      // remove activity from selection
+      this.selectedActivities.splice(index, 1);
+    }
+  }
+};
+
+
+/**
+ * @param {appx.Document} doc Document to evaluate
+ * @param {number} index
+ * @param {Array.<appx.Document>} array Array of documents to filter
+ * @return {boolean}
+ * @private
+ */
+app.ActivityFilterController.prototype.filter_ = function(doc, index, array) {
+  if (!this.selectedActivities.length) {
+    return true;
+  }
+  return doc.activities.some(function(activity) {
+    return this.selectedActivities.indexOf(activity) != -1;
+  }.bind(this));
+};
+
+
+/**
+ * @param {Array.<appx.Document>} docs
+ * @return {Array.<appx.Document>}
+ * @export
+ */
+app.ActivityFilterController.prototype.filter = function(docs) {
+  return docs.filter(this.filter_.bind(this));
+};
+
+app.module.controller('appActivityFilterController', app.ActivityFilterController);

--- a/c2corg_ui/static/js/main.js
+++ b/c2corg_ui/static/js/main.js
@@ -19,6 +19,7 @@ goog.require('app.OutingFiltersController');
 goog.require('app.RouteEditingController');
 goog.require('app.XreportFiltersController');
 goog.require('app.MapController');
+goog.require('app.activityFilterDirective');
 goog.require('app.addAssociationDirective');
 goog.require('app.advancedSearchDirective');
 goog.require('app.alertsDirective');

--- a/c2corg_ui/static/partials/activityfilter.html
+++ b/c2corg_ui/static/partials/activityfilter.html
@@ -1,0 +1,13 @@
+<div class="activity-filter" ng-if="afilterCtrl.activities.length > 1 && afilterCtrl.documents.length > 3">
+  <span translate>You may filter the list by selecting activities:</span>
+  <div class="route-activities flex wrap-row">
+    <div ng-repeat="activity in afilterCtrl.activities" class="activity">
+      <div>
+        <div class="icon-{{activity}}" class="icon-" ng-click="afilterCtrl.toggle(activity)"
+             uib-tooltip="{{activity | translate}}" tooltip-append-to-body="true"
+             ng-class="{'activity-selected' : afilterCtrl.selectedActivities.indexOf(activity) > -1}">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -318,6 +318,11 @@
     routes = document['associations']['all_routes']['documents'] if type == 'all_routes' else document['associations']['routes']
     associations = 'detailsCtrl.documentService.document.associations.'
     associations += 'all_routes.documents' if type == 'all_routes' else 'routes'
+    activities = []
+    for route in routes:
+        for activity in route['activities']:
+            if activity not in activities:
+                activities.append(activity)
   %>
     ${add_seo_association_links(routes, 'routes')}
     <section
@@ -329,37 +334,40 @@
         <span class="glyphicon glyphicon-map-marker"></span>
         <span translate>Associated routes</span><span class="glyphicon glyphicon-menu-down"></span>
       </h3>
-      <div class="associated-documents collapse in" id="associated-routes">
-        <div class="list-item" ng-repeat="doc in ${associations}" ng-class="{'new-item': doc['new']}">
-          <app-card app-card-doc="doc"></app-card>
-          % if type == 'routes':
-            <app-delete-association child-doctype="routes" parent-id="${document['document_id']}" child-id="doc.document_id"
-              ng-if="${test_association_rights(document)}
-              % if document['type'] == 'o':
-                  && ${associations}.length > 1
-              % endif
-            "></app-delete-association>
+      <div class="collapse in" id="associated-routes">
+        <app-activity-filter activities="${activities}" documents="${associations}"></app-activity-filter>
+        <div class="associated-documents">
+          <div class="list-item" ng-repeat="doc in afilterCtrl.filter(${associations})" ng-class="{'new-item': doc['new']}">
+            <app-card app-card-doc="doc"></app-card>
+            % if type == 'routes':
+              <app-delete-association child-doctype="routes" parent-id="${document['document_id']}" child-id="doc.document_id"
+                ng-if="${test_association_rights(document)}
+                % if document['type'] == 'o':
+                    && ${associations}.length > 1
+                % endif
+              "></app-delete-association>
+            % endif
+          </div>
+          % if type == 'all_routes':
+            <%
+                fragment = '{0}={1}'.format(document['type'], document['document_id'])
+            %>
+            <div class="list-item">
+              <a class="vertical-align" ng-href="${request.route_path('routes_index')}#${fragment}">
+                <button class="gray-btn btn show-more" translate>show all</button>
+              </a>
+            </div>
           % endif
+          % if document['doctype'] == 'waypoints':
+            <div class="list-item vertical-align new-route" protected-url-btn
+                 url="${request.route_path('routes_add') + '#w=' + str(document['document_id'])}">
+              <a>
+                <button class="btn orange-btn" translate>add a new route to this waypoint</button>
+              </a>
+            </div>
+          % endif
+          ${generate_empty_list_items(5)}
         </div>
-        % if type == 'all_routes':
-          <%
-              fragment = '{0}={1}'.format(document['type'], document['document_id'])
-          %>
-          <div class="list-item">
-            <a class="vertical-align" ng-href="${request.route_path('routes_index')}#${fragment}">
-              <button class="gray-btn btn show-more" translate>show all</button>
-            </a>
-          </div>
-        % endif
-        % if document['doctype'] == 'waypoints':
-          <div class="list-item vertical-align new-route" protected-url-btn
-               url="${request.route_path('routes_add') + '#w=' + str(document['document_id'])}">
-            <a>
-              <button class="btn orange-btn" translate>add a new route to this waypoint</button>
-            </a>
-          </div>
-        % endif
-        ${generate_empty_list_items(5)}
       </div>
     </section>
 </%def>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -959,34 +959,45 @@ ul {
   }
 }
 
-.create-edit-document, .preferences {
-  .section {
-    .route-activities {
+.create-edit-document, .preferences, .activity-filter {
+  .route-activities {
+    @media @phone {
+      justify-content: space-between;
+    }
+    .activity {
+      width: 20%;
+      text-align: center;
+      cursor: pointer;
+      @media (max-width: @screen-md-min) {
+        width: 33%;
+      }
+    }
+    [class^="icon-"] {
+      font-size: 4em;
+      @media (max-width: @screen-sm-min) {
+        font-size: 3.5em;
+      }
+      @media (max-width: @screen-sm-max) {
+        font-size: 3.5em;
+      }
       @media @phone {
-        justify-content: space-between;
-      }
-      .activity {
-        width: 20%;
-        text-align: center;
-        cursor: pointer;
-        @media (max-width: @screen-md-min) {
-          width: 33%;
-        }
-      }
-      [class^="icon-"] {
-        font-size: 4em;
-        @media (max-width: @screen-sm-min) {
-          font-size: 3.5em;
-        }
-        @media (max-width: @screen-sm-max) {
-          font-size: 3.5em;
-        }
-        @media @phone {
-          font-size: 3em;
-        }
+        font-size: 3em;
       }
     }
   }
+}
+.activity-filter {
+  margin: 10px;
+  .route-activities {
+    .activity {
+      width: auto;
+    }
+  }
+}
+
+.activity-selected {
+  color: @C2C-orange !important;
+  transition: 0.2s ease-in-out;
 }
 
 .preferences, .mailinglists, .following {

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -628,11 +628,6 @@ input[type="radio"] {
   }
 }
 
-.activity-selected {
-  color: @C2C-orange !important;
-  transition: 0.2s ease-in-out;
-}
-
 #participants-group app-simple-search{
   margin-bottom: 0;
 }


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/523

The PR adds a set of activity buttons (depending on the activities of the associated routes) shown above the list of associated routes in a WP page. When a button is clicked a filter on the activity is applied to the list, showing only the routes with the given activity.

See https://github.com/c2corg/v6_ui/issues/523#issuecomment-237206666
https://docs.angularjs.org/api/ng/filter/filter

I have still a problem with this PR: the ``this`` context of the controller's filter function is set to ``Window`` instead of the controller instance itself, thus the selected activity property is not accessible in https://github.com/c2corg/v6_ui/blob/06e7954c6ecfaf21e58bbe745cb336ea745a9143/c2corg_ui/static/js/activityfilter.js#L64

Binding a context as in ``ng-repeat="doc in ${associations} | filter: afilterCtrl.filter.bind(afilterCtrl)"`` causes an angular error ("bind is disallowed here").