### PR TITLE
Fix incorrect route history placeholder

### DIFF
--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -809,7 +809,7 @@ updating_doc = route_id and route_lang
               <textarea app-markdown-editor name="route_history"
                         ng-model="route.locales[0].route_history"
                         class="form-control"
-                        placeholder="{{'Describes here historical information about the route (date, names..) ' | translate}}"></textarea>
+                        placeholder="{{'Describe historical information about the route (date, names..) here' | translate}}"></textarea>
             </div>
 
             ## GEAR LOCALE


### PR DESCRIPTION
The string in Transifex has no trailing whitespace. Which probably explains why this string is not translated in the UI despite it "exists" and is translated in Transifex.