### PR TITLE
Revert change 14cc7f4 because it breaks map/list hidding switches

### DIFF
--- a/c2corg_ui/templates/helpers/list.html
+++ b/c2corg_ui/templates/helpers/list.html
@@ -1,5 +1,5 @@
 <%def name="toggle_map_btns()">\
-  <button class="btn btn-primary no-map-btn show-list hidden-xs" ng-if="noList"
+  <button class="btn btn-primary no-map-btn show-list hidden-xs" ng-show="noList"
           ng-click="noList = false; noMap = false; mainCtrl.resizeMap();">
     <span  class="glyphicon glyphicon-th-large"></span>
     <span translate>Show list</span>
@@ -8,7 +8,7 @@
 
 <%def name="toggle_list_btns()">\
 <button class="btn orange-btn btn-default no-list-btn hidden-xs"
-        ng-if="!noMap" ng-click="noList = !noList; noMap = false; mainCtrl.resizeMap();">
+        ng-show="!noMap" ng-click="noList = !noList; noMap = false; mainCtrl.resizeMap();">
   <span class="glyphicon glyphicon-eye-close"></span>
   <span translate>Hide list</span>
 </button>


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1745

Replacing ``ng-show`` by ``ng-if`` in 14cc7f4 seems to break the map/list hidding switches.
Perhaps the explanation is here https://stackoverflow.com/a/21870119
> ng-if will remove elements from DOM. This means that all your handlers or anything else attached to those elements will be lost. For example, if you bound a click handler to one of child elements, when ng-if evaluates to false, that element will be removed from DOM and your click handler will not work any more, even after ng-if later evaluates to true and displays the element. You will need to reattach the handler.

I have not reverted the whole commit 14cc7f4 because the buttons seem to work as expected with the suggested change. More testing might be needed.