### PR TITLE
Add a spinner when the profile page data are loading

### DIFF
--- a/c2corg_ui/templates/profile/view.html
+++ b/c2corg_ui/templates/profile/view.html
@@ -43,7 +43,7 @@
 <section class="view-details-section">
 
   <div app-user-profile="${user_id}" app-user-profile-lang="${lang}">
-    <div id="user-profile-data"></div>
+    <div id="user-profile-data" app-loading></div>
   </div>
 
   ${show_other_langs_links('profiles', profile, other_langs)}


### PR DESCRIPTION
I have noticed that when loading a profile page, if the API response is a bit long, nothing tells the visitor that something is going on => this PR simply adds a loading spinner when loading profile data until the content is displayed.