### PR TITLE
Fix markdown links

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -2,6 +2,7 @@ import bbcode
 import markdown
 import html
 
+from c2corg_ui.format.autolink import AutoLinkExtension
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
 from c2corg_ui.format.img import C2CImageExtension
 from c2corg_ui.format.video import C2CVideoExtension
@@ -34,6 +35,7 @@ def _get_markdown_parser():
             C2CWarningExtension(),
             Nl2BrExtension(),
             TocExtension(marker='[toc]', baselevel=2),
+            AutoLinkExtension()
         ]
         _markdown_parser = markdown.Markdown(output_format='xhtml5',
                                              extensions=extensions)
@@ -46,7 +48,8 @@ def _get_bbcode_parser():
         # prevent that BBCode parser escapes again (the Markdown parser does
         # this already)
         bbcode.Parser.REPLACE_ESCAPE = ()
-        _bbcode_parser = bbcode.Parser(escape_html=False, newline='\n')
+        _bbcode_parser = bbcode.Parser(
+            escape_html=False, newline='\n', replace_links=False)
     return _bbcode_parser
 
 

--- a/c2corg_ui/format/autolink.py
+++ b/c2corg_ui/format/autolink.py
@@ -1,0 +1,38 @@
+import markdown
+from markdown.inlinepatterns import Pattern
+
+EXTRA_AUTOLINK_RE = r'(?<!"|>)(?<!\[url=)((https?://|www)[-\w./#?%=&]+)'
+
+
+class AutoLinkPattern(Pattern):
+
+    def handleMatch(self, m):  # noqa
+        el = markdown.util.etree.Element('a')
+        if m.group(2).startswith('http'):
+            href = m.group(2)
+        else:
+            href = 'http://%s' % m.group(2)
+        el.set('href', href)
+        el.text = m.group(2)
+        return el
+
+
+class AutoLinkExtension(markdown.Extension):
+    """
+    Make links without tag clickable.
+
+    There's already an inline pattern called autolink which handles
+    <http://www.google.com> type links. So lets call this extra_autolink.
+
+    Based on: http://stackoverflow.com/a/1665440/119937
+    """
+
+    def extendMarkdown(self, md, md_globals):  # noqa
+        md.inlinePatterns.add(
+            'extra_autolink',
+            AutoLinkPattern(EXTRA_AUTOLINK_RE, self),
+            '<automail')
+
+
+def makeExtension(configs=[]):  # noqa
+    return AutoLinkExtension(configs=configs)

--- a/c2corg_ui/tests/format/test/links.json
+++ b/c2corg_ui/tests/format/test/links.json
@@ -1,5 +1,5 @@
 [{
   "id":"wikilinks",
-  "markdown":"Some text and a [[waypoints/12345/fr/some-slug|wiki link]] before [[/whatever|another one]] that follows.",
+  "text":"Some text and a [[waypoints/12345/fr/some-slug|wiki link]] before [[/whatever|another one]] that follows.",
   "expected":"<p>Some text and a <a href=\"/waypoints/12345/fr/some-slug\">wiki link</a> before <a href=\"/whatever\">another one</a> that follows.</p>"
 }]

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -5,6 +5,9 @@
 <ul>
 <li>a <a href="http://example.com">standard link</a></li>
 <li>another <a href="https://httpbin.org/get?value1=1&amp;value2=2">link</a></li>
+<li>and a <a href="https://example.com">markdown link</a></li>
+<li><a href="http://www.example.com">http://www.example.com</a></li>
+<li>and also a link without tag: <a href="https://example.com">https://example.com</a></li>
 <li>some <em>italic âccentuated content</em></li>
 </ul>
 <p>Another list:</p>

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -1,10 +1,10 @@
-<h2>Title 1</h2>
+<h3 id="title-1">Title 1</h3>
 <p>Some <strong>bold text</strong> and a <a href="/waypoints/12345/fr/some-slug">wiki link</a> before <a href="/whatever">another one</a> that follows.</p>
-<h3>Title 2</h3>
+<h4 id="title-2">Title 2</h4>
 <p>Here is a 'list':</p>
 <ul>
 <li>a <a href="http://example.com">standard link</a></li>
-<li>another <a href="https://httpbin.org/get?value1=1&amp;value2=2">link</a></li>
+<li>another <a href="https://httpbin.org/get?value1=1&value2=2">link</a></li>
 <li>and a <a href="https://example.com">markdown link</a></li>
 <li><a href="http://www.example.com">http://www.example.com</a></li>
 <li>and also a link without tag: <a href="https://example.com">https://example.com</a></li>

--- a/c2corg_ui/tests/format/test/sample.md
+++ b/c2corg_ui/tests/format/test/sample.md
@@ -7,6 +7,9 @@ Here is a 'list':
 
 * a [url=http://example.com]standard link[/url]
 * another [url=https://httpbin.org/get?value1=1&value2=2]link[/url]
+* and a [markdown link](https://example.com)
+* <http://www.example.com>
+* and also a link without tag: https://example.com
 * some [i]italic âccentuated content[/i]
 
 Another list:

--- a/c2corg_ui/tests/format/test_format.py
+++ b/c2corg_ui/tests/format/test_format.py
@@ -4,6 +4,7 @@ import markdown
 import json
 
 from c2corg_ui.format import _get_bbcode_parser
+from c2corg_ui.format.autolink import AutoLinkExtension
 from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
 from c2corg_ui.tests import read_file
 
@@ -13,7 +14,8 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 class TestFormat(unittest.TestCase):
     def setUp(self):  # noqa
         extensions = [
-            C2CWikiLinkExtension(),
+            AutoLinkExtension(),
+            C2CWikiLinkExtension()
         ]
         self.markdown_parser = markdown.Markdown(output_format='xhtml5',
                                                  extensions=extensions)

--- a/c2corg_ui/tests/format/test_format.py
+++ b/c2corg_ui/tests/format/test_format.py
@@ -1,11 +1,8 @@
 import os
 import unittest
-import markdown
 import json
 
-from c2corg_ui.format import _get_bbcode_parser
-from c2corg_ui.format.autolink import AutoLinkExtension
-from c2corg_ui.format.wikilinks import C2CWikiLinkExtension
+from c2corg_ui.format import parse_code, configure_parsers
 from c2corg_ui.tests import read_file
 
 base_path = os.path.dirname(os.path.abspath(__file__))
@@ -13,18 +10,11 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 
 class TestFormat(unittest.TestCase):
     def setUp(self):  # noqa
-        extensions = [
-            AutoLinkExtension(),
-            C2CWikiLinkExtension()
-        ]
-        self.markdown_parser = markdown.Markdown(output_format='xhtml5',
-                                                 extensions=extensions)
-        self.bbcode_parser = _get_bbcode_parser()
+        configure_parsers({'api_url': 'https://api.camptocamp.org/'})
 
     def test_all(self):
-        def do_test(id, markdown, expected):
-            result = self.markdown_parser.convert(markdown)
-            result = self.bbcode_parser.format(result)
+        def do_test(id, text, expected):
+            result = parse_code(text)
             self.assertEqual(result, expected, id)
 
         test_path = os.path.join(base_path, 'test')
@@ -33,9 +23,9 @@ class TestFormat(unittest.TestCase):
             file_path = os.path.join(test_path, file)
             if os.path.isfile(file_path):
                 if file.endswith(".md"):
-                    markdown = read_file(file_path)
+                    text = read_file(file_path)
                     expected = read_file(file_path.replace(".md", ".html"))
-                    do_test(file, markdown, expected)
+                    do_test(file, text, expected)
 
                 elif file.endswith(".json"):
                     tests = json.loads(read_file(file_path))


### PR DESCRIPTION
Markdown links (`[Link](http://www.link.com)`) were not replaced properly. After the Markdown parser had inserted the link (`<a href="...">...</a>`), the BBCode parser created again a link for the part inside `href="..."`.

This PR proposes not to replace links without tag with the BBCode parser, instead to do it with a Markdown extension.

See also: https://github.com/c2corg/v6_ui/issues/1576#issuecomment-290510655