### PR TITLE
fix age field when editing xreport

### DIFF
--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -297,8 +297,8 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
                              'has-success': editForm.age.$valid && xreport.age }">
               <label ng-class="{ 'control-label': xreport.age && editForm.nb_impacted.$invalid }"><span translate>age</span></label>
               <div class="input-group">
-                <input type="number" name="age" min="0" max="99" ng-model="xreport.age" class="form-control"/>
-##                   <span class="input-group-addon">years</span>
+                <input class="form-control" type="number" name="age" min="0" max="99" ng-model="xreport.age"/>
+                <span class="input-group-addon">years</span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="xreport.age"></span>
               <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="editForm.xreport.age.$touched && editForm.xreport.age.$invalid"></span>


### PR DESCRIPTION
Don't know why it was commented... Surely a mistake.

Was:
![c2c26](https://user-images.githubusercontent.com/2234024/27691139-75925d08-5ce3-11e7-8d48-de7b209291db.png)

Now:
![c2c25](https://user-images.githubusercontent.com/2234024/27691136-73364146-5ce3-11e7-9d36-2a17dcfe5827.png)
