### PR TITLE
Show available langs directly in the document pages

### DIFF
--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -81,11 +81,9 @@ area['doctype'] = 'areas'
 
   % if version:
     ${show_archive_data('areas', area, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('areas', area, other_langs)}
   % endif
 
   <div class="view-details-informations col-xs-12 informations">
@@ -137,7 +135,6 @@ area['doctype'] = 'areas'
 % if not version:
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
-    ${show_other_langs_links('areas', area, other_langs)}
     ${show_missing_langs_links('areas', area, missing_langs)}
     ${show_merge_documents_dialog('areas')}
   </div>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -60,11 +60,9 @@ other_langs, missing_langs = get_lang_lists(article, lang)
 
   % if version:
     ${show_archive_data('articles', article, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('articles', article, other_langs)}
   % endif
 
   <div class="view-details-informations col-xs-12  informations">
@@ -127,7 +125,6 @@ other_langs, missing_langs = get_lang_lists(article, lang)
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('articles', article, other_langs)}
     ${show_missing_langs_links('articles', article, missing_langs)}
     ${show_merge_documents_dialog('articles')}
     ${show_delete_document_dialog('articles', lang, other_langs)}

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -62,12 +62,9 @@ other_langs, missing_langs = get_lang_lists(book, lang)
 
   % if version:
     ${show_archive_data('books', book, locale, version)}
-  % endif
-
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('books', book, other_langs)}
   % endif
 
   <div class="view-details-informations col-xs-12  informations">
@@ -113,7 +110,6 @@ other_langs, missing_langs = get_lang_lists(book, lang)
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('books', book, other_langs)}
     ${show_missing_langs_links('books', book, missing_langs)}
     ${show_merge_documents_dialog('books')}
     ${show_delete_document_dialog('books', lang, other_langs)}

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -87,16 +87,14 @@
 
 <%def name="show_other_langs_links(module, document, other_langs)">\
   % if other_langs:
-    <div id="other-langs">
-      <div class="modal-header"><h3 class="text-center" translate>View in other lang</h3></div>
-      <ul>
-        % for l in other_langs:
-          <li>
-            <a href="${request.route_path(module + '_view_id_lang', id=document['document_id'], lang=l)}" x-translate>${l}</a>
-            <span class="glyphicon glyphicon-chevron-right"></span>
-          </li>
-        % endfor
-      </ul>
+    <div class="other-langs"><span translate>View in other lang</span>
+      <%
+          route = 'profiles_view' if module == 'profiles' else (module + '_view_id_lang')
+      %>
+      % for l in other_langs:
+        <a href="${request.route_path(route, id=document['document_id'], lang=l)}" x-translate>${l}</a>
+        ${' - ' if not loop.last else ''}
+      % endfor
     </div>
   % endif
 </%def>
@@ -520,7 +518,7 @@
 
 <%def name="get_document_description(locale, doctype, title=None)">\
   % if locale.get('summary') or locale.get('description'):
-    <div class="view-details-description col-xs-12  description">
+    <div class="view-details-description col-xs-12 description">
       % if doctype not in ['article', 'profile']:
         <h3 class="heading show-phone">
           % if title:
@@ -624,9 +622,6 @@
         <li><a ng-click="detailsCtrl.openModal('#cotometer-dialog','md')"><span class="glyphicon glyphicon-sort-by-attributes"></span> <translate>Cotometer</translate></a></li>
         <li class="show-only-mobile"><a class="addthis_button_compact" addthis:ui_click="true" addthis:ui_disable="true"><span class="glyphicon glyphicon-share-alt"></span> <translate>Share</translate></a></li>
         <li><a href="${request.route_path(doctype + '_history', id=doc_id, lang=doc_lang)}"><span class="glyphicon glyphicon-hourglass"></span> <translate>History</translate></a></li>
-        % if other_langs:
-        <li ng-click="detailsCtrl.openModal('#other-langs')"><a><span class="glyphicon glyphicon-globe"></span> <translate>View in other lang</translate></a></li>
-        % endif
         % if missing_langs:
         <li ng-if="userCtrl.hasEditRights('${doctype}', ${options}, ${protected})"
             ng-click="detailsCtrl.openModal('#missing-langs')"><a><span class="glyphicon glyphicon-edit"></span> <translate>Translate into an other lang</translate></a></li>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -84,6 +84,8 @@ from json import dumps
 
   % if version:
     ${show_archive_data('images', image, locale, version)}
+  % else:
+    ${show_other_langs_links('images', image, other_langs)}
   % endif
 
   <div class="view-details-wrapper">
@@ -157,7 +159,6 @@ from json import dumps
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('images', image, other_langs)}
     ${show_missing_langs_links('images', image, missing_langs)}
     ${show_merge_documents_dialog('images')}
     ${show_delete_document_dialog('images', lang, other_langs)}

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -110,11 +110,9 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 
   % if version:
     ${show_archive_data('outings', outing, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('outings', outing, other_langs)}
   % endif
 
   <div class="view-details-informations col-xs-12  informations">
@@ -185,7 +183,6 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
 % if not version:
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
-    ${show_other_langs_links('outings', outing, other_langs)}
     ${show_missing_langs_links('outings', outing, missing_langs)}
     ${delete_association_confirmation_modal()}
     ${show_merge_documents_dialog('outings')}

--- a/c2corg_ui/templates/profile/data.html
+++ b/c2corg_ui/templates/profile/data.html
@@ -2,8 +2,9 @@
 from c2corg_ui.templates.utils import get_lang_lists
 from json import dumps
 %>
-<%namespace file="../helpers/view.html" import="get_image_gallery, get_document_description, show_areas, get_licence"/>
-<%namespace file="helpers/view.html" import="get_profile_general"/>
+<%namespace file="../helpers/view.html" import="get_image_gallery, get_document_description,
+    show_areas, get_licence, show_other_langs_links, show_missing_langs_links"/>
+<%namespace file="helpers/view.html" import="get_profile_general, show_profile_float_buttons"/>
 
 % if not_authorized:
   <div class="view-details-not-authorised text-center">
@@ -13,6 +14,10 @@ from json import dumps
   </div>
 
 % else:
+  <%
+      user_id = profile['document_id']
+      other_langs, missing_langs = get_lang_lists(profile, lang)
+  %>
 
   <div app-view-details>
     % if geometry:
@@ -32,7 +37,7 @@ from json import dumps
             "properties": {
               "title": ${dumps(profile["name"]) | n},
               "lang": "${locale["lang"]}",
-              "documentId": ${profile['document_id']},
+              "documentId": ${user_id},
               "module": "profiles",
               "highlight": true
             }
@@ -43,6 +48,7 @@ from json import dumps
     <div ng-init="detailsCtrl.documentService.setAssociations(${profile['associations']});"></div>
 
     ${get_image_gallery()}
+    ${show_other_langs_links('profiles', profile, other_langs)}
 
     <div class="view-details-informations col-xs-12  informations">
       <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
@@ -56,7 +62,10 @@ from json import dumps
 
     ${get_document_description(locale, 'profile')}
 
-    <app-feed app-feed-profile="${profile['document_id']}" id="feed"></app-feed>
+    <app-feed app-feed-profile="${user_id}" id="feed"></app-feed>
 
   </div>
+
+  ${show_missing_langs_links('profiles', profile, missing_langs)}
+  ${show_profile_float_buttons(user_id, lang, other_langs, missing_langs)}
 % endif

--- a/c2corg_ui/templates/profile/helpers/view.html
+++ b/c2corg_ui/templates/profile/helpers/view.html
@@ -69,9 +69,6 @@
       </div>
       <ul class="dropdown-menu" role="menu">
         <li class="show-only-mobile"><a class="addthis_button_compact" addthis:ui_click="true" addthis:ui_disable="true"><span class="glyphicon glyphicon-share-alt"></span> <translate>Share</translate></a></li>
-        % if other_langs:
-          <li ng-click="detailsCtrl.openModal('#other-langs')"><a><span class="glyphicon glyphicon-globe"></span> <translate>View in other lang</translate></a></li>
-        % endif
         % if missing_langs:
           <li ng-click="detailsCtrl.openModal('#missing-langs')"><a><span class="glyphicon glyphicon-edit"></span> <translate>Translate into an other lang</translate></a></li>
         % endif

--- a/c2corg_ui/templates/profile/view.html
+++ b/c2corg_ui/templates/profile/view.html
@@ -1,12 +1,8 @@
 <%!
     from c2corg_common.attributes import activities, image_categories, image_types
-    from c2corg_ui.templates.utils import get_lang_lists
 %>
 <%inherit file="../base.html"/>
-<%namespace file="../helpers/view.html" import="show_badge, show_locale_title,
-    photoswipe_gallery, show_missing_langs_links, show_other_langs_links,
-    generate_share_metadata"/>
-<%namespace file="helpers/view.html" import="show_profile_float_buttons"/>
+<%namespace file="../helpers/view.html" import="show_badge, show_locale_title, photoswipe_gallery, generate_share_metadata"/>
 
 <%block name="pagelang">lang="${lang}"</%block>
 
@@ -15,13 +11,6 @@
 <%block name="metarobots">
   <meta name="robots" content="index,follow">
 </%block>
-
-<%
-    user_id = profile['document_id']
-    locale = locales[0]
-    lang_data = {'available_langs': [l['lang'] for l in locales]}
-    other_langs, missing_langs = get_lang_lists(lang_data, lang)
-%>
 
 <%block name="moduleConstantsValues">
   ## Set in the data request
@@ -41,21 +30,15 @@
 
 <header class="view-details-title">
   <h1>
-    <span>${locale['title']}</span>
+    <span>${locales[0]['title']}</span>
     ${show_badge(profile, 'profile')}
   </h1>
 </header>
 
 <section class="view-details-section">
-
-  <div app-user-profile="${user_id}" app-user-profile-lang="${lang}">
+  <div app-user-profile="${profile['document_id']}" app-user-profile-lang="${lang}">
     <div id="user-profile-data" app-loading></div>
   </div>
-
-  ${show_other_langs_links('profiles', profile, other_langs)}
-  ${show_missing_langs_links('profiles', profile, missing_langs)}
-  ${show_profile_float_buttons(user_id, lang, other_langs, missing_langs)}
-
 </section>
 
 <div class="ng-hide">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -111,11 +111,9 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 <section class="view-details-section" app-view-details ng-class="{'row-list' : switchCtrl.showList}">
   % if version:
     ${show_archive_data('routes', route, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('routes', route, other_langs)}
   % endif
 
   <div class="thumbnail view-details-informations col-sm-12 informations">
@@ -191,7 +189,6 @@ other_langs, missing_langs = get_lang_lists(route, lang)
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('routes', route, other_langs)}
     ${show_missing_langs_links('routes', route, missing_langs)}
     ${show_merge_documents_dialog('routes')}
     ${show_delete_document_dialog('routes', lang, other_langs)}

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -109,14 +109,12 @@ waypoint['doctype'] = 'waypoints'
 
   % if version:
     ${show_archive_data('waypoints', waypoint, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('waypoints', waypoint, other_langs)}
   % endif
 
-  <div class="view-details-informations col-xs-12  informations">
+  <div class="view-details-informations col-xs-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Information</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
@@ -137,7 +135,7 @@ waypoint['doctype'] = 'waypoints'
   <% description_title = 'road access' if waypoint['waypoint_type'] == 'access' else 'description' %>
   ${get_document_description(locale, 'waypoint', description_title)}
 
-  <div class="description ">
+  <div class="description">
     ${get_waypoint_access_field(locale, waypoint['waypoint_type'], True)}
     ${get_waypoint_access_period(locale, waypoint['waypoint_type'], True)}
   </div>
@@ -194,7 +192,6 @@ waypoint['doctype'] = 'waypoints'
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('waypoints', waypoint, other_langs)}
     ${show_missing_langs_links('waypoints', waypoint, missing_langs)}
     ${show_merge_documents_dialog('waypoints')}
     ${show_delete_document_dialog('waypoints', lang, other_langs)}

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -103,11 +103,9 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
 <section class="view-details-section" app-view-details>
   % if version:
     ${show_archive_data('xreports', xreport, locale, version)}
-  % endif
-
-  ## IMAGES
-  % if not version:
+  % else:
     ${get_image_gallery()}
+    ${show_other_langs_links('xreports', xreport, other_langs)}
   % endif
 
   <div class="view-details-informations col-xs-12 informations">
@@ -177,7 +175,6 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
   <div class="ng-hide">
     <div id="image-uploader" app-image-uploader activities="${activities}" categories="${image_categories}" types="${image_types}"></div>
     ${delete_association_confirmation_modal()}
-    ${show_other_langs_links('xreports', xreport, other_langs)}
     ${show_missing_langs_links('xreports', xreport, missing_langs)}
     ${show_merge_documents_dialog('xreports')}
     ${show_delete_document_dialog('xreports', lang, other_langs)}

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -23,6 +23,10 @@
   .view-details-informations .accordion {
     padding: 0;
   }
+
+  .other-langs {
+    display: none;
+  }
 }
 
 .lead {

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -116,7 +116,7 @@ h1 {
   font-size: 3em;
 }
 
-#missing-langs, #other-langs {
+#missing-langs {
   a {
     text-decoration: none;
   }
@@ -164,7 +164,7 @@ h1 {
 }
 
 main {
-  #missing-langs, #other-langs, #merge-documents-dialog {
+  #missing-langs, #merge-documents-dialog {
     display: none;
   }
 }

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -606,6 +606,10 @@
       color: @C2C-orange
     }
   }
+
+  .other-langs {
+    clear: both;
+  }
 } /*.view-details-section*/
 
 .view-details-map {


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1680

The layout of the lang links are still a bit raw but I have not much inspiration to make them nicer (patch/help welcome :P ). The available langs entry in the Plus menu has been removed.

@Courgetteandratatouille this might impact your work about the page layout redesign.

<img width="400" alt="capture d ecran 2017-08-10 a 22 16 37" src="https://user-images.githubusercontent.com/1192331/29190374-24934cfc-7e1a-11e7-9ac2-61ea79c8328a.png">
