### PR TITLE
On desktop, menu should be a dropup

### DIFF
--- a/less/floatbuttons.less
+++ b/less/floatbuttons.less
@@ -115,7 +115,7 @@
     left: -100%;
     position: relative;
     float: right;
-    margin-top: -55px;
+    bottom: 210px;
 
     @media @phone{
       left: initial;


### PR DESCRIPTION
Following @desnoes feedback, on small screens having a narrow height, all items are not shown otherwise.