### PR TITLE
Constrain wikilinks

### DIFF
--- a/c2corg_ui/format/wikilinks.py
+++ b/c2corg_ui/format/wikilinks.py
@@ -13,7 +13,8 @@ from markdown.extensions import Extension
 from markdown.inlinepatterns import Pattern
 from markdown.util import etree
 
-WIKILINK_RE = r'\[\[([^|]+)\|([^\]]+)\]\]'
+# document_type/document_id(/lang(/slug))
+WIKILINK_RE = r'\[\[([a-z]+\/[0-9]+(?:\/[a-z]{2}(?:\/[a-z0-9\-]+)?)?)\|([^\]]+)\]\]'
 
 
 class C2CWikiLinkExtension(Extension):

--- a/c2corg_ui/format/wikilinks.py
+++ b/c2corg_ui/format/wikilinks.py
@@ -13,8 +13,8 @@ from markdown.extensions import Extension
 from markdown.inlinepatterns import Pattern
 from markdown.util import etree
 
-# document_type/document_id(/lang(/slug))
-WIKILINK_RE = r'\[\[([a-z]+\/[0-9]+(?:\/[a-z]{2}(?:\/[a-z0-9\-]+)?)?)\|([^\]]+)\]\]'
+# document_type/document_id(/lang(/slug))(#anchor)
+WIKILINK_RE = r'\[\[([a-z]+\/[0-9]+(?:\/[a-z]{2}(?:\/[a-z0-9\-]+)?)?(?:#[a-z0-9\-]+)?)\|([^\]]+)\]\]'  # noqa
 
 
 class C2CWikiLinkExtension(Extension):

--- a/c2corg_ui/tests/format/test/links.json
+++ b/c2corg_ui/tests/format/test/links.json
@@ -1,7 +1,35 @@
 [{
   "id":"wikilinks",
   "text":"Some text and a [[waypoints/12345/fr/some-slug|wiki link]] before [[/whatever|another one]] that follows.",
-  "expected":"<p>Some text and a <a href=\"/waypoints/12345/fr/some-slug\">wiki link</a> before <a href=\"/whatever\">another one</a> that follows.</p>"
+  "expected":"<p>Some text and a <a href=\"/waypoints/12345/fr/some-slug\">wiki link</a> before [[/whatever|another one]] that follows.</p>"
+},{
+  "id":"wikilink-simple",
+  "text":"[[articles/1234|mini]]",
+  "expected":"<p><a href=\"/articles/1234\">mini</a></p>"
+},{
+  "id":"wikilink-lang",
+  "text":"[[articles/1234/eu|lang]]",
+  "expected":"<p><a href=\"/articles/1234/eu\">lang</a></p>"
+},{
+  "id":"wikilink-slug",
+  "text":"[[articles/1234/en/sl-ug|slug]]",
+  "expected":"<p><a href=\"/articles/1234/en/sl-ug\">slug</a></p>"
+},{
+  "id":"wikilink-whatever",
+  "text":"[[/whatever|whatever]]",
+  "expected":"<p>[[/whatever|whatever]]</p>"
+},{
+  "id":"wikilink-bad-slug",
+  "text":"[[articles/1234/BAD-Slug|bad slug]]",
+  "expected":"<p>[[articles/1234/BAD-Slug|bad slug]]</p>"
+},{
+  "id":"wikilink-bad-lanf",
+  "text":"[[articles/1234/a23|mini]]",
+  "expected":"<p>[[articles/1234/a23|mini]]</p>"
+},{
+  "id":"wikilink-bad-id",
+  "text":"[[articles/id|bad id]]",
+  "expected":"<p>[[articles/id|bad id]]</p>"
 },{
   "id":"autolink1",
   "text":"A raw URL http://www.example.com in some text",

--- a/c2corg_ui/tests/format/test/links.json
+++ b/c2corg_ui/tests/format/test/links.json
@@ -15,6 +15,10 @@
   "text":"[[articles/1234/en/sl-ug|slug]]",
   "expected":"<p><a href=\"/articles/1234/en/sl-ug\">slug</a></p>"
 },{
+  "id":"wikilink-anchor",
+  "text":"[[articles/1234#anch-or|anchor]]",
+  "expected":"<p><a href=\"/articles/1234#anch-or\">anchor</a></p>"
+},{
   "id":"wikilink-whatever",
   "text":"[[/whatever|whatever]]",
   "expected":"<p>[[/whatever|whatever]]</p>"
@@ -30,6 +34,10 @@
   "id":"wikilink-bad-id",
   "text":"[[articles/id|bad id]]",
   "expected":"<p>[[articles/id|bad id]]</p>"
+},{
+  "id":"wikilink-bad-anchor",
+  "text":"[[articles/1234/fr#AnChor|bad anchor]]",
+  "expected":"<p>[[articles/1234/fr#AnChor|bad anchor]]</p>"
 },{
   "id":"autolink1",
   "text":"A raw URL http://www.example.com in some text",

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -1,5 +1,5 @@
 <h3 id="title-1">Title 1</h3>
-<p>Some <strong>bold text</strong> and a <a href="/waypoints/12345/fr/some-slug">wiki link</a> before <a href="/whatever">another one</a> that follows.</p>
+<p>Some <strong>bold text</strong> and a <a href="/waypoints/12345/fr/some-slug">wiki link</a> before [[/whatever|another one]] that follows.</p>
 <h4 id="title-2">Title 2</h4>
 <p>Here is a 'list':</p>
 <ul>

--- a/c2corg_ui/tests/format/test_format.py
+++ b/c2corg_ui/tests/format/test_format.py
@@ -15,7 +15,7 @@ class TestFormat(unittest.TestCase):
     def test_all(self):
         def do_test(id, text, expected):
             result = parse_code(text)
-            self.assertEqual(result, expected, id)
+            self.assertEqual(result.rstrip(), expected.rstrip(), id)
 
         test_path = os.path.join(base_path, 'test')
 


### PR DESCRIPTION
Instead of allowing any content in the left hand side, only allow pattern like
document_type/document_id(/lang(/slug))

See #1727