### PR TITLE
Fix conflicts between map geolocation and editing forms

### DIFF
--- a/c2corg_ui/static/js/editing/documentediting.js
+++ b/c2corg_ui/static/js/editing/documentediting.js
@@ -544,7 +544,7 @@ app.DocumentEditingController.prototype.hasMissingProps = function(doc, showErro
       }
     }
   }
-  if (missing['data']['errors'].length > 0) {
+  if (missing['data']['errors'].length) {
     this.alerts.addError(missing);
   }
   return hasError;
@@ -614,6 +614,10 @@ app.DocumentEditingController.prototype.preview = function() {
  * @export
  */
 app.DocumentEditingController.prototype.confirmSave = function(isValid) {
+  if (!isValid) {
+    this.alerts.addError('Form is not valid');
+    return;
+  }
   var template = angular.element('#save-confirmation-modal').clone();
   var modalInstance = this.modal.open({
     animation: true,

--- a/c2corg_ui/static/partials/map/geolocation.html
+++ b/c2corg_ui/static/partials/map/geolocation.html
@@ -1,4 +1,4 @@
-<button class="btn btn-primary btn-xs" ngeo-mobile-geolocation ngeo-mobile-geolocation-map="::geoCtrl.map"
+<button type="button" class="btn btn-primary btn-xs" ngeo-mobile-geolocation ngeo-mobile-geolocation-map="::geoCtrl.map"
   ngeo-mobile-geolocation-options="::geoCtrl.mobileGeolocationOptions" tooltip-placement="bottom"
   uib-tooltip="{{'Recenter on your current position' | translate}}"><span class="glyphicon glyphicon-screenshot"></span>
 </button>

--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -128,7 +128,8 @@
       tooltip-placement="left" uib-tooltip="{{'Preview' | translate}}">
       <span class="glyphicon glyphicon-eye-open"></span>
     </button>
-    <button type="submit" class="btn orange-btn btn-lg float-button"
+    <button type="button" class="btn orange-btn btn-lg float-button"
+      ng-click="editCtrl.confirmSave(editForm.$valid)"
       ng-if="!editForm.$invalid && !editCtrl.hasMissingProps(${model}, false)"
       tooltip-placement="left" uib-tooltip="{{'Save' | translate}}">
       <span class="glyphicon glyphicon-ok"></span>

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -34,7 +34,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
   % if updating_doc:
     app-document-editing-id="${waypoint_id}" app-document-editing-lang="${waypoint_lang}"
   % endif
-    class="document-editing" name="editForm" novalidate ng-submit="editCtrl.confirmSave(editForm.$valid)">
+    class="document-editing" name="editForm" novalidate>
 
     <div class="ng-hide">{{type = waypoint.waypoint_type}}</div>
 


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1293 and https://github.com/c2corg/v6_ui/issues/1528
See also pending PR https://github.com/c2corg/v6_ui/pull/1743

What I have observed:
* pressing the ENTER key in a text input triggers the editing form ``ng-submit`` (as a result it shows the quality modal box)
* clicking on the geolocation button also triggers the editing form ``ng-submit`` etc.

If we replace the ``ng-submit`` by an ``ng-click`` on the "Save" button, pressing ENTER no longer submit the form (as asked by https://github.com/c2corg/v6_ui/issues/1528). It also prevents the form from being submitted when clicking the recenter button.

Adding an explicit ``type="button"`` attribute to the geolocation button ("recenter on my current position") was necessary to prevent the button handler to be triggered when pressing the ENTER key while in an input field of the form. 