### PR TITLE
Hide share button on mobile (is an item in plus menu instead)

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -606,7 +606,9 @@
       <p class="float-button-text" translate>Comments</p>
     </div>
 
-    <div class="float-button float-share-alt addthis_button" addthis:ui_click="true" addthis:ui_offset_top="40" addthis:ui_offset_left="-50" tooltip-placement="left" uib-tooltip="{{'Share' | translate}}">
+    <div class="float-button float-share-alt addthis_button hide-only-mobile"
+        addthis:ui_click="true" addthis:ui_offset_top="40" addthis:ui_offset_left="-50"
+        tooltip-placement="left" uib-tooltip="{{'Share' | translate}}">
       <span class="glyphicon glyphicon-share"></span>
       <p class="float-button-text" translate>Share</p>
     </div>

--- a/c2corg_ui/templates/profile/helpers/view.html
+++ b/c2corg_ui/templates/profile/helpers/view.html
@@ -56,7 +56,7 @@
       <p class="float-button-text" translate>Add images</p>
     </div>
 
-    <div class="float-button float-share-alt addthis_button" addthis:ui_click="true" addthis:ui_offset_top="40" addthis:ui_offset_left="-50" tooltip-placement="left" uib-tooltip="{{'Share' | translate}}">
+    <div class="float-button float-share-alt addthis_button hide-only-mobile" addthis:ui_click="true" addthis:ui_offset_top="40" addthis:ui_offset_left="-50" tooltip-placement="left" uib-tooltip="{{'Share' | translate}}">
       <span class="glyphicon glyphicon-share"></span>
       <p class="float-button-text" translate>Share</p>
     </div>


### PR DESCRIPTION
This PR fixes a missing class for share button on mobile.