### PR TITLE
Rework sidemenu

### DIFF
--- a/c2corg_ui/static/js/style/sidemenu.js
+++ b/c2corg_ui/static/js/style/sidemenu.js
@@ -6,17 +6,27 @@ goog.require('app');
  * @export
  */
 app.sidemenu = function() {
-  $('.menu-open-close').click(function() {
-    if ($('#sidemenu').hasClass('menu-open')) {
-      $('#sidemenu').removeClass('menu-open');
-      $('#sidemenu').addClass('menu-closed');
+  /* handle sidebar hiding */
+  var body = $('body');
+  var content = $('.page-content');
+
+  $('.menu-open-close').on('click', function() {
+    body.toggleClass('menu-toggled');
+    if (body.hasClass('menu-toggled')) {
+      content.prepend('<div id="content-toggled">');
     } else {
-      $('#sidemenu').removeClass('menu-closed');
-      $('#sidemenu').addClass('menu-open');
+      $('#content-toggled').remove();
     }
   });
 
-  $('.menu-open-close').click(function() {
-    $('.menu-open-close.menu').toggleClass('is-active');
+  $(window).resize(function() {
+    if (window.innerWidth >= 1100 && body.hasClass('menu-toggled')) {
+      body.toggleClass('menu-toggled', false);
+      $('#content-toggled').remove();
+    }
+  });
+  content.on('click', '#content-toggled', function() {
+    body.toggleClass('menu-toggled', false);
+    $('#content-toggled').remove();
   });
 };

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -51,14 +51,14 @@ closure_library_path = settings.get('closure_library_path')
   <body class="on-load loading">
     <%include file="sidemenu.html"/>
     <img src="${request.static_path('c2corg_ui:static/img/loading.gif')}" class="loading-gif">
-    <a href="${request.route_path('index')}" title="{{'Back to homepage'|translate}}" class="logo header">
-      <img src="${request.static_path('c2corg_ui:static/img/logo2.svg')}" alt="Camptocamp.org"/>
-    </a>
     <main class="page-content">
       ${self.body()}
     </main>
     <div class="page-header">
-      <button class="btn btn-default menu-open-close header"><span class="glyphicon glyphicon-align-justify"></span></button>
+      <button class="btn btn-default menu-open-close header"><span class="glyphicon glyphicon-menu-hamburger"></span></button>
+      <a href="${request.route_path('index')}" title="{{'Back to homepage'|translate}}" class="logo header">
+        <img src="${request.static_path('c2corg_ui:static/img/logo2.svg')}" alt="Camptocamp.org"/>
+      </a>
       <div class="quick-search">
         <app-simple-search app-simple-search-standard="true" dataset="wrcb"></app-simple-search>
       </div>

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -533,8 +533,8 @@ app-simple-search {
   top: 0;
   margin-bottom: 0;
   border: 0;
-  padding-bottom: 6px;
-  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-top: 6px;
   z-index: 33;
 
   @media @phone {
@@ -543,6 +543,7 @@ app-simple-search {
 
   .btn {
     border: none;
+    min-height: 35px;
   }
 
   .search {
@@ -669,13 +670,8 @@ app-simple-search {
   margin-top: @page-header-height;
   margin-left: @menu-width;
 
-  @media @tablet {
-    margin-left: @menu-width-tablet;
-    margin-top:  9px;
-  }
-  @media @phone {
+  @media (max-width: @tablet-max) {
     margin-left: 0;
-    margin-top: @page-header-height;
   }
 
   .archive-data {

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -19,7 +19,7 @@
 }
 
 /* always shown when greater than grid breakpoint */
-@media (min-width: @tablet-max) {
+@media (min-width: (@tablet-max + 1)) {
   #sidemenu {
     transform: translate3d(0, 0, 0) !important;
   }
@@ -220,44 +220,25 @@ body.menu-toggled #content-toggled {
     left: 7px;
     right: 7px;
     height: 4px;
-    background: @darkgray;
-    transition: transform 0.3s;
+    background: @C2C-orange;
+    transform: rotate(180deg);
     &::before, &::after {
       position: absolute;
       display: block;
       left: 0;
-      width: 100%;
+      width: 50%;
       height: 4px;
-      background-color: @darkgray;
+      background-color: @C2C-orange;
       content: "";
     }
     &::before {
-      top: -8.5px;
-      transform-origin: top right;
-      transition: transform 0.3s, width 0.3s, top 0.3s;
-    }
-    &::after {
-      bottom: -8.5px;
-      transform-origin: bottom right;
-      transition: transform 0.3s, width 0.3s, bottom 0.3s;
-    }
-  }
-}
-
-body.menu-toggled .menu-open-close.menu {
-  span {
-    transform: rotate(180deg);
-    background-color: @C2C-orange;
-    &::before, &::after {
-      width: 50%;
-      background-color: @C2C-orange;
-    }
-    &::before {
       top: 0;
+      transform-origin: top right;
       transform: translateX(16px) translateY(2px) rotate(45deg);
     }
     &::after {
       bottom: 0;
+      transform-origin: bottom right;
       transform: translateX(16px) translateY(-2px) rotate(-45deg);
     }
   }

--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -1,49 +1,64 @@
 @import "variables.less";
 
+/* Hide for mobile, show later */
+@menu-width: 200px;
+@menu-translation: @menu-width + 2px; // 2px for safety
+#sidemenu {
+  transition: transform 0.3s;
+  transform: translate3d(-@menu-translation, 0, 0);
+  outline: 1px solid transparent; // fix transition display bug
+
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1002;
+  width: @menu-width;
+  height: 100%;
+  overflow-x: hidden;
+}
+
+/* always shown when greater than grid breakpoint */
+@media (min-width: @tablet-max) {
+  #sidemenu {
+    transform: translate3d(0, 0, 0) !important;
+  }
+}
+
+/* whatever the screen size, sidemenu is shown when body has class .sidemenu-toggled */
+body.menu-toggled #sidemenu {
+  transform: translate3d(0, 0, 0);
+}
+
+#content-toggled {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  z-index: 1001;
+  cursor: pointer;
+
+  background-color: black;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+body.menu-toggled #content-toggled {
+  opacity: 0.1;
+}
+
+
 #sidemenu {
   color: @darkgray;
   box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
   background-color: white;
-  width: @menu-width;
-  will-change: width;
   margin: 0;
-  position: fixed;
-  top: 0;
   white-space: nowrap;
-  z-index: 1002;
-  height: 100%;
   font-size: 1em;
-  transition: 0.3s;
 
-  @media (max-width: @tablet-max) {
-    width: @menu-width-tablet;
-    will-change: width;
-
-    .menu-text, .logo, .footer-nav, .version {
-      display: none !important;
-    }
-    /*should not be !important*/
-    .advertisement {
-      display: none;
-    }
-    .page-menu {
-      display: inline-block;
-    }
-    .logo {
-      left: -100px;
-      transition: 0.1s;
-    }
-    .menu-open-close {
-      margin: auto;
-    }
-  }
-
-  @media (max-width: @phone-max) {
-    width: @menu-width;
-    left: -@menu-width;
-    .logo {
-      width: 140px;
-    }
+  .page-menu {
+    width: 100%;
   }
 
   @media (max-height: 400px){
@@ -64,6 +79,7 @@
       width: 100px;
     }
   }
+
   @media (max-height: 745px){
     .advertisement {
       display: none !important;
@@ -74,10 +90,6 @@
     .version {
       display: none !important;
     }
-  }
-
-  .page-menu {
-    width: 100%;
   }
 
   .logo {
@@ -141,12 +153,7 @@
     display: block;
   }
 
-   /*#sidemenu.menu-open*/
-  &.menu-open {
-    width: @menu-width !important;
-    will-change: width;
-    left: 0 !important;
-
+  body.menu-toggled #sidemenu {
     .menu-text:not(.hidden-locale), .logo  {
       display: inline !important;
     }
@@ -158,10 +165,6 @@
     }
     .footer-nav {
       display: flex !important;
-    }
-    .menu-open-close {
-      margin: auto;
-      float: right;
     }
   } /* menu-open*/
 }  /*sidemenu*/
@@ -186,6 +189,13 @@
   }
 }
 
+.homepage {
+  margin-left: 45px;
+  @media (max-width: @tablet-max) {
+    margin-left: 0;
+  }
+}
+
 .menu-open-close.menu {
   display: none;
   margin: auto;
@@ -197,33 +207,10 @@
   outline: none;
   border: none;
 
-  @media @tablet {
-    display: block;
-    margin: auto;
-  }
-  @media @phone {
-    display: block;
-    margin: 0;
-    float: right;
-  }
-  &.is-active {
-    span {
-      transform: rotate(180deg);
-      background-color: @C2C-orange;
-      &::before, &::after {
-        width: 50%;
-        background-color: @C2C-orange;
-      }
-      &::before {
-        top: 0;
-        transform: translateX(16px) translateY(2px) rotate(45deg);
-      }
-      &::after {
-        bottom: 0;
-        transform: translateX(16px) translateY(-2px) rotate(-45deg);
-      }
-    }
-
+  @media (max-width: @tablet-max) {
+    display: inline;
+    top: -15px;
+    left: 5px;
   }
 
   span {
@@ -255,19 +242,36 @@
       transition: transform 0.3s, width 0.3s, bottom 0.3s;
     }
   }
-} /* menu-open-close*/
+}
+
+body.menu-toggled .menu-open-close.menu {
+  span {
+    transform: rotate(180deg);
+    background-color: @C2C-orange;
+    &::before, &::after {
+      width: 50%;
+      background-color: @C2C-orange;
+    }
+    &::before {
+      top: 0;
+      transform: translateX(16px) translateY(2px) rotate(45deg);
+    }
+    &::after {
+      bottom: 0;
+      transform: translateX(16px) translateY(-2px) rotate(-45deg);
+    }
+  }
+}
+ /* menu-open-close*/
 
 .menu-open-close.header{
   display: none;
-  top: 5px;
   position: fixed;
-  left: 100px;
+  top: 6px;
+  left: 5px;
   z-index: 31;
-  font-size: 17px;
-  padding-bottom: 2px;
-  padding-top: 7px;
 
-  @media @phone {
+  @media (max-width: @tablet-max) {
     display: block;
   }
 }
@@ -363,22 +367,18 @@ footer {
 /*footer*/
 
 .logo.header {
-  position: relative;
+  position: fixed;
   display: none;
   margin-left: 10px;
   margin-bottom: 6px;
   z-index: 34;
   width: 80px;
 
-  @media @tablet {
-    margin-left: @menu-width-tablet + 10;
-  }
-  @media @phone {
-    position: fixed;
-  }
   @media (max-width: @tablet-max) {
+    margin-left: @menu-width-tablet + 10;
     display: block;
     top: 4px;
+    left: 0;
   }
   img {
     height: 39px;


### PR DESCRIPTION
* to ensure ad is displayed, no more intermediate status for tablet
* when opened on mobile or tablet, content is grayed, clicking anywhere closes the menu
* buttons to open or close the menu are positioned identically
* rework layout

next stuff to (possibly) handle:

* smaller ad when there is not enough place for the big one? e.g. on mobile, 160 * 60?
* allow to fold menu on desktop (and save preferences)