### PR TITLE
Fix contextual help partial encoding

### DIFF
--- a/c2corg_ui/static/partials/contexthelp/route-labande_ski_rating.html
+++ b/c2corg_ui/static/partials/contexthelp/route-labande_ski_rating.html
@@ -3,7 +3,7 @@
   <li><strong>S1</strong> : <span translate>Easy descent which does not require any particular technical abilities such as forest tracks for example.</span></li>
   <li><strong>S2</strong> : <span translate>Wide slopes which are easy to manoeuvre, maybe fairly steep (25&deg;).</span></li>
   <li><strong>S3</strong> : <span translate>Slopes up to 35&deg; (equivalent to the steepest runs in ski resorts, on hard snow). Requires good skiing abilities in all snow conditions.</span></li>
-  <li><strong>S4</strong> : <span translate>Slopes up to 45&deg;, if exposure is low (between 30 and 40° if it is high or the passage is narrow). Very good skiing abilities are required.</span></li>
+  <li><strong>S4</strong> : <span translate>Slopes up to 45&deg;, if exposure is low (between 30 and 40&deg; if it is high or the passage is narrow). Very good skiing abilities are required.</span></li>
   <li><strong>S5</strong> : <span translate>Slopes between 45 and 50&deg; or more if exposure remains low. From 40&deg; upwards if exposure is high. As well as a perfect downhill skiing technique, control of nerves becomes very important at this level of difficulty.</span></li>
   <li><strong>S6</strong> : <span translate>Above 50&deg; if exposure is high (which is often the case) or short stretches above 55&deg; with little exposure.</span></li>
   <li><strong>S7</strong> : <span translate>Stretches at 60&deg; or more, high rock bands to jump or more generally very steep or exposed terrain.</span></li>


### PR DESCRIPTION
The docker image generation is currently blocked for the UI because of some encoding problem in ``c2corg_ui/static/partials/contexthelp/route-labande_ski_rating.html``

See https://travis-ci.org/c2corg/v6_ui/builds/279916613#L4417-L4424
> Traceback (most recent call last):
  File "/var/www/.build/venv/lib/python3.4/site-packages/mako/cmd.py", line 61, in cmdline
    sys.stdout.write(template.render(**kw))
UnicodeEncodeError: 'ascii' codec can't encode character '\xb0' in position 61770: ordinal not in range(128)
make: *** [c2corg_ui/static/build/templatecache.js] Error 1
Makefile:239: recipe for target 'c2corg_ui/static/build/templatecache.js' failed

I had already fixed the problem in https://github.com/c2corg/v6_ui/pull/1783 but should have made the change in a dedicated PR. I have then cherry-picked the change from branch ``feed_redesign`` to the current branch, hoping it won't create a conflict (will it?).