### PR TITLE
Fine-tune link parser regexp

### DIFF
--- a/c2corg_ui/format/autolink.py
+++ b/c2corg_ui/format/autolink.py
@@ -1,7 +1,9 @@
 import markdown
 from markdown.inlinepatterns import Pattern
 
-EXTRA_AUTOLINK_RE = r'(?<!"|>)(?<!\[url=)((https?://|www)[-\w./#?%=&]+)'
+# Only catch strings starting with http://, https:// or www
+# but not preceeded by a " or a > (link is already done)
+EXTRA_AUTOLINK_RE = r'(?<!"|>)((https?://|(?<!http://)(?<!https://)www)[-\w./#?%=&]+)'  # noqa
 
 
 class AutoLinkPattern(Pattern):

--- a/c2corg_ui/tests/format/test/links.json
+++ b/c2corg_ui/tests/format/test/links.json
@@ -2,4 +2,24 @@
   "id":"wikilinks",
   "text":"Some text and a [[waypoints/12345/fr/some-slug|wiki link]] before [[/whatever|another one]] that follows.",
   "expected":"<p>Some text and a <a href=\"/waypoints/12345/fr/some-slug\">wiki link</a> before <a href=\"/whatever\">another one</a> that follows.</p>"
+},{
+  "id":"autolink1",
+  "text":"A raw URL http://www.example.com in some text",
+  "expected":"<p>A raw URL <a href=\"http://www.example.com\">http://www.example.com</a> in some text</p>"
+},{
+  "id":"autolink2",
+  "text":"A raw URL https://www.example.com in some text",
+  "expected":"<p>A raw URL <a href=\"https://www.example.com\">https://www.example.com</a> in some text</p>"
+},{
+  "id":"autolink3",
+  "text":"A raw URL www.example.com in some text",
+  "expected":"<p>A raw URL <a href=\"http://www.example.com\">www.example.com</a> in some text</p>"
+},{
+  "id":"autolink4",
+  "text":"Already converted links such as <a href=\"http://www.example.com\">a link</a> are not impacted.",
+  "expected":"<p>Already converted links such as <a href=\"http://www.example.com\">a link</a> are not impacted.</p>"
+},{
+  "id":"autolink5",
+  "text":"Even that one <a href=\"http://www.example.com\">www.example.com</a> is not impacted.",
+  "expected":"<p>Even that one <a href=\"http://www.example.com\">www.example.com</a> is not impacted.</p>"
 }]


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1576

With https://github.com/c2corg/v6_ui/pull/1661 @tsauerwein has made raw URLs clickable (even if not embedded in a markdown or bbcode tag).
There are still some cases resulting in a conflict though.

For instance: https://www.camptocamp.org/routes/56781/fr/cornettes-de-bise-l-ami-numero-3
![capture du 2017-06-20 16-42-59](https://user-images.githubusercontent.com/1192331/27339256-9917ec2e-55d7-11e7-9b78-e5324af8b46f.png)
The source document code being:
```
- Topo et tracé sur [url=http://www.chablais-grimpe.com/bise/bise_voiesatmosphere.php?f=0]Chablais Grimpe[/url]
```
Please note that the link is parsed as expected if the URL has no "www" in it.

The problem comes from the autolink regexp: https://github.com/c2corg/v6_ui/blob/815ebbd1bac4c1883ad18c38782810f8124f60c7/c2corg_ui/format/autolink.py#L4
```
EXTRA_AUTOLINK_RE = r'(?<!"|>)(?<!\[url=)((https?://|www)[-\w./#?%=&]+)'
```
* as expected it does not catch ``<a href="http://www.example.com">www.example.com</a>``
* but it catches ``<a href="http://www.example.com">http://www.example.com</a>`` and the second ``www.example.com`` is understood as a raw URL.

This PR improves the regexp to avoid this behaviour. I have also removed the test about the leading ``[url=`` because since the BBcode parser is run before the Markdown parser, bbcode tags such as ``[url=`` have already been converted.