### PR TITLE
Fix incorrect positioning of filters buttons

### DIFF
--- a/less/filters.less
+++ b/less/filters.less
@@ -292,6 +292,7 @@ form[app-search-filters] {
 .more-filters-btn-container {
   .flex();
   justify-content: center;
+  flex-flow: wrap row;
   padding-top: 5px;
   transition: .2s;
   @media @phone {

--- a/less/stickyfilters.less
+++ b/less/stickyfilters.less
@@ -5,7 +5,6 @@
   font-size: 1.4em;
   z-index: 29;
   top: @page-header-height + @page-main-title-height;
-  height: @page-main-title-height + 10;
   left: @menu-width;
   padding-top: 2px !important;
   background-color: #DDDDDD;


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1622

See the explanations and screenshots at https://github.com/c2corg/v6_ui/issues/1622#issuecomment-302391613

Currently this PR makes the buttons in the primary filters section wrap to a new line if all 3 are shown and the screen width is too small (instead of overflowing and causing a horizontal scroll bar).

Side-effect to handle: when scrolling down in a mobile screen, the button are made "sticky" at the top of the screen but remain on 2 lines:
![capture du 2017-05-19 19-23-31](https://cloud.githubusercontent.com/assets/1192331/26259558/dcd99362-3cc9-11e7-885b-af477b743fc0.png)

Should I "simply" make the gray background bigger so that both lines are covered (but then the screen height available to show the cards is reduced)? Or perhaps we could use reduced button titles to make sure the buttons are rendered on a single line, at least when "sticky"?

