### PR TITLE
Improve loading time

### DIFF
--- a/c2corg_ui/static/js/loading.js
+++ b/c2corg_ui/static/js/loading.js
@@ -24,10 +24,8 @@ app.loadingDirective = function($http) {
        }, function() {
          if ($http.pendingRequests.length > 0) {
            $('.loading-gif').show();
-           el.addClass('loading');
          } else {
            $('.loading-gif').hide();
-           el.removeClass('loading');
          }
        });
      }

--- a/c2corg_ui/templates/account.html
+++ b/c2corg_ui/templates/account.html
@@ -3,7 +3,7 @@
 <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Account')">${show_title('Account')}</title></%block>
 
 <div class="auth-form">
-  <section app-loading>
+  <section app-loading ng-cloak>
     <div ng-controller="appAccountController as accountCtrl">
       <h1 translate>Change account parameters</h1>
       <form name="accountForm" novalidate ng-submit="accountCtrl.save()">

--- a/c2corg_ui/templates/area/edit.html
+++ b/c2corg_ui/templates/area/edit.html
@@ -17,7 +17,7 @@ from c2corg_common.attributes import default_langs, area_types
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${area_id if area_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing an area' | translate) : ('Creating an area' | translate)"></label>

--- a/c2corg_ui/templates/article/edit.html
+++ b/c2corg_ui/templates/article/edit.html
@@ -13,7 +13,7 @@ from c2corg_common.attributes import default_langs, activities, article_categori
 <%block name="pagetitle"><title ng-init="id = ${article_id if article_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an article') : mainCtrl.page_title('Creating an article')">${show_title('Create/edit article')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${article_id if article_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing an article' | translate) : ('Creating an article' | translate)"></label>

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -83,7 +83,7 @@ other_langs, missing_langs = get_lang_lists(article, lang)
   </div>
 
   % if not version:
-    <div class="view-details-associations col-xs-12 associations"
+    <div class="view-details-associations col-xs-12 associations" ng-cloak
       % if not has_associations(article):
          ng-show="userCtrl.hasEditRights('articles', {'articleType': '${article['article_type']}', 'authorId': ${article['author']['user_id']}})"
       % endif

--- a/c2corg_ui/templates/auth.html
+++ b/c2corg_ui/templates/auth.html
@@ -7,7 +7,7 @@ from pyramid.settings import asbool
 
 <div app-auth class="auth-form" app-loading>
 
-  <section>
+  <section ng-cloak>
     <div ng-show="authCtrl.uiStates.showLoginForm">
       <h1 translate>Login</h1>
 
@@ -55,7 +55,6 @@ from pyramid.settings import asbool
         </button>
       </p>
     </div>
-
 
     <div ng-show="authCtrl.uiStates.showRegisterForm">
       <h1 translate>Register</h1>
@@ -144,7 +143,6 @@ from pyramid.settings import asbool
       </p>
     </div>
 
-
     <div ng-show="authCtrl.uiStates.showRequestChangePasswordForm">
       <h1 translate>Reset password</h1>
 
@@ -178,7 +176,6 @@ from pyramid.settings import asbool
         </button>
       </p>
     </div>
-
 
     <div ng-show="authCtrl.uiStates.showChangePasswordForm">
       <h1 translate>Change password</h1>

--- a/c2corg_ui/templates/base.html
+++ b/c2corg_ui/templates/base.html
@@ -8,7 +8,7 @@ closure_library_path = settings.get('closure_library_path')
 %>\
 <%namespace file="helpers/common.html" import="show_title"/>\
 <!DOCTYPE html>
-<html ng-cloak <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl" itemscope itemtype="http://schema.org/Article">
+<html <%block name="pagelang"></%block> ng-app="app" ng-controller="MainController as mainCtrl" itemscope itemtype="http://schema.org/Article">
   <head>
     <%block name="pagetitle"><title ng-bind="mainCtrl.page_title('Home')">${show_title('Home')}</title></%block>
     <meta charset="utf-8">

--- a/c2corg_ui/templates/book/edit.html
+++ b/c2corg_ui/templates/book/edit.html
@@ -14,7 +14,7 @@ from c2corg_common.attributes import default_langs, quality_types, activities, b
 <%block name="pagetitle"><title ng-init="id = ${book_id if book_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a book') : mainCtrl.page_title('Creating a book')">${show_title('Create/edit book')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${book_id if book_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing a book' | translate) : ('Creating a book' | translate)"></label>

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -70,7 +70,7 @@ other_langs, missing_langs = get_lang_lists(book, lang)
     ${get_image_gallery()}
   % endif
 
-  <div class="view-details-informations col-xs-12  informations">
+  <div class="view-details-informations col-xs-12 informations">
     <h3 class="heading informations" ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#document-informations">
       <span translate>Informations</span><span class="glyphicon glyphicon-menu-down"></span>
     </h3>
@@ -85,7 +85,7 @@ other_langs, missing_langs = get_lang_lists(book, lang)
   </div>
 
   % if not version:
-    <div class="view-details-associations col-xs-12  associations">
+    <div class="view-details-associations col-xs-12 associations" ng-cloak>
       <span class="lead">
           <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
             <label translate>Add association</label>

--- a/c2corg_ui/templates/following.html
+++ b/c2corg_ui/templates/following.html
@@ -7,7 +7,7 @@ from c2corg_common.attributes import mailinglists
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
 <div class="following" app-loading>
-  <section app-following>
+  <section app-following ng-cloak>
     <h3 class="green-text" translate>Followed users</h3>
     <p translate>Here is the list of users you are following and whose activity you will see in your personal feed.</p>
     <app-simple-search app-select="flCtrl.addUser(doc)" dataset="u"></app-simple-search>

--- a/c2corg_ui/templates/image/edit.html
+++ b/c2corg_ui/templates/image/edit.html
@@ -19,7 +19,7 @@ from c2corg_common.attributes import default_langs, activities, image_types, ima
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${image_id if image_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing an image' | translate) : ('Creating an image' | translate)"></label>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -119,7 +119,7 @@ from json import dumps
   % endif
 
   % if not version:
-    <div class="view-details-associations col-xs-12 associations"
+    <div class="view-details-associations col-xs-12 associations" ng-cloak
       % if not has_associations(image):
          ng-if="userCtrl.hasEditRights('images', {'imageType': '${image['image_type']}', 'imageCreator': ${image['creator']['user_id']}})"
       % endif

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -18,7 +18,7 @@ updating_doc = outing_id and outing_lang
 <%block name="pagetitle"><title ng-init="id=${outing_id if outing_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing an outing') : mainCtrl.page_title('Creating an outing')">${show_title('Create/edit outing')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-cloak ng-init="id=${outing_id if outing_id else 0}"
       ng-bind="id ? ('Editing an outing' | translate) : ('Creating an outing' | translate)"

--- a/c2corg_ui/templates/outing/preview.html
+++ b/c2corg_ui/templates/outing/preview.html
@@ -21,7 +21,7 @@ ${show_preview_warning()}
       <span class="glyphicon glyphicon-arrow-right"></span>&nbsp;<span translate>outing</span>
     </label>
   </h1>
-  <div class="outing-date" class="ng-cloak">${show_fulldate(outing['date_start'], outing['date_end'])}</div>
+  <div class="outing-date" ng-cloak>${show_fulldate(outing['date_start'], outing['date_end'])}</div>
 </header>
 
 <section class="view-details-section">

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -149,7 +149,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     <%
         userIds = dumps([user['document_id'] for user in outing['associations']['users']])
     %>
-    <div class="view-details-associations col-xs-12 associations"
+    <div class="view-details-associations col-xs-12 associations" ng-cloak
        % if not has_associations(outing):
          ng-if="userCtrl.hasEditRights('outings', {'users': ${userIds}})"
        % endif

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -93,7 +93,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
     <span class="title">${locale['title']}</span><br>
     ${show_badge(outing, 'outing')}
   </h1>
-  <div class="outing-date" class="ng-cloak">${show_fulldate(outing['date_start'], outing['date_end'])}</div>
+  <div class="outing-date" ng-cloak>${show_fulldate(outing['date_start'], outing['date_end'])}</div>
 </header>
 
 % if outing.get('areas'):

--- a/c2corg_ui/templates/preferences.html
+++ b/c2corg_ui/templates/preferences.html
@@ -7,7 +7,7 @@ from c2corg_common.attributes import activities
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
 <div class="preferences" app-loading>
-  <section app-preferences>
+  <section app-preferences ng-cloak>
     <div class="preferences-filter">
       <h3 class="green-text" translate>Filter preferences</h3>
       <p translate>Here you may set activity and region filters that will apply to the homepage feed.</p>

--- a/c2corg_ui/templates/profile/edit.html
+++ b/c2corg_ui/templates/profile/edit.html
@@ -12,7 +12,7 @@ from c2corg_common.attributes import activities, user_categories
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 class="text-center">
     <label class="label label-primary" translate>Editing a profile</label>

--- a/c2corg_ui/templates/route/edit.html
+++ b/c2corg_ui/templates/route/edit.html
@@ -22,7 +22,7 @@ updating_doc = route_id and route_lang
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-cloak ng-init="id=${route_id if route_id else 0}" ng-bind="id ? ('Editing a route' | translate) : ('Creating a route' | translate)" class="text-center"></h1>
 

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -148,18 +148,18 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
   % if not version:
     ## route has always at least 1 associated waypoint so this div will always be displayed
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations" ng-cloak>
       <ul class="actions">
         <li>
           <app-list-switch type="short"></app-list-switch>
         </li>
       </ul>
       <span class="lead">
+        <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+          <label translate>Add association</label>
+          <app-add-association parent-id="${route_id}" parent-doctype="routes" dataset="wrcbx"></app-add-association>
+        </div>
         <section>
-          <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
-            <label translate>Add association</label>
-            <app-add-association parent-id="${route_id}" parent-doctype="routes" dataset="wrcbx"></app-add-association>
-          </div>
           ${show_associated_waypoints(route)}
           ${show_associated_routes(route)}
           ${show_associated_articles(route)}

--- a/c2corg_ui/templates/waypoint/edit.html
+++ b/c2corg_ui/templates/waypoint/edit.html
@@ -23,7 +23,7 @@ from c2corg_common.attributes import default_langs, climbing_outdoor_types, publ
 
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${waypoint_id if waypoint_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing a waypoint' | translate) : ('Creating a waypoint' | translate)"></label>

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -143,7 +143,8 @@ waypoint['doctype'] = 'waypoints'
   </div>
 
   % if not version:
-    <div class="view-details-associations col-xs-12 associations" ng-init="a = detailsCtrl.documentService.document.associations"
+    <div class="view-details-associations col-xs-12 associations" ng-cloak
+         ng-init="a = detailsCtrl.documentService.document.associations"
          ng-show="userCtrl.auth.isAuthenticated() || a.waypoint_children.length || a.waypoints.length">
       <ul class="actions">
         <li>
@@ -151,25 +152,24 @@ waypoint['doctype'] = 'waypoints'
         </li>
       </ul>
       <span class="lead">
+        <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
+          <label translate>Add association</label>
+          <app-add-association parent-id="${waypoint_id}" parent-doctype="waypoints" dataset="wcbx"></app-add-association>
+        </div>
         <section>
-          <div ng-show="userCtrl.auth.isAuthenticated()" class="add-association">
-            <label translate>Add association</label>
-            <app-add-association parent-id="${waypoint_id}" parent-doctype="waypoints" dataset="wcbx"></app-add-association>
-          </div>
           ${show_associated_waypoints(waypoint, 'waypoints', showDelete=False)}
           ${show_associated_waypoints(waypoint, 'waypoint_children')}
         </section>
       </span>
     </div>
-    <div class="view-details-associations col-xs-12 associations">
+    <div class="view-details-associations col-xs-12 associations" ng-cloak>
       <span class="lead">
         <section>
           ${show_associated_routes(waypoint, 'all_routes')}
         </section>
       </span>
     </div>
-
-    <div class="view-details-associations col-xs-12 associations" ng-show="a.recent_outings.total > 0 || a.articles.length || a.books.length">
+    <div class="view-details-associations col-xs-12 associations" ng-show="a.recent_outings.total > 0 || a.articles.length || a.books.length" ng-cloak>
       <span class="lead">
         <section>
           ${show_associated_articles(waypoint)}

--- a/c2corg_ui/templates/xreport/edit.html
+++ b/c2corg_ui/templates/xreport/edit.html
@@ -17,7 +17,7 @@ from c2corg_common.attributes import default_langs, activities, event_types, \
 <%block name="pagetitle"><title ng-init="id = ${xreport_id if xreport_id else 0}" ng-bind="id ? mainCtrl.page_title('Editing a report') : mainCtrl.page_title('Creating a report')">${show_title('Create/edit report')}</title></%block>
 <%block name="metarobots"><meta name="robots" content="noindex,nofollow"></%block>
 
-<section class="create-edit-document">
+<section class="create-edit-document" ng-cloak>
 
   <h1 ng-init="id = ${xreport_id if xreport_id else 0}" class="text-center">
     <label class="label label-primary" ng-bind="id ? ('Editing a report' | translate) : ('Creating a report' | translate)"></label>

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -146,7 +146,7 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
   </div>
 
   % if not version:
-    <div class="view-details-associations col-xs-12 associations"
+    <div class="view-details-associations col-xs-12 associations" ng-cloak
          ng-init="a = detailsCtrl.documentService.document.associations"
          ng-show="a.waypoints.length || a.routes.length || a.articles.length || a.outings.length">
       <span class="lead">

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -190,13 +190,6 @@ input[type=checkbox]:checked + * {
   background-position: right 2px center;
 }
 
-.loading {
-  opacity: 0.5;
-  transition: .3s;
-  pointer-events: none;
-  overflow: hidden;
-}
-
 .overflow-scroll {
   overflow-y: scroll;
 }


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/456

As for now, an ``ng-cloak`` directive is set on the main ``<html>`` tag, to make sure the page is shown only when all angular related parts are ready. The downside is that it delays the rendering of the pages, making them appearing slower.

This PR finetunes a bit the use of ``ng-cloak`` to make the page being displayed even if some secondary parts are not ready yet, making the page loading faster.

I have also removed the white shade that is generally shown when the loading directive is enabled (including when the page was loading): I don't think this white shade is really useful and it makes the pages flashing.

An improvement I would like to add as well (but have not succeeded in doing so yet) would be to use a loading bar at the top of the page, as in github pages, eg. https://github.com/c2corg/v6_ui
See https://github.com/chieffancypants/angular-loading-bar

An incomplete PR already exists, see https://github.com/c2corg/v6_ui/pull/963 I have tried to port it to the current PR, but at the moment with no effect (perhaps because of the ``ng-cloak``). See https://github.com/c2corg/v6_ui/pull/1776