### PR TITLE
Rationalize slick options

### DIFF
--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -300,7 +300,7 @@ app.ViewDetailsController.prototype.initPhotoswipe_ = function() {
  * @private
  */
 app.ViewDetailsController.prototype.initSlickGallery_ = function() {
-  $('.photos').slick({slidesToScroll: 3, dots: false});
+  $('.photos').slick({});
 };
 
 

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -151,7 +151,7 @@
     </div>
   % endif
 </%def>
-  
+
 <%def name="show_locale_title(locale, is_tab_title=False)">\
   <%
       title = get_title(locale)
@@ -857,7 +857,7 @@
 
 <%def name="get_image_gallery()">\
   <div class="view-details-photos col-xs-12 tab description" ng-show="detailsCtrl.documentService.document.associations.images.length > 0">
-    <div class="photos" data-slick='{"variableWidth": true, "infinite": false, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
+    <div class="photos" data-slick='{"slidesToScroll": 2, "variableWidth": true, "infinite": false, "focusOnSelect": false, "lazyLoad": "progressive"}'></div>
   </div>
 </%def>
 


### PR DESCRIPTION
do not use options in both data-slick and .slick({})

I also configured it to scroll for 2 slides (2 slides are displayed on mobile)

Strangely, I get weird effects (only one image dispalyed on screen) when

* configuring slick through JS
* trying to define responsive options in data-slick attribute