### PR TITLE
Video extension should come before autolink extension

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -30,12 +30,12 @@ def _get_markdown_parser():
         extensions = [
             C2CWikiLinkExtension(),
             C2CImageExtension(api_url=_parsers_settings['api_url']),
-            C2CVideoExtension(),
             C2CImportantExtension(),
             C2CWarningExtension(),
             Nl2BrExtension(),
             TocExtension(marker='[toc]', baselevel=2),
             AutoLinkExtension(),
+            C2CVideoExtension(),
             C2CLTagExtension(),
         ]
         _markdown_parser = markdown.Markdown(output_format='xhtml5',

--- a/c2corg_ui/format/video.py
+++ b/c2corg_ui/format/video.py
@@ -21,7 +21,7 @@ class C2CVideoExtension(Extension):
         pattern = C2CVideo(VIDEO_RE)
         pattern.md = md
         # append to end of inline patterns
-        md.inlinePatterns.add('c2cvideo', pattern, "<not_strong")
+        md.inlinePatterns.add('c2cvideo', pattern, "<extra_autolink")
 
 
 class C2CVideo(Pattern):


### PR DESCRIPTION
@fbunoz was right: the autolink extension was eating the video tag.
This PR fixes it by applying the video extension before the autolink.

@asaunier I don't know how to run the autolink tests. Could you check it is still working appropriately?