### PR TITLE
Allow to disable comments in outings or xreports

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -861,7 +861,7 @@
   </div>
 </%def>
 
-<%def name="get_comments()">\
+<%def name="get_comments(disable=False)">\
   <div class="view-details-comments col-xs-12 comments">
     <h3 class="heading comments"
         data-toggle="collapse" data-target="#discourse-comments"
@@ -870,17 +870,23 @@
       <span translate>Comments</span>
       <span class="glyphicon glyphicon-menu-down"></span>
     </h3>
-    <section id="discourse-comments" class="collapse in" ng-init="detailsCtrl.getComments()">
-      <div ng-if="detailsCtrl.documentService.document.topic_id == null" class="no-thread">
-        <p class="text-center" translate>No thread yet?</p>
-        <p class="text-center" translate
-            ng-if="!userCtrl.auth.isAuthenticated()">Log in to post the first comment</p>
-        <button class="btn gray-btn"
-            ng-if="userCtrl.auth.isAuthenticated()"
-            ng-click="detailsCtrl.createTopic()"
-            translate>Post the first comment</button>
-      </div>
-    </section>
+    % if disable:
+      <section id="discourse-comments" class="collapse in">
+        <p class="text-center" translate>Comments are disabled.</p>
+      </section>
+    % else:
+      <section id="discourse-comments" class="collapse in" ng-init="detailsCtrl.getComments()">
+        <div ng-if="detailsCtrl.documentService.document.topic_id == null" class="no-thread">
+          <p class="text-center" translate>No thread yet?</p>
+          <p class="text-center" translate
+              ng-if="!userCtrl.auth.isAuthenticated()">Log in to post the first comment</p>
+          <button class="btn gray-btn"
+              ng-if="userCtrl.auth.isAuthenticated()"
+              ng-click="detailsCtrl.createTopic()"
+              translate>Post the first comment</button>
+        </div>
+      </section>
+    % endif
   </div>
 </%def>
 

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -528,7 +528,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## PARTICIPANTS
-            <div id="participants-group" class="form-group  full" ng-class="{'has-success': outing.locales[0]['participants']}">
+            <div id="participants-group" class="form-group full" ng-class="{'has-success': outing.locales[0]['participants']}">
               <label translate>participants</label>
               <div class="input-group">
                 <input type="text"  ng-model="outing.locales[0]['participants']" class="form-control" />
@@ -555,9 +555,16 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## COMMENT
-            <div class=" full form-group">
+            <div class="full form-group">
               <label translate>personal comments</label>
               <textarea app-markdown-editor class="form-control description" placeholder="{{'write your comments' | translate}}" ng-model="outing.locales[0]['description']"></textarea>
+            </div>
+
+            ## COMMENTS MANAGEMENT
+            <div class="form-group half">
+              <label translate>disable_comments</label>
+              <input type="checkbox" ng-model="outing.disable_comments">
+              <span ng-click="editCtrl.pushToArray(outing, 'disable_comments', !outing.disable_comments, $event)" translate>If checked, comments cannot be posted or read.</span>
             </div>
 
           </div>

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -164,7 +164,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
       </span>
     </div>
 
-    ${get_comments()}
+    ${get_comments(outing.get('disable_comments'))}
 
     ${show_float_buttons(outing, lang, other_langs, missing_langs)}
   % endif

--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -491,13 +491,18 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].modifications"></span>
             </div>
 
-			
-			
             ## other_comments
             <div id="other_comments-group" class="form-group full">
               <label translate>other_comments</label>
               <textarea app-markdown-editor name="other_comments" ng-model="xreport.locales[0].other_comments" class="form-control" placeholder="{{'Briefly describe any injuries. Comments that do not fit into any other fields can be entered here.' | translate}}"></textarea>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.locales[0].other_comments"></span>
+            </div>
+
+            ## COMMENTS MANAGEMENT
+            <div class="form-group half">
+              <label translate>disable_comments</label>
+              <input type="checkbox" ng-model="xreport.disable_comments">
+              <span ng-click="editCtrl.pushToArray(xreport, 'disable_comments', !xreport.disable_comments, $event)" translate>If checked, comments cannot be posted or read.</span>
             </div>
 
           </div>

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -160,7 +160,7 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
       </span>
     </div>
 
-    ${get_comments()}
+    ${get_comments(xreport.get('disable_comments'))}
 
     ${show_float_buttons(xreport, lang, other_langs, missing_langs)}
   % endif

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ gaiohttp-websocket==0.1.1
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@d8ce59a
+git+https://github.com/c2corg/v6_common.git@ca4cb94
 
 -e .


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1515
Requires https://github.com/c2corg/v6_common/pull/57 and https://github.com/c2corg/v6_api/pull/673

[for outings and xreports only]

The PR adds a ``disable_comments`` attribute that can be checked/unchecked in the outings/xreports editing forms:
![capture du 2017-06-21 16-04-29](https://user-images.githubusercontent.com/1192331/27388280-5779d0e2-569b-11e7-85d5-33c8b055ca0a.png)

If checked, the comments section (even though comments have been posted in the meantime) is replaced by "Comments are disabled.":
![capture du 2017-06-21 16-05-09](https://user-images.githubusercontent.com/1192331/27388360-8bd54a4c-569b-11e7-9342-dba6a9c71630.png)

If not checked comments are shown as usual.


