### PR TITLE
Add link to help article in edit form for slackline documents

### DIFF
--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -195,6 +195,15 @@ updating_doc = route_id and route_lang
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="route.slackline_type"></span>
             </div>
 
+            ## SLACKLINING HELP
+            <div class="form-group data half">
+              <label>
+                  <span class="glyphicon glyphicon-question-sign need-help-icon"></span>
+                  <span translate>Need help?</span>
+              </label>
+              <a href="/articles/890427" target="_blank" translate>How does this work?</a>
+            </div>
+
           </div>
         </section>
 

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -277,6 +277,15 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
               </ul>
             </div>
 
+            ## SLACKLINE HELP
+            <div class="form-group" ng-if="type == 'slackline_spot'">
+              <label>
+                  <span class="glyphicon glyphicon-question-sign need-help-icon"></span>
+                  <span translate>Need help?</span>
+              </label>
+              <a href="/articles/890427" target="_blank" translate>How does this work?</a>
+            </div>
+
             <div class="data half" ng-if="['climbing_outdoor', 'climbing_indoor', 'slackline_spot'].indexOf(type) > -1">
 
               ## CLIMBING OUT TYPES

--- a/less/documentedit.less
+++ b/less/documentedit.less
@@ -438,6 +438,10 @@
     font-weight: bold;
     text-align: center;
   }
+
+  .need-help-icon {
+    font-size: 120%;
+  }
 }
 
 .section {


### PR DESCRIPTION
The first feedback that I got from people trying to create new topos is, that they were totally lost. I created an article (https://www.camptocamp.org/articles/890427), that a friend also translated to French, to explain a bit the document structure and to give guidance.

I would like to show a link to this article if 'slackline' was selected as activity for a route, or if 'slackline_spot' is selected for a waypoint.

![c2c-help](https://user-images.githubusercontent.com/266474/26846986-20dd9b1a-4b04-11e7-8969-007717cd751a.png)
