### PR TITLE
Fix wrong date restore from advanced search permalinks

### DIFF
--- a/c2corg_ui/static/js/search/outingfilters.js
+++ b/c2corg_ui/static/js/search/outingfilters.js
@@ -16,8 +16,6 @@ goog.require('app.SearchFiltersController');
 app.OutingFiltersController = function($scope, ngeoLocation, ngeoDebounce,
     advancedSearchFilters) {
 
-  goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
-
   /**
    * @type {Array.<Date>}
    * @export
@@ -45,7 +43,9 @@ app.OutingFiltersController = function($scope, ngeoLocation, ngeoDebounce,
    */
   this.dateMinEnd = null;
 
+  goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
 };
+
 goog.inherits(app.OutingFiltersController, app.SearchFiltersController);
 
 

--- a/c2corg_ui/static/js/search/xreportfilters.js
+++ b/c2corg_ui/static/js/search/xreportfilters.js
@@ -16,8 +16,6 @@ goog.require('app.SearchFiltersController');
 app.XreportFiltersController = function($scope, ngeoLocation, ngeoDebounce,
     advancedSearchFilters) {
 
-  goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
-
   /**
    * @type {Array.<Date>}
    * @export
@@ -45,7 +43,9 @@ app.XreportFiltersController = function($scope, ngeoLocation, ngeoDebounce,
    */
   this.dateMinEnd = null;
 
+  goog.base(this, $scope, ngeoLocation, ngeoDebounce, advancedSearchFilters);
 };
+
 goog.inherits(app.XreportFiltersController, app.SearchFiltersController);
 
 

--- a/c2corg_ui/templates/xreport/index.html
+++ b/c2corg_ui/templates/xreport/index.html
@@ -10,7 +10,7 @@
     'act': {'type': 'list'},
     'l': {'type': 'list'},
     'xtyp': {'type': 'list'},
-    'xdate': {'type': 'date'},
+    'date': {'type': 'date'},
     'xalt': {'type': 'range'},
     'xpar': {'type': 'range'},
     'ximp': {'type': 'range'},


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1295

The parent constructor was called too early, before the child class properties were added. Then they were not available when the parent constructor asked for parsing the permalinks.