### PR TITLE
Fix escaping in urls

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -43,6 +43,9 @@ def _get_markdown_parser():
 def _get_bbcode_parser():
     global _bbcode_parser
     if not _bbcode_parser:
+        # prevent that BBCode parser escapes again (the Markdown parser does
+        # this already)
+        bbcode.Parser.REPLACE_ESCAPE = ()
         _bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
     return _bbcode_parser
 

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -1,9 +1,10 @@
 <h2>Title 1</h2>
 <p>Some <strong>bold text</strong> and a <a href="/waypoints/12345/fr/some-slug">wiki link</a> before <a href="/whatever">another one</a> that follows.</p>
 <h3>Title 2</h3>
-<p>Here is a list:</p>
+<p>Here is a 'list':</p>
 <ul>
 <li>a <a href="http://example.com">standard link</a></li>
+<li>another <a href="https://httpbin.org/get?value1=1&amp;value2=2">link</a></li>
 <li>some <em>italic âccentuated content</em></li>
 </ul>
 <p>Another list:</p>
@@ -11,3 +12,4 @@
 <li><a href="/routes/56730">Eperon de la Tournette</a></li>
 <li><a href="/routes/49571">Versant W - Couloir Saudan</a></li>
 </ul>
+<p>"Slope": &gt; 30° and &lt; 35°</p>

--- a/c2corg_ui/tests/format/test/sample.md
+++ b/c2corg_ui/tests/format/test/sample.md
@@ -3,12 +3,15 @@ Some [b]bold text[/b] and a [[waypoints/12345/fr/some-slug|wiki link]] before [[
 
 ### Title 2
 
-Here is a list:
+Here is a 'list':
 
 * a [url=http://example.com]standard link[/url]
+* another [url=https://httpbin.org/get?value1=1&value2=2]link[/url]
 * some [i]italic âccentuated content[/i]
 
 Another list:
 
 - [[routes/56730|Eperon de la Tournette]]
 - [[routes/49571|Versant W - Couloir Saudan]]
+
+"Slope": > 30° and < 35°

--- a/c2corg_ui/tests/format/test_format.py
+++ b/c2corg_ui/tests/format/test_format.py
@@ -1,9 +1,9 @@
 import os
 import unittest
-import bbcode
 import markdown
 import json
 
+from c2corg_ui.format import _get_bbcode_parser
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
 from c2corg_ui.tests import read_file
 
@@ -17,7 +17,7 @@ class TestFormat(unittest.TestCase):
         ]
         self.markdown_parser = markdown.Markdown(output_format='xhtml5',
                                                  extensions=extensions)
-        self.bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+        self.bbcode_parser = _get_bbcode_parser()
 
     def test_all(self):
         def do_test(id, markdown, expected):


### PR DESCRIPTION
URLs like `[url=https://httpbin.org/get?value1=1&value2=2]link[/url]` are converted to `<a href="https://httpbin.org/get?value1=1&amp;amp;value2=2">link</a>` (note the `&amp;amp;`), while it should be `<a href="https://httpbin.org/get?value1=1&amp;value2=2">link</a>`.

This PR prevents that the BBCode parser escapes characters again, that the Markdown parser already has escaped.