### PR TITLE
Contextual help + modification of outing link in sidemenu

### DIFF
--- a/c2corg_ui/static/partials/contexthelp/associate.html
+++ b/c2corg_ui/static/partials/contexthelp/associate.html
@@ -1,0 +1,13 @@
+<p translate>Associate documents (e.g. routes, waypoints, books...etc)</p>
+<ul>
+<li><span translate> Enter a discriminatory part of the document's name. It is possible to search on multiple keywords. For a route, this includes the name of the summit(s) associated to the route.</span></li>
+<li><span translate> A list of documents is shown: click on the document to associate, even if there is only one result.</span></li>
+<li><span translate> For a route, the list of documents contains the routes associated to the selected summit or its sub-summits. Select the desired route.</span></li>
+<li><span translate> It is also possible to enter the document Id (appearing in its URL. Exemple: for the route with https://www.camptocamp.org/routes/57510/fr/triangle-du-pelago-eperon-nw-voie-demenge the Id is 57510).</span></li>
+</ul>
+<p translate>If you have mistakenly associated a document, you cannot de-associate it by yourself. You have to ask the guidebook moderators:</p>
+<ul>
+<li><span translate> Insert a comment to this document and write "@Moderation_Topoguide" at the beginning of the message. This will alert moderators.</span></li>
+<li><span translate> Describe your problem, and post the comment.</span></li>
+</ul>
+

--- a/c2corg_ui/static/partials/contexthelp/associate.html
+++ b/c2corg_ui/static/partials/contexthelp/associate.html
@@ -1,13 +1,12 @@
 <p translate>Associate documents (e.g. routes, waypoints, books...etc)</p>
 <ul>
-<li><span translate> Enter a discriminatory part of the document's name. It is possible to search on multiple keywords. For a route, this includes the name of the summit(s) associated to the route.</span></li>
-<li><span translate> A list of documents is shown: click on the document to associate, even if there is only one result.</span></li>
-<li><span translate> For a route, the list of documents contains the routes associated to the selected summit or its sub-summits. Select the desired route.</span></li>
-<li><span translate> It is also possible to enter the document Id (appearing in its URL. Exemple: for the route with https://www.camptocamp.org/routes/57510/fr/triangle-du-pelago-eperon-nw-voie-demenge the Id is 57510).</span></li>
+  <li translate>Enter a discriminatory part of the document's name. It is possible to search on multiple keywords. For a route, this includes the name of the summit(s) associated to the route.</li>
+  <li translate>A list of documents is shown: click on the document to associate, even if there is only one result.</li>
+  <li translate>For a route, the list of documents contains the routes associated to the selected summit or its sub-summits. Select the desired route.</li>
+  <li translate>It is also possible to enter the document Id appearing in its URL. Eg.: for the route with url https://www.camptocamp.org/routes/57510/fr/triangle-du-pelago-eperon-nw-voie-demenge the Id is 57510.</li>
 </ul>
 <p translate>If you have mistakenly associated a document, you cannot de-associate it by yourself. You have to ask the guidebook moderators:</p>
 <ul>
-<li><span translate> Insert a comment to this document and write "@Moderation_Topoguide" at the beginning of the message. This will alert moderators.</span></li>
-<li><span translate> Describe your problem, and post the comment.</span></li>
+  <li translate> Insert a comment to this document and write "@Moderation_Topoguide" at the beginning of the message. This will alert moderators.</li>
+  <li translate> Describe your problem, and post the comment.</li>
 </ul>
-

--- a/c2corg_ui/static/partials/contexthelp/outing-avalanche_signs.html
+++ b/c2corg_ui/static/partials/contexthelp/outing-avalanche_signs.html
@@ -1,0 +1,22 @@
+<p translate>Observations of danger signs, fresh avalanche trace, and natural avalanche or human-triggered avalanche the day of the outing.</p>
+<p translate>Give your observations concerning the snowpack stability:</p>
+<ul>
+<li><strong translate>Danger signs</strong> :</li>
+	<ul>	
+	<li><span translate>recent cornices</span></li>
+	<li><span translate>slab structure detected with ski pole</span></li>
+	<li><span translate>settling sounds ("chiii", "wouff" ou "bang")</span></li>
+	<li><span translate>shooting cracks</span></li>
+	</ul>
+<li><strong translate>Avalanches</strong> : </li>
+	<ul>	
+	<li><span translate>signs of recent avalanche activity (fracture lines, avalanche track, deposit)</span></li>
+	<li><span translate>natural avalanches or skier-triggered avalanches observed directly</span></li>
+	<li><span translate>settling sounds ("chiii", "wouff" ou "bang")</span></li>
+	<li><span translate>For each avalanche, indicate:</span></li>
+		<ul>	
+		<li><span translate>type of avalanche : dry or wet snow, point or slab release</span></li>
+		<li><span translate>location, elevation and approximate dimensions of the avalanche in the start zone and in the deposit zone</span></li>
+		</ul>
+	</ul>
+</ul>

--- a/c2corg_ui/static/partials/contexthelp/outing-avalanche_signs.html
+++ b/c2corg_ui/static/partials/contexthelp/outing-avalanche_signs.html
@@ -1,22 +1,25 @@
 <p translate>Observations of danger signs, fresh avalanche trace, and natural avalanche or human-triggered avalanche the day of the outing.</p>
 <p translate>Give your observations concerning the snowpack stability:</p>
 <ul>
-<li><strong translate>Danger signs</strong> :</li>
-	<ul>	
-	<li><span translate>recent cornices</span></li>
-	<li><span translate>slab structure detected with ski pole</span></li>
-	<li><span translate>settling sounds ("chiii", "wouff" ou "bang")</span></li>
-	<li><span translate>shooting cracks</span></li>
-	</ul>
-<li><strong translate>Avalanches</strong> : </li>
-	<ul>	
-	<li><span translate>signs of recent avalanche activity (fracture lines, avalanche track, deposit)</span></li>
-	<li><span translate>natural avalanches or skier-triggered avalanches observed directly</span></li>
-	<li><span translate>settling sounds ("chiii", "wouff" ou "bang")</span></li>
-	<li><span translate>For each avalanche, indicate:</span></li>
-		<ul>	
-		<li><span translate>type of avalanche : dry or wet snow, point or slab release</span></li>
-		<li><span translate>location, elevation and approximate dimensions of the avalanche in the start zone and in the deposit zone</span></li>
-		</ul>
-	</ul>
+  <li><strong translate>Danger signs</strong> :
+    <ul>	
+      <li translate>recent cornices</li>
+      <li translate>slab structure detected with ski pole</li>
+      <li translate>settling sounds ("chiii", "wouff" ou "bang")</li>
+      <li translate>shooting cracks</li>
+    </ul>
+  </li>
+  <li><strong translate>Avalanches</strong> :
+    <ul>		
+      <li translate>signs of recent avalanche activity (fracture lines, avalanche track, deposit)</li>
+      <li translate>natural avalanches or skier-triggered avalanches observed directly</li>
+      <li translate>settling sounds ("chiii", "wouff" ou "bang")</li>
+      <li translate>For each avalanche, indicate:
+        <ul>  
+          <li translate>type of avalanche : dry or wet snow, point or slab release</li>
+          <li translate>location, elevation and approximate dimensions of the avalanche in the start zone and in the deposit zone</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
 </ul>

--- a/c2corg_ui/static/partials/contexthelp/outing-conditions_levels.html
+++ b/c2corg_ui/static/partials/contexthelp/outing-conditions_levels.html
@@ -1,0 +1,7 @@
+<p translate>Allows to syntetically indicate the encountered conditions on each part of the route:</p>
+<ul>
+  <li><strong translate>Location / elevation / orientation</strong> : <span translate>caracteristics of the location: localization, elevation range, orientation, relief (dale, gully...).</span></li>
+  <li><strong translate>Soft</strong> : <span translate>depth of soft snow in cm (sinking with the pole).</span></li>
+  <li><strong translate>Total</strong> : <span translate>total snow depth in cm. Leave this field empty if the value is unknown.</span></li>
+  <li><strong translate>Comment</strong> : <span translate>quality of the snow, rough stratigraphic analysis, ski quality.</span></li>
+</ul>

--- a/c2corg_ui/static/partials/contexthelp/outing-frequentation.html
+++ b/c2corg_ui/static/partials/contexthelp/outing-frequentation.html
@@ -1,8 +1,8 @@
 <p translate>Crowding of the route during the outing.</p>
 <p translate>The assessment is of course subjective, but a scale has been built to express crowding and the inconvenience caused by other people on the route:</p>
 <ul>
-<li><strong translate>nobody</strong> : <span translate>we were alone</span></li>
-<li><strong translate>some people</strong> : <span translate>there were other people but not more than our own group (for climbing, there was one other party)</span></li>
-<li><strong translate>quite crowded</strong> : <span translate>there were other people, more than our own group, but they caused no disturbance (for climbing, there were 2 or 3 other parties, well spaced-out on the route)</span></li>
-<li><strong translate>lots of people</strong> : <span translate>there were many other people, in far greater number than our own group, which caused some disturbance (for climbing, there were 4 or more parties, with queuing at the belays or rappels, etc)</span></li>
+  <li><strong translate>nobody</strong> : <span translate>we were alone</span></li>
+  <li><strong translate>some people</strong> : <span translate>there were other people but not more than our own group (for climbing, there was one other party)</span></li>
+  <li><strong translate>quite crowded</strong> : <span translate>there were other people, more than our own group, but they caused no disturbance (for climbing, there were 2 or 3 other parties, well spaced-out on the route)</span></li>
+  <li><strong translate>lots of people</strong> : <span translate>there were many other people, in far greater number than our own group, which caused some disturbance (for climbing, there were 4 or more parties, with queuing at the belays or rappels, etc)</span></li>
 </ul>

--- a/c2corg_ui/static/partials/contexthelp/outing-frequentation.html
+++ b/c2corg_ui/static/partials/contexthelp/outing-frequentation.html
@@ -1,0 +1,8 @@
+<p translate>Crowding of the route during the outing.</p>
+<p translate>The assessment is of course subjective, but a scale has been built to express crowding and the inconvenience caused by other people on the route:</p>
+<ul>
+<li><strong translate>nobody</strong> : <span translate>we were alone</span></li>
+<li><strong translate>some people</strong> : <span translate>there were other people but not more than our own group (for climbing, there was one other party)</span></li>
+<li><strong translate>quite crowded</strong> : <span translate>there were other people, more than our own group, but they caused no disturbance (for climbing, there were 2 or 3 other parties, well spaced-out on the route)</span></li>
+<li><strong translate>lots of people</strong> : <span translate>there were many other people, in far greater number than our own group, which caused some disturbance (for climbing, there were 4 or more parties, with queuing at the belays or rappels, etc)</span></li>
+</ul>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -115,7 +115,7 @@ updating_doc = outing_id and outing_lang
 
             ## ROUTE TAKEN
             <div class="full form-group">
-              <label><span translate>Taken routes</span> *</label>
+              <label app-context-help context-help-title="{{'Taken routes' | translate}}" context-help-content-url="/static/partials/contexthelp/associate.html"><span translate>Taken routes</span> *</label>
               <h5 translate ng-show="outing.associations.routes.length == 0">Choose at least one route taken during the outing.</h5>
               <app-simple-search parent-id="outing.document_id"
                 app-select="editCtrl.documentService.pushToAssociations(doc, 'routes', true)" dataset="r"></app-simple-search>
@@ -253,7 +253,7 @@ updating_doc = outing_id and outing_lang
             ## CONDITIONS LEVELS
             <div class="full form-group"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1 ">
-              <label translate>conditions_levels</label>
+              <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-conditions_levels.html" translate>conditions_levels</label>
               <table class="table table-striped conditions-levels" ng-if="outing.locales[0].conditions_levels[0]">
                 <thead>
                   <tr>
@@ -285,7 +285,7 @@ updating_doc = outing_id and outing_lang
 
             ## CONDITION RATING
             <div class="form-group half" ng-class="{'has-success': outing.condition_rating}" ng-init="condition_ratings = ${condition_ratings}">
-              <label translate>condition_rating</label>
+              <label app-context-help context-help-title="{{'condition_rating' | translate}}" context-help-content="{{'Global judgment on the conditions encountered on the route during the outing. This criterion can be used to filter outings. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>condition_rating</label>
               <div class="input-group">
                 <select class="form-control" ng-model="outing.condition_rating" ng-options="rat as mainCtrl.translate(rat) for rat in condition_ratings"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
@@ -299,7 +299,7 @@ updating_doc = outing_id and outing_lang
                              'has-error': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid,
                              'has-success': outing.elevation_up_snow }"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('mountain_climbing') > -1  || outing.activities.indexOf('snow_ice_mixed') > -1">
-              <label ng-class="{ 'control-label': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid }" translate>elevation_up_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid }" app-context-help context-help-title="{{'elevation_up_snow' | translate}}" context-help-content="{{'Elevation at which skis were put on, on the way up. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>elevation_up_snow</label>
               <div class="input-group">
                 <input type="number" min="0" max="9999" minlength="1" name="elevation_up_snow" ng-model="outing.elevation_up_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
@@ -318,7 +318,7 @@ updating_doc = outing_id and outing_lang
                              'has-error': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid,
                              'has-success': outing.elevation_down_snow }"
                  ng-if="outing.activities.indexOf('snow_ice_mixed') > -1 || outing.activities.indexOf('mountain_climbing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('skitouring') > -1">
-              <label ng-class="{ 'control-label': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid }" translate>elevation_down_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid }" app-context-help context-help-title="{{'elevation_down_snow' | translate}}" context-help-content="{{'Elevation at which skis were taken off, on the way down. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>elevation_down_snow</label>
               <div class="input-group">
                 <input type="number" min="0" max="9999" minlength="1" name="elevation_down_snow" ng-model="outing.elevation_down_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
@@ -349,7 +349,7 @@ updating_doc = outing_id and outing_lang
 
             ## GLACIER RATING
             <div class="form-group half" ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('mountain_climbing') > -1  || outing.activities.indexOf('snow_ice_mixed') > -1 ">
-              <label translate>glacier_rating</label>
+              <label app-context-help context-help-title="{{'glacier_rating' | translate}}" context-help-content="{{'Condition of the glacier followed by the route: covered and easty to cross, delicate but travel is possible, open and difficult to cross or clearly imposible to cross. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>glacier_rating</label>
               <div class="input-group" ng-class="{'has-success': outing.glacier_rating }">
                 <select class="form-control" ng-model="outing.glacier_rating" ng-options="rat as mainCtrl.translate(rat) for rat in ${glacier_ratings}"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
@@ -375,7 +375,7 @@ updating_doc = outing_id and outing_lang
             ## AVALANCHES
             <div class="form-group  full"  ng-if="(outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1
                       || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1) && (outing.avalanche_signs != 'no' && outing.avalanche_signs != null) ">
-              <label translate>avalanches</label>
+              <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-avalanche_signs.html" translate>avalanches</label>
               <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['avalanches']"></textarea>
             </div>
 
@@ -399,7 +399,7 @@ updating_doc = outing_id and outing_lang
 
             ## FREQUENTATION
             <div class="form-group half" ng-class="{'has-success': outing.frequentation}" ng-init="frequentation_types = ${frequentation_types}">
-              <label translate>frequentation</label>
+              <label app-context-help context-help-title="{{'frequentation' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-frequentation.html" translate>frequentation</label>
               <select class="form-control" ng-model="outing.frequentation" ng-options="rat as mainCtrl.translate(rat) for rat in frequentation_types"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.frequentation"></span>
             </div>
@@ -509,7 +509,9 @@ updating_doc = outing_id and outing_lang
             ## ASSOCIATED PARTICIPANTS
             ## TODO better to show all users in one row, will have to convert users in controller.
             <div id="participants-group" class="form-group  full" ng-class="{'has-success': outing.locales[0]['participants']}">
-              <label translate>associated_participants</label>
+              <label app-context-help context-help-title="{{'associated_participants' | translate}}" context-help-content="{{'Registered participants can be directly associated to the outing, thus allowing them to modify the outing, add pictures, and associate other registered participants.' |translate}}" translate>associated_participants</label>
+
+
 
               <section class="section associations" ng-show="outing.associations.users.length > 0">
                 <app-simple-search parent-id="outing.document_id"
@@ -529,7 +531,7 @@ updating_doc = outing_id and outing_lang
 
             ## PARTICIPANTS
             <div id="participants-group" class="form-group full" ng-class="{'has-success': outing.locales[0]['participants']}">
-              <label translate>participants</label>
+              <label app-context-help context-help-title="{{'participants' | translate}}" context-help-content="{{'List of participants to the outing who are not registered users on the website.' |translate}}" translate>participants</label>
               <div class="input-group">
                 <input type="text"  ng-model="outing.locales[0]['participants']" class="form-control" />
                 <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>

--- a/c2corg_ui/templates/outing/edit.html
+++ b/c2corg_ui/templates/outing/edit.html
@@ -253,7 +253,7 @@ updating_doc = outing_id and outing_lang
             ## CONDITIONS LEVELS
             <div class="full form-group"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1 ">
-              <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-conditions_levels.html" translate>conditions_levels</label>
+               <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-conditions_levels.html"><span translate>conditions_levels</span></label>
               <table class="table table-striped conditions-levels" ng-if="outing.locales[0].conditions_levels[0]">
                 <thead>
                   <tr>
@@ -285,7 +285,7 @@ updating_doc = outing_id and outing_lang
 
             ## CONDITION RATING
             <div class="form-group half" ng-class="{'has-success': outing.condition_rating}" ng-init="condition_ratings = ${condition_ratings}">
-              <label app-context-help context-help-title="{{'condition_rating' | translate}}" context-help-content="{{'Global judgment on the conditions encountered on the route during the outing. This criterion can be used to filter outings. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>condition_rating</label>
+              <label app-context-help context-help-title="{{'condition_rating' | translate}}" context-help-content="{{'Global judgment on the conditions encountered on the route during the outing. This criterion can be used to filter outings. The <i>Conditions</i> field allows to fill in additional information.' | translate}}"><span translate>condition_rating</span></label>
               <div class="input-group">
                 <select class="form-control" ng-model="outing.condition_rating" ng-options="rat as mainCtrl.translate(rat) for rat in condition_ratings"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
@@ -299,7 +299,7 @@ updating_doc = outing_id and outing_lang
                              'has-error': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid,
                              'has-success': outing.elevation_up_snow }"
                  ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('mountain_climbing') > -1  || outing.activities.indexOf('snow_ice_mixed') > -1">
-              <label ng-class="{ 'control-label': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid }" app-context-help context-help-title="{{'elevation_up_snow' | translate}}" context-help-content="{{'Elevation at which skis were put on, on the way up. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>elevation_up_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_up_snow.$touched && editForm.elevation_up_snow.$invalid }" app-context-help context-help-title="{{'elevation_up_snow' | translate}}" context-help-content="{{'Elevation at which skis were put on, on the way up. The <i>Conditions</i> field allows to fill in additional information.' | translate}}"><span translate>elevation_up_snow</span></label>
               <div class="input-group">
                 <input type="number" min="0" max="9999" minlength="1" name="elevation_up_snow" ng-model="outing.elevation_up_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
@@ -318,7 +318,7 @@ updating_doc = outing_id and outing_lang
                              'has-error': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid,
                              'has-success': outing.elevation_down_snow }"
                  ng-if="outing.activities.indexOf('snow_ice_mixed') > -1 || outing.activities.indexOf('mountain_climbing') > -1 || outing.activities.indexOf('ice_climbing') > -1  || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('skitouring') > -1">
-              <label ng-class="{ 'control-label': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid }" app-context-help context-help-title="{{'elevation_down_snow' | translate}}" context-help-content="{{'Elevation at which skis were taken off, on the way down. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>elevation_down_snow</label>
+              <label ng-class="{ 'control-label': editForm.elevation_down_snow.$touched && editForm.elevation_down_snow.$invalid }" app-context-help context-help-title="{{'elevation_down_snow' | translate}}" context-help-content="{{'Elevation at which skis were taken off, on the way down. The <i>Conditions</i> field allows to fill in additional information.' | translate}}"><span translate>elevation_down_snow</span></label>
               <div class="input-group">
                 <input type="number" min="0" max="9999" minlength="1" name="elevation_down_snow" ng-model="outing.elevation_down_snow" class="form-control" />
                 <span class="input-group-addon">m</span>
@@ -349,7 +349,7 @@ updating_doc = outing_id and outing_lang
 
             ## GLACIER RATING
             <div class="form-group half" ng-if="outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1 || outing.activities.indexOf('mountain_climbing') > -1  || outing.activities.indexOf('snow_ice_mixed') > -1 ">
-              <label app-context-help context-help-title="{{'glacier_rating' | translate}}" context-help-content="{{'Condition of the glacier followed by the route: covered and easty to cross, delicate but travel is possible, open and difficult to cross or clearly imposible to cross. The <i>Conditions</i> field allows to fill in additional information.' | translate}}" translate>glacier_rating</label>
+              <label app-context-help context-help-title="{{'glacier_rating' | translate}}" context-help-content="{{'Condition of the glacier followed by the route: covered and easy to cross, delicate but travel is possible, open and difficult to cross or clearly imposible to cross. The <i>Conditions</i> field allows to fill in additional information.' | translate}}"><span translate>glacier_rating</span></label>
               <div class="input-group" ng-class="{'has-success': outing.glacier_rating }">
                 <select class="form-control" ng-model="outing.glacier_rating" ng-options="rat as mainCtrl.translate(rat) for rat in ${glacier_ratings}"><option value=""></option></select>
                 <span class="input-group-addon"><span class="glyphicon glyphicon-star"></span></span>
@@ -375,7 +375,7 @@ updating_doc = outing_id and outing_lang
             ## AVALANCHES
             <div class="form-group  full"  ng-if="(outing.activities.indexOf('skitouring') > -1 || outing.activities.indexOf('snowshoeing') > -1
                       || outing.activities.indexOf('ice_climbing') > -1 || outing.activities.indexOf('snow_ice_mixed') > -1) && (outing.avalanche_signs != 'no' && outing.avalanche_signs != null) ">
-              <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-avalanche_signs.html" translate>avalanches</label>
+              <label app-context-help context-help-title="{{'conditions_levels' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-avalanche_signs.html"><span translate>avalanches</span></label>
               <textarea app-markdown-editor class="form-control" ng-model="outing.locales[0]['avalanches']"></textarea>
             </div>
 
@@ -399,7 +399,7 @@ updating_doc = outing_id and outing_lang
 
             ## FREQUENTATION
             <div class="form-group half" ng-class="{'has-success': outing.frequentation}" ng-init="frequentation_types = ${frequentation_types}">
-              <label app-context-help context-help-title="{{'frequentation' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-frequentation.html" translate>frequentation</label>
+              <label app-context-help context-help-title="{{'frequentation' | translate}}" context-help-content-url="/static/partials/contexthelp/outing-frequentation.html"><span translate>frequentation</span></label>
               <select class="form-control" ng-model="outing.frequentation" ng-options="rat as mainCtrl.translate(rat) for rat in frequentation_types"><option value=""></option></select>
               <span class="glyphicon glyphicon-ok form-control-feedback" ng-show="outing.frequentation"></span>
             </div>
@@ -509,9 +509,7 @@ updating_doc = outing_id and outing_lang
             ## ASSOCIATED PARTICIPANTS
             ## TODO better to show all users in one row, will have to convert users in controller.
             <div id="participants-group" class="form-group  full" ng-class="{'has-success': outing.locales[0]['participants']}">
-              <label app-context-help context-help-title="{{'associated_participants' | translate}}" context-help-content="{{'Registered participants can be directly associated to the outing, thus allowing them to modify the outing, add pictures, and associate other registered participants.' |translate}}" translate>associated_participants</label>
-
-
+              <label app-context-help context-help-title="{{'associated_participants' | translate}}" context-help-content="{{'Registered participants can be directly associated to the outing, thus allowing them to modify the outing, add pictures, and associate other registered participants.' |translate}}"><span translate>associated_participants</span></label>
 
               <section class="section associations" ng-show="outing.associations.users.length > 0">
                 <app-simple-search parent-id="outing.document_id"
@@ -531,7 +529,7 @@ updating_doc = outing_id and outing_lang
 
             ## PARTICIPANTS
             <div id="participants-group" class="form-group full" ng-class="{'has-success': outing.locales[0]['participants']}">
-              <label app-context-help context-help-title="{{'participants' | translate}}" context-help-content="{{'List of participants to the outing who are not registered users on the website.' |translate}}" translate>participants</label>
+              <label app-context-help context-help-title="{{'participants' | translate}}" context-help-content="{{'List of participants to the outing who are not registered users on the website.' |translate}}"><span translate>participants</span></label>
               <div class="input-group">
                 <input type="text"  ng-model="outing.locales[0]['participants']" class="form-control" />
                 <span class="input-group-addon"><span class="glyphicon glyphicon-user"></span></span>
@@ -563,7 +561,7 @@ updating_doc = outing_id and outing_lang
             </div>
 
             ## COMMENTS MANAGEMENT
-            <div class="form-group half">
+            <div class="form-group full">
               <label translate>disable_comments</label>
               <input type="checkbox" ng-model="outing.disable_comments">
               <span ng-click="editCtrl.pushToArray(outing, 'disable_comments', !outing.disable_comments, $event)" translate>If checked, comments cannot be posted or read.</span>

--- a/c2corg_ui/templates/sidemenu.html
+++ b/c2corg_ui/templates/sidemenu.html
@@ -22,7 +22,7 @@
       </a>
     </li>
     <li class="main-menu" ng-class="{'menu-selected': mainCtrl.isPath('outings')}">
-      <a href="${request.route_path('outings_index')}">
+      <a href="${request.route_path('outings_index')}#qa=draft,great">
         <i class="glyphicon glyphicon-time" tooltip-placement="right" uib-tooltip="{{'Outings' | translate}}"></i>
         <span class="menu-text" translate>Outings</span>
       </a>


### PR DESCRIPTION
- Modification of outing link in sidemenu : solve [#1437](urlhttps://github.com/c2corg/v6_ui/issues/1437) for outings. Outings having a completeness in the range "draft-excellent" are displayed by default. An user have to modify filter criterion to display empty outings. This concerns only the file "sidemenu.html"
- Add contextual help in the outing creation form. Solve [#1772](urlhttps://github.com/c2corg/v6_ui/issues/1772)
