### PR TITLE
Fix position of map recentering tools with Safari/iOS

### DIFF
--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -368,6 +368,14 @@ div.help-block {
   margin: 3% 0 3% 0;
 }
 
+/* Safari 9+ fix for not visible map recentering tools */
+_::-webkit-:not(:root:root), .map-right {
+  top: @page-header-height + @page-main-title-height;
+  .map {
+    height: ~"calc(100vh - 120px - @{page-header-height} - @{page-main-title-height})" !important;
+  }
+}
+
 .map-right {
   flex: 1;
   transition: .3s;
@@ -386,7 +394,7 @@ div.help-block {
       -moz-box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       box-shadow: 0 0 36px -10px rgba(0,0,0,0.56);
       margin-top: 0;
-      height: ~"calc(100vh - 120px)" !important;
+      height: ~"calc(100vh - 120px)";
     }
   }
 }


### PR DESCRIPTION
Port of changes suggested by @dkocich at 5355ab671d2c0a84d12561700d7966aaab948ad1

Related to https://github.com/c2corg/v6_ui/issues/1137
Replace PR https://github.com/c2corg/v6_ui/pull/1506

Should be deployed on the demo to be tested on various devices and browsers.