### PR TITLE
 Add Text in the middle feature support & test

### DIFF
--- a/c2corg_ui/format/ltag.py
+++ b/c2corg_ui/format/ltag.py
@@ -11,52 +11,59 @@ from markdown.preprocessors import Preprocessor
 from markdown.blockprocessors import BlockProcessor
 from markdown.util import etree
 import re
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class LTagPreprocessor(Preprocessor):
     """ Preprocess lines to clean LTag blocks """
 
     """ Supported tags are L#, R# """
-    RE_LTAG_UNSUPPORTED = re.compile(r'[L|R]#[^\s|]+')
+    RE_LTAG_UNSUPPORTED = re.compile(r'[L|R]#[^\s|\~]+')
 
     def __init__(self, processor):
         self.processor = processor
 
-    def is_ltag_supported(self, text):
+    def is_line_ltag_supported(self, text):
         return self.RE_LTAG_UNSUPPORTED.search(text) is not None
 
     def run(self, lines):
         # Reset ltag processor
         self.processor.reset_for_new_document()
+
         new_lines = []
-        is_ltag_block = False
-        nb_lines = len(lines)
+        is_block_ltag = False
+        last_line = len(lines) - 1
         for i, line in enumerate(lines):
 
             # If there is an unsupported tag, skip the entire block
-            if self.is_ltag_supported(line):
-                self.processor.set_skip(True)
+            if self.is_line_ltag_supported(line):
+                log.info("Skip all because of unsupported LTAG : \""+line+"\"")
+                self.processor.skip()
 
-            is_ltag_line = self.processor.is_ltag(line)
-            if i < nb_lines - 1:
-                is_ltag_next_line = self.processor.is_ltag(lines[i+1])
+            # Are current & next lines LTags ?
+            is_line_ltag_line = self.processor.is_line_globally_ltag(line)
+            if i < last_line:
+                is_line_ltag_next_line \
+                    = self.processor.is_line_globally_ltag(lines[i+1])
             else:
-                is_ltag_next_line = False
+                is_line_ltag_next_line = False
 
             # Strip empty lines inside ltag blocks
-            if is_ltag_block and is_ltag_next_line and not line.strip():
+            if is_block_ltag and is_line_ltag_next_line and not line.strip():
                 continue
 
-            # Make sur LTag block is preceded by a blank line
-            if not is_ltag_block and is_ltag_line and lines[i-1].strip():
+            # Make sure LTag block is preceded by a blank line
+            if not is_block_ltag and is_line_ltag_line and lines[i-1].strip():
                 new_lines.append("\n")
 
-            # Make sur LTag block is followed by a blank line
-            if is_ltag_block and not is_ltag_line and line.strip():
+            # Make sure LTag block is followed by a blank line
+            if is_block_ltag and not is_line_ltag_line and line.strip():
                 new_lines.append("\n")
 
             new_lines.append(line)
-            is_ltag_block = is_ltag_line
+            is_block_ltag = is_line_ltag_line
 
         return new_lines
 
@@ -64,26 +71,30 @@ class LTagPreprocessor(Preprocessor):
 class LTagProcessor(BlockProcessor):
     """ Process LTags. """
 
-    RE_LTAG_BLOCK = re.compile(r'^\s*(?:[L|R]#(?:[^|\n]*(?:\|[^|\n]*)+)\n?)+$')
-    RE_LTAG = re.compile(r'([L|R])#(_|~|[0-9]*)')
+    RE_LTAG_BLOCK = re.compile(r'^\s*(?:[L|R]#(?:[^|\n]*(?:\|[^|\n]*)+))+$')
+    RE_LTAG_FOR_TEXT_IN_THE_MIDDLE_BLOCK = re.compile(r'^\s*[L|R]#~.*$')
+    RE_LTAG = re.compile(r'(?P<pitch_type>[L|R])#(?P<modifier>_|[0-9]*)')
+    RE_LTAG_FOR_TEXT_IN_THE_MIDDLE = re.compile(r'[L|R]#~\s*')
     RE_RTAG_ROW_DISTINCTION = re.compile(r'^\s*R#.*$')
     RE_PIPE_SELECTION = re.compile(r'(\|)(?![^|]*\]\])')
+
     ltag_template = '<span class="pitch"><span translate>{0}</span>{1}</span>'
     pipe_replacement = '__--|--__'
     pitch_count = 1
     abseil_count = 1
-    skip = False
+    shouldSkip = False
+    text_in_the_middle = False
 
     def __init__(self, parser):
         super(LTagProcessor, self).__init__(parser)
 
-    def set_skip(self, skip):
-        self.skip = skip
+    def skip(self):
+        self.shouldSkip = True
 
     def reset_for_new_document(self):
         self.pitch_count = 1
         self.abseil_count = 1
-        self.skip = False
+        self.shouldSkip = False
 
     def increment_row_count(self, row):
         if self.RE_RTAG_ROW_DISTINCTION.search(row) is not None:
@@ -98,11 +109,46 @@ class LTagProcessor(BlockProcessor):
 
         return self.pitch_count
 
-    def is_ltag(self, text):
+    def is_line_ltag(self, text):
         return self.RE_LTAG_BLOCK.search(text) is not None
 
+    def is_line_globally_ltag(self, text):
+        is_line_ltag = self.is_line_ltag(text)
+
+        if is_line_ltag:
+            self.text_in_the_middle = False
+
+        # There is some text lines that should be consider as ltag
+        if self.text_in_the_middle:
+            return True
+
+        # There is a text in the middle LTAG "L#~"
+        # so we'll include the following lines until next LTAG
+        if self.is_line_ltag_for_text_in_the_middle(text):
+            self.text_in_the_middle = True
+            return True
+
+        return is_line_ltag
+
+    def is_line_ltag_for_text_in_the_middle(self, text):
+        return self.RE_LTAG_FOR_TEXT_IN_THE_MIDDLE_BLOCK.search(text) \
+            is not None
+
     def test(self, parent, block):
-        return not self.skip and self.is_ltag(block)
+        # Early return if we have to skip the whole block because of an
+        # unsupported Ltag
+        if self.shouldSkip:
+            return False
+
+        # Split block in lines
+        rows = block.split('\n')
+        is_block_ltag = True
+        for row in rows:
+            if not self.is_line_globally_ltag(row):
+                is_block_ltag = False
+                break
+
+        return is_block_ltag
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
@@ -114,13 +160,33 @@ class LTagProcessor(BlockProcessor):
         table = etree.SubElement(parent, 'table')
         table.set('class', 'ltag')
         tbody = etree.SubElement(table, 'tbody')
+        max_col_number = 0
+        text_in_the_middle_td = None
         for row in rows:
+            # Text in the middle case
+            if self.is_line_ltag(row):
+                text_in_the_middle_td = None
+
+            if text_in_the_middle_td is not None:
+                text_in_the_middle_td.text = text_in_the_middle_td.text \
+                    + "<br/>" + row
+                continue
+
+            if self.is_line_ltag_for_text_in_the_middle(row):
+                tr = etree.SubElement(tbody, 'tr')
+                text_in_the_middle_td = etree.SubElement(tr, 'td')
+                text_in_the_middle_td.set('colspan', str(max_col_number - 1))
+                text_in_the_middle_td.text \
+                    = self.RE_LTAG_FOR_TEXT_IN_THE_MIDDLE.sub('', row)
+                continue
+
             tr = etree.SubElement(tbody, 'tr')
             cols = row.split(self.pipe_replacement)
             col_number = 1
 
-            # Pitch / Abseil cell
+            # Pitch / Relay cell
             td = etree.SubElement(tr, 'td')
+
             td.text = self.process_ltag(cols[0], col_number)
             col_number += 1
 
@@ -130,6 +196,8 @@ class LTagProcessor(BlockProcessor):
                 td.text = self.process_ltag(col, col_number)
                 col_number += 1
 
+            max_col_number = max(col_number, max_col_number)
+
             self.increment_row_count(row)
 
     def process_ltag(self, text, col_number):
@@ -137,8 +205,8 @@ class LTagProcessor(BlockProcessor):
         matches = self.RE_LTAG.finditer(text)
 
         for match in matches:
-            pitch_type = match.group(1)
-            # modifier = match.group(2)
+            pitch_type = match.group('pitch_type')
+            # modifier = match.group('modifier')
             pitch_number = self.get_row_count(col_number, pitch_type)
 
             text = text.replace(

--- a/c2corg_ui/tests/format/test/ltags.json
+++ b/c2corg_ui/tests/format/test/ltags.json
@@ -21,7 +21,12 @@
     },
     {
         "id": "Unsupported LTag",
-        "text": "L#~ |1\nL#| 2",
-        "expected": "<p>L#~ |1<br />\nL#| 2</p>"
+        "text": "L#+1 |1\nL#| 2",
+        "expected": "<p>L#+1 |1<br />\nL#| 2</p>"
+    },
+    {
+        "id": "Text in the middle",
+        "text": "L# | 1 \nL#~ text in\nthe middle\nL# | 2 ",
+        "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td colspan=\"2\">text in<br/>the middle</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
     }
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,15 @@ ui:
   environment:
     api_url: 'https://api.demov6.camptocamp.org'
     version: ''
-    redis_url: 'redis://redis:6379/'
+#   redis_url: 'redis://redis:6379/'
   volumes:
     - ./c2corg_ui:/var/www/c2corg_ui
     - ./less:/var/www/less
     - ./less-discourse:/var/www/less-discourse
     - ./less-print:/var/www/less-print
-  #command: make -f config/docker serve
-  #links:
-  #  - redis
+  command: make -f config/docker serve
+# links:
+#    - redis
 
 #redis:
 #  image: 'docker.io/redis:3.2'


### PR DESCRIPTION
New PR, same as https://github.com/c2corg/v6_ui/pull/1824 with squashed commits & origin branch

Given the result for that much complexity added to the code, I'm not sure that I've properly understood the original purpose of tag `L#~`. Documentation didn't helped me that much ^^ https://www.camptocamp.org/articles/305462/fr/aide-topoguide-l-balise-de-description-des-longueurs

Markdown

``` 
## Approche
Du pont sur le Tramouillon revenir vers le village et prendre immédiatement à gauche une sente qui monte vers la falaise du Ponteil. Prendre une sente vers la partie droite de la falaise. Noms indiqués au pied des voies sur une vire. Départ commun avec [[routes/57140|Yakafokon]].

## La voie

L# | 5b+ | tout droit, courte longueur à enchaîner avec L2 (Yakafokon part à droite)

L# | 6a+ | un petit toit (pas de bloc) puis un dièdre court et technique.

L# | 6a | traverse à gauche, remonte un dièdre et retraverse à gauche les pieds dans une dalle patinée pour contourner un toit.

L#~ Texte.
Retour à la ligne possible.

Saut de ligne possible en ajoutant au moins un espace dans la ligne vide.
Les sous-titres et les listes ne sont pas acceptés.

L# | 6a | tout droit, court passage athlétique puis facile pour rejoindre un dièdre puis une traversée en dalle sous un gros toit.

L# | 6b+ | contourne le toit par la gauche, athlétique et soutenu ; très bien protégé.

L# | 6a | un pas à gauche puis tout droit dans un dièdre évasé pour sortir sur une large vire.

Descendre de quelques mètres sur la vire pour trouver la dernière longueur.

L# | 5c | grande longueur en ascendance à droite dans un système de dièdres/blocs puis dalle à silex.

## Descente
On peut rejoindre la sortie de Nid d'Aigle 50m à droite en sortant de la voie. Une corde statique permet d'accéder au premier rappel. 
- Corde de 2*50m : trois rappels. 
- Corde de 2*60m : deux rappels (le premier faisant 58m).

On peut aussi emprunter les rappels situés 30m à droite de la Martine : premier rappel de 40m sur un arbre, puis un deuxième de 40m sur chaîne.
```

HTML
```
<div class="ficontent collapse max in">
  <summary class="document-summary">
      
      <p>Très belle ambiance aérienne, face courte mais soutenue.</p>
  </summary>

  
  <h3 id="approche">Approche</h3>
  <p>Du pont sur le Tramouillon revenir vers le village et prendre immédiatement à gauche une sente qui monte vers la falaise du Ponteil. Prendre une sente vers la partie droite de la falaise. Noms indiqués au pied des voies sur une vire. Départ commun avec <a href="/routes/57140">Yakafokon</a>.</p>
  <h3 id="la-voie">La voie</h3>
  <table class="ltag">
    <tbody>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>1</span></td>
            <td>5b+</td>
            <td>tout droit, courte longueur à enchaîner avec L2 (Yakafokon part à droite)</td>
        </tr>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>2</span></td>
            <td>6a+</td>
            <td>un petit toit (pas de bloc) puis un dièdre court et technique.</td>
        </tr>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>3</span></td>
            <td>6a</td>
            <td>traverse à gauche, remonte un dièdre et retraverse à gauche les pieds dans une dalle patinée pour contourner un toit.</td>
        </tr>
        <tr>
            <td colspan="4">Texte.<br>Retour à la ligne possible.<br>Saut de ligne possible en ajoutant au moins un espace dans la ligne vide.<br>Les sous-titres et les listes ne sont pas acceptés.</td>
        </tr>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>4</span></td>
            <td>6a</td>
            <td>tout droit, court passage athlétique puis facile pour rejoindre un dièdre puis une traversée en dalle sous un gros toit.</td>
        </tr>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>5</span></td>
            <td>6b+</td>
            <td>contourne le toit par la gauche, athlétique et soutenu ; très bien protégé.</td>
        </tr>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>6</span></td>
            <td>6a</td>
            <td>un pas à gauche puis tout droit dans un dièdre évasé pour sortir sur une large vire.</td>
        </tr>
    </tbody>
</table>
<p>Descendre de quelques mètres sur la vire pour trouver la dernière longueur.</p>
<table class="ltag">
    <tbody>
        <tr>
            <td><span class="pitch"><span translate=""><span class="ng-scope">L</span></span>7</span></td>
            <td>5c</td>
            <td>grande longueur en ascendance à droite dans un système de dièdres/blocs puis dalle à silex.</td>
        </tr>
    </tbody>
</table>
<h3 id="descente">Descente</h3>
<p>On peut rejoindre la sortie de Nid d'Aigle 50m à droite en sortant de la voie. Une corde statique permet d'accéder au premier rappel. <br>
    - Corde de 2<em>50m : trois rappels. <br>
    - Corde de 2</em>60m : deux rappels (le premier faisant 58m).</p>
    <p>On peut aussi emprunter les rappels situés 30m à droite de la Martine : premier rappel de 40m sur un arbre, puis un deuxième de 40m sur chaîne.</p>
</div>
```

Result
<img width="806" alt="capture d ecran 2017-11-20 a 22 57 28" src="https://user-images.githubusercontent.com/1516110/33043611-4e6fa44a-ce46-11e7-8125-37afb43222a5.png">
