### PR TITLE
ensure text is placed under icon

### DIFF
--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -1,12 +1,17 @@
 @import "variables.less";
 
-.view-details-associations .section,  .view-details-informations, #document-informations, .name-icon,
+.view-details-associations .section,  .view-details-informations, #document-informations,
 .view-details-associations .associated-documents {
   .flex();
   &.collapse:not(.in) {
     display: none;
   }
   flex-flow: wrap row;
+}
+
+.name-icon {
+  display: flex;
+  flex-flow: wrap column;
 }
 
 .view-details-title {


### PR DESCRIPTION
Depending on available space, text was sometime put on the right, or on the bottom.
We now ensure the text is displayed on the bottom.
This was never the case on screen media, but could happen on print.

Was e.g.
![c2c8](https://user-images.githubusercontent.com/2234024/27327563-3901d520-55af-11e7-815d-a05d0d16af9c.png)

Now
![c2c7](https://user-images.githubusercontent.com/2234024/27327561-36d5a7c2-55af-11e7-905c-427d5693745a.png)
