### PR TITLE
Remove now useless bottom margin on mobile

### DIFF
--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -1412,7 +1412,7 @@ app-add-association {
 
   @media @phone {
     min-height:  50px;
-    margin-bottom: -200px;
+    margin-bottom: 0;
   }
   h2 {
     margin-top: 10px;


### PR DESCRIPTION
Fixes #1856: on mobile, a botom margin of `-200px` was used, but it doesn't seem useful anymore. With the new design, content bottom is hidden > emove this margin.