### PR TITLE
Add langs to feed preferences

### DIFF
--- a/c2corg_ui/static/js/preferences.js
+++ b/c2corg_ui/static/js/preferences.js
@@ -52,6 +52,12 @@ app.PreferencesController = function($scope, appAuthentication, appApi,
   this.activities = [];
 
   /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.langs = [];
+
+  /**
    * @type {Array.<appx.Area>}
    * @export
    */
@@ -67,6 +73,7 @@ app.PreferencesController = function($scope, appAuthentication, appApi,
     this.api_.readPreferences().then(function(response) {
       var data = /** @type {appx.UserPreferences} */ (response['data']);
       this.activities = data.activities;
+      this.langs = data.langs;
       this.areas = data.areas;
       this.followed_only = data.followed_only;
 
@@ -95,6 +102,22 @@ app.PreferencesController.prototype.updateActivities = function(activity) {
     });
   } else {
     this.activities.push(activity);
+  }
+  this.save_();
+};
+
+
+/**
+ * @param {string} lang
+ * @export
+ */
+app.PreferencesController.prototype.updateLangs = function(lang) {
+  if (this.langs.indexOf(lang) > -1) {
+    this.langs = this.langs.filter(function(item) {
+      return item !== lang;
+    });
+  } else {
+    this.langs.push(lang);
   }
   this.save_();
 };
@@ -134,6 +157,7 @@ app.PreferencesController.prototype.removeArea = function(id) {
 app.PreferencesController.prototype.save_ = function() {
   var data = {
     'activities': this.activities,
+    'langs': this.langs,
     'areas': this.areas,
     'followed_only': this.followed_only
   };

--- a/c2corg_ui/templates/preferences.html
+++ b/c2corg_ui/templates/preferences.html
@@ -1,5 +1,5 @@
 <%!
-from c2corg_common.attributes import activities
+from c2corg_common.attributes import activities, default_langs
 %>
 <%inherit file="base.html"/>
 <%namespace file="helpers/common.html" import="show_title, generate_empty_list_items"/>
@@ -23,6 +23,27 @@ from c2corg_common.attributes import activities
 
     <div ng-hide="prefCtrl.followed_only" class="section preferences-act-areas">
 
+      <div class="preferences-langs">
+        <h3 class="green-text text-left" translate>langs</h3>
+        <div class="flex wrap-row">
+          <button type="button" ng-repeat="lang in ${default_langs}"
+                  ng-click="prefCtrl.updateLangs(lang)" class="btn btn-default"
+                  ng-class="{'orange-btn' : prefCtrl.langs.indexOf(lang) > -1}">{{lang | translate}}</button>
+        </div>
+      </div>
+
+      <div class="preferences-activities">
+        <h3 class="green-text text-left" translate>activities</h3>
+        <div class="route-activities flex wrap-row">
+          <div ng-repeat="activity in ${activities}" class="activity">
+            <div class="route-activity icon-{{activity}}" class="icon-" ng-click="prefCtrl.updateActivities(activity)"
+                 ng-class="{'activity-selected' : prefCtrl.activities.indexOf(activity) > -1}">
+            </div>
+            <p>{{activity | translate}}</p>
+          </div>
+        </div>
+      </div>
+
       <div class="preferences-areas">
         <h3 translate class="green-text">Areas</h3>
         <app-simple-search app-select="prefCtrl.addArea(doc)" dataset="a"></app-simple-search>
@@ -34,18 +55,6 @@ from c2corg_common.attributes import activities
             <span class="glyphicon glyphicon-trash" ng-click="prefCtrl.removeArea(area.document_id)"></span>
           </div>
           ${generate_empty_list_items(5)}
-        </div>
-      </div>
-
-      <div class="preferences-activities section associations ">
-        <h3 class="green-text text-left" translate>activities</h3>
-        <div class="route-activities flex wrap-row">
-          <div ng-repeat="activity in ${activities}" class="activity">
-            <div class="route-activity icon-{{activity}}" class="icon-" ng-click="prefCtrl.updateActivities(activity)"
-                 ng-class="{'activity-selected' : prefCtrl.activities.indexOf(activity) > -1}">
-            </div>
-            <p>{{activity | translate}}</p>
-          </div>
         </div>
       </div>
 

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -970,9 +970,12 @@ ul {
       font-size: 6em;
     }
   }
-  .preferences-activities, .preferences-areas {
+  .preferences-activities, .preferences-areas, .preferences-langs {
     border-top: 1px solid rgba(221, 221, 221, 0.5);
     margin-top: 30px;
+  }
+  .preferences-langs button {
+    margin: 5px;
   }
   @media @phone {
     .route-activity {


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1382

I have changed the order of the filters: WAS regions > activities, NOW IS langs > activities > regions => makes the new "langs" pref more visible + if there are many regions, the activities filter is not pushed far down the page.

The PR is ready. Or almost: I would like to get rid of the "focus" styling of the buttons (there are shown gray after being clicked) => I would like to have only 2 states: either orange (selected) or white (not selected).
But I have not found how to have the "focus" styling ignored!?

![capture du 2017-09-13 19-59-21](https://user-images.githubusercontent.com/1192331/30392770-122a06b4-98be-11e7-9f7a-f7413a21767a.png)
