### PR TITLE
Spread the disable comments option over the full editing form width

### DIFF
--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -561,7 +561,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## COMMENTS MANAGEMENT
-            <div class="form-group half">
+            <div class="form-group full">
               <label translate>disable_comments</label>
               <input type="checkbox" ng-model="outing.disable_comments">
               <span ng-click="editCtrl.pushToArray(outing, 'disable_comments', !outing.disable_comments, $event)" translate>If checked, comments cannot be posted or read.</span>


### PR DESCRIPTION
Before:

<img width="874" alt="capture d ecran 2017-07-30 a 14 59 21" src="https://user-images.githubusercontent.com/1192331/28753688-2b956994-7538-11e7-9926-29ca04962bdd.png">

After:

<img width="864" alt="capture d ecran 2017-07-30 a 15 03 06" src="https://user-images.githubusercontent.com/1192331/28753692-3aab6c44-7538-11e7-8c9f-9996f6f9fcc6.png">

This is already the case for in xreports editing forms.