### PR TITLE
Ensure consistent margin with feed images

### DIFF
--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -50,17 +50,17 @@
       </span>
     </p>
 
-    <div class="flex wrap-row">
+    <div class="details flex wrap-row">
       <div ng-if="::doc.image1" class="images flex">
-        <a class="big-image thumbnail flex" ng-href="/images/{{::doc.image1.document_id}}/{{::doc.image1.locales[0].lang}}"
+        <a class="thumbnail flex" ng-href="/images/{{::doc.image1.document_id}}/{{::doc.image1.locales[0].lang}}"
            ng-style="(!doc.image2 && !doc.image3) && {'width': '100%'}">
           <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image1.filename, 'MI')}})"></span>
         </a>
-        <a class="small-image thumbnail flex" ng-href="/images/{{::doc.image2.document_id}}/{{::doc.image2.locales[0].lang}}"
+        <a class="thumbnail flex" ng-href="/images/{{::doc.image2.document_id}}/{{::doc.image2.locales[0].lang}}"
          ng-if="::doc.image2">
           <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image2.filename, 'MI')}})"></span>
         </a>
-        <a class="small-image thumbnail flex" ng-href="/images/{{::doc.image3.document_id}}/{{::doc.image3.locales[0].lang}}"
+        <a class="thumbnail flex" ng-href="/images/{{::doc.image3.document_id}}/{{::doc.image3.locales[0].lang}}"
           ng-if="::doc.image3">
           <span class="image" style="background-image: url({{feedCtrl.createImageUrl(doc.image3.filename, 'MI')}})"></span>
         </a>

--- a/less/feed.less
+++ b/less/feed.less
@@ -23,6 +23,9 @@
       margin-top: 0;
     }
   }
+  .details {
+    margin-left: -5px;
+  }
   .images {
     height: 150px;
     min-width: 300px;
@@ -33,9 +36,10 @@
     }
     margin-bottom: 6px;
     margin-top: 6px;
+    margin-left: 0;
     order: 1;
     flex: 1 1 400px;
-    
+
     .thumbnail {
       overflow: hidden;
       border: 2px solid rgba(88, 150, 165, .2);
@@ -53,29 +57,19 @@
         transform: scale(1.1);
       }
     }
-    
+
     a {
       float: left;
       &:nth-child(2) {
         margin-bottom: 5px;
       }
-      &.big-image {
-        flex:1;
-        max-width: 200px;
-        height: 150px;
-        @media @phone {
-          height: 100px;
-        } 
+      flex:1;
+      max-width: 200px;
+      height: 150px;
+      @media @phone {
+        height: 100px;
       }
-      &.small-image {
-        flex:1;
-        margin-left: 5px;
-        height: 150px;
-        max-width: 200px;
-        @media @phone {
-          height: 100px;
-        }
-      }
+      margin-left: 5px;
     }
   }
   .feed-list {
@@ -102,12 +96,16 @@
     border-radius: 10px;
     width: 80%;
     @media @big {
-      width: 60%;    
+      width: 60%;
     }
     transition: .3s;
     flex-direction: column;
+    .list-item {
+      margin-left: 5px;
+    }
     &:first-of-type .list-item {
       margin-top: 13px;
+      margin-left: 0;
     }
     /*left triangle*/
     &:before {


### PR DESCRIPTION
Related to #1691.

Was:
![chrome3](https://user-images.githubusercontent.com/2234024/27134453-e94985e8-5115-11e7-924b-31bb264ed1a6.png)

Now:
![chrome4](https://user-images.githubusercontent.com/2234024/27134489-08779b1c-5116-11e7-97b5-661140c1f59b.png)


Off course, margin is consistent when images are positioned below:
![chrome5](https://user-images.githubusercontent.com/2234024/27134495-0b2dedde-5116-11e7-9245-d1394a4bd0c1.png)
