### PR TITLE
Cotometer menu changes

### DIFF
--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -621,7 +621,6 @@
       </div>
       <ul class="dropdown-menu dm-icon" role="menu">
         <li><a ng-click="detailsCtrl.printPage()"><span class="glyphicon glyphicon-print"></span> <translate>Print page</translate></a></li>
-        <li><a ng-click="detailsCtrl.openModal('#cotometer-dialog','md')"><span class="glyphicon glyphicon-sort-by-attributes"></span> <translate>Cotometer</translate></a></li>
         <li class="show-only-mobile"><a class="addthis_button_compact" addthis:ui_click="true" addthis:ui_disable="true"><span class="glyphicon glyphicon-share-alt"></span> <translate>Share</translate></a></li>
         <li><a href="${request.route_path(doctype + '_history', id=doc_id, lang=doc_lang)}"><span class="glyphicon glyphicon-hourglass"></span> <translate>History</translate></a></li>
         % if other_langs:

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -17,7 +17,6 @@ from json import dumps
     get_outing_participants, get_outing_general, get_outing_heights,
     show_fulldate, get_conditions"/>
 
-<%namespace file="../helpers/cotometer.html" import="show_cotometer_dialog"/>
 <%
 outing_id = outing['document_id']
 outing['doctype'] = 'outings'
@@ -190,7 +189,6 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     ${delete_association_confirmation_modal()}
     ${show_merge_documents_dialog('outings')}
     ${show_delete_document_dialog('outings', lang, other_langs)}
-    ${show_cotometer_dialog('outings', lang, other_langs)}
   </div>
 
   ${photoswipe_gallery()}

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -519,7 +519,7 @@ updating_doc = route_id and route_lang
               <div class="input-group">
                 <select class="form-control" ng-model="route.ski_rating" ng-options="rat as rat for rat in ${ski_ratings}"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
-                <span class="input-group-addon" ng-click="editCtrl.openModal('#cotometer-dialog','md')"><span class="glyphicon glyphicon-sort-by-attributes"></span></span>
+                <span class="input-group-addon" ng-click="editCtrl.openModal('#cotometer-dialog','md')"><span class="glyphicon glyphicon-question-sign"></span></span>
               </div>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-if="route.ski_rating"></span>
 

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -21,8 +21,6 @@ from json import dumps
     get_route_access, get_route_associated_maps, get_route_orientations,
     get_route_gear"/>
 
-<%namespace file="../helpers/cotometer.html" import="show_cotometer_dialog"/>
-
 <%
 route_id = route['document_id']
 route['doctype'] = 'routes'
@@ -195,7 +193,6 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     ${show_missing_langs_links('routes', route, missing_langs)}
     ${show_merge_documents_dialog('routes')}
     ${show_delete_document_dialog('routes', lang, other_langs)}
-    ${show_cotometer_dialog('routes', lang, other_langs)}
   </div>
 
   ${photoswipe_gallery()}


### PR DESCRIPTION
The cotometer is a nice tool but I feel a bit "unhappy" because:

* the cotometer button icon is not very intuitive in the route editing form:
<img width="403" alt="capture d ecran 2017-08-10 a 17 01 38" src="https://user-images.githubusercontent.com/1192331/29176923-9cb9ca3a-7ded-11e7-9ce6-f857d1603049.png">
=> I doubt that users will easily understand they can open the cotometer by clicking on this icon. I suggest to rather use the question mark icon:
<img width="397" alt="capture d ecran 2017-08-10 a 17 02 47" src="https://user-images.githubusercontent.com/1192331/29176985-c531f352-7ded-11e7-8246-2e546d327d27.png">

=> commit 67879b6

* there is a "cotometer" entry in the "Plus" menu of any document (whatever its type, including WP or images for instance - by the way clicking on the "Cotometer" menu in those pages does nothing) => that does not look very consistent :P 
In addition I don't think this entry is relevant here because in the "Plus" menu other entries are document-related tools (history, merging, deleting, other languages, translations), they does not deal with the content itself. In addition, as a user, I don't find it intuitive to look at a document "Plus" menu to get an assistant about skitouring route ratings => OK when I have to provide the rating (editing form), but not really in the viewing page. Or maybe in a dedicated page, without having to open whatever document to find it :P 

As a result I suggest to remove this entry from the Plus menu: commit fd92529