### PR TITLE
Micro-optimize translation strings

### DIFF
--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -24,12 +24,12 @@
             <span class="value" ng-if="::doc['height_diff_difficulties']">{{::doc['height_diff_difficulties']}}&nbsp;m</span>
           </span>
           <span class="slackline-length" ng-if="::doc['route_length'] && cardCtrl.hasActivity(['slacklining'])"
-            uib-tooltip="{{'Length'| translate}}" tooltip-append-to-body="true">
+            uib-tooltip="{{'length'| translate}}" tooltip-append-to-body="true">
             <span class="glyphicon glyphicon-resize-horizontal"></span>
             <span class="value">{{::doc['route_length']}}&nbsp;m</span>
           </span>
           <span class="slackline-height" ng-if="::doc['slackline_height']"
-                uib-tooltip="{{'Height'| translate}}" tooltip-append-to-body="true">
+                uib-tooltip="{{'height'| translate}}" tooltip-append-to-body="true">
             <span class="glyphicon glyphicon-resize-vertical"></span>
             <span class="value">{{::doc['slackline_height']}}&nbsp;m</span>
           </span>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -157,12 +157,12 @@ updating_doc = route_id and route_lang
         </section>
 
         <section class="section slacklining" ng-if="editCtrl.hasActivity(['slacklining'])">
-          <h2 class="heading show-phone"><span translate>Slacklining</span></h2>
+          <h2 class="heading show-phone"><span translate>slacklining</span></h2>
           <div class="content" id="numbers-edit">
 
             ## LENGTH
             <div id="route_length-group" class="data half form-group" ng-class="{ 'has-error': editForm.route_length.$touched && editForm.route_length.$invalid,'has-success': route.route_length }">
-              <label translate>Length</label>
+              <label translate>length</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="route_length" ng-model="route.route_length" class="form-control" />
                 <span class="input-group-addon">m</span>
@@ -176,7 +176,7 @@ updating_doc = route_id and route_lang
 
             ## HEIGHT
             <div id="route_slackline_height-group" class="data half form-group" ng-class="{ 'has-error': editForm.slackline_height.$touched && editForm.slackline_height.$invalid,'has-success': route.slackline_height }">
-              <label translate>Height</label>
+              <label translate>height</label>
               <div class="input-group">
                 <input type="number" min="0" minlength="1" name="slackline_height" ng-model="route.slackline_height" class="form-control" />
                 <span class="input-group-addon">m</span>

--- a/c2corg_ui/templates/route/filters.html
+++ b/c2corg_ui/templates/route/filters.html
@@ -45,7 +45,7 @@ activities = [activity for activity in activities if activity != 'paragliding']
           ${add_multiselect('sltyp', slackline_types)}
         </div>
         <div class="col-xs-12 col-sm-6 filter">
-          <label translate>Length</label><br>
+          <label translate>length</label><br>
           <app-slider filter="rlen" filters-list="filtersCtrl.filters" max="2000" step="10" unit="m"></app-slider>
         </div>
       </div>

--- a/c2corg_ui/templates/route/helpers/view.html
+++ b/c2corg_ui/templates/route/helpers/view.html
@@ -177,7 +177,7 @@ from c2corg_ui.templates.utils import get_route_gear_articles, format_length
         % endif
 
         % if route.get('slackline_height'):
-        <p><span translate class="value-title">Height</span>: <b class="value">${route['slackline_height']} m</b></p>
+        <p><span translate class="value-title">height</span>: <b class="value">${route['slackline_height']} m</b></p>
         % endif
 
         % if route.get('mtb_height_diff_portages'):


### PR DESCRIPTION
See https://github.com/c2corg/v6_ui/issues/1543#issuecomment-301148200

> Concerning the translation strings, I have noticed there were some (nearly) duplicates introduced by this PR. For instance "Height" or "Length" ("height" or "length" were already available) or "slackline" / "Slackline". I think the translations are capitalized anyway, then are they really needed?

For @asaunier... :)