### PR TITLE
Remove some useless classes

### DIFF
--- a/c2corg_ui/templates/outing/preview.html
+++ b/c2corg_ui/templates/outing/preview.html
@@ -36,7 +36,7 @@ ${show_preview_warning()}
          % endif
       </div>
        <div class="col-xs-12 col-md-8 col-lg-9">
-         <section id="document-informations" class="collapse in">
+         <section id="document-informations">
              <div class="finfo">
               <div class="ficontent">
                 <div class="row">

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -130,7 +130,7 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
            ${get_licence(outing)}
         </div>
          <div class="col-xs-12 col-md-8 col-lg-9" id="right-column">
-           <section id="document-informations" class="collapse in">
+           <section id="document-informations">
                <div class="finfo">
                 <div class="ficontent">
                   <div class="row">

--- a/c2corg_ui/templates/route/preview.html
+++ b/c2corg_ui/templates/route/preview.html
@@ -34,7 +34,7 @@ ${show_preview_warning()}
       </div>
       <div class="col-xs-12 col-md-8 col-lg-9">
 
-        <section id="document-informations" class="collapse in flexmobile">
+        <section id="document-informations" class="flexmobile">
           <div class="finfo">
             <div class="ficontent">
               <div class="row">

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -135,7 +135,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
           ${get_licence(route)}
         </div>
         <div class="col-xs-12 col-md-8 col-lg-9" id="right-column">
-          <section id="document-informations" class="collapse in flexmobile">
+          <section id="document-informations" class="flexmobile">
             <div class="finfo">
               <div class="ficontent">
                 <div class="row">

--- a/c2corg_ui/templates/waypoint/preview.html
+++ b/c2corg_ui/templates/waypoint/preview.html
@@ -31,7 +31,7 @@ ${show_preview_warning()}
 
       </div>
       <div class="col-xs-12 cold-md-8 col-lg-9">
-        <section id="document-informations" class="collapse in">
+        <section id="document-informations">
           <div class="finfo">
             <div class="ficontent">
               <div class="row">

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -137,7 +137,7 @@ waypoint['doctype'] = 'waypoints'
 
           </div>
           <div class="col-xs-12 cold-md-8 col-lg-9" id="right-column">
-            <section id="document-informations" class="collapse in">
+            <section id="document-informations">
               <div class="finfo">
                 <div class="ficontent">
                   <div class="row">


### PR DESCRIPTION
Some classes applied to document-informations sections are useless: there is no collapsing applied there.