### PR TITLE
Rework annoucement design

### DIFF
--- a/c2corg_ui/static/js/announcement.js
+++ b/c2corg_ui/static/js/announcement.js
@@ -18,7 +18,6 @@ app.announcementDirective = function() {
 app.module.directive('appAnnouncement', app.announcementDirective);
 
 /**
- * @param {!angular.Scope} $scope Scope.
  * @param {app.Api} appApi Api service.
  * @param {app.Lang} appLang Lang service.
  * @constructor
@@ -26,13 +25,7 @@ app.module.directive('appAnnouncement', app.announcementDirective);
  * @struct
  */
 
-app.AnnouncementController = function($scope,appApi, appLang) {
-
-  /**
-   * @type {!angular.Scope}
-   * @private
-   */
-  this.scope_ = $scope;
+app.AnnouncementController = function(appApi, appLang) {
 
   /**
    * @type {app.Api}
@@ -50,7 +43,7 @@ app.AnnouncementController = function($scope,appApi, appLang) {
    * @type {boolean}
    * @export
    */
-  this.visible = false;
+  this.expanded = false;
 
   /**
    * @type {boolean}
@@ -95,7 +88,7 @@ app.AnnouncementController.prototype.handleAnnouncement = function(response) {
  * @export
  */
 app.AnnouncementController.prototype.toggle = function() {
-  this.visible = !this.visible;
+  this.expanded = !this.expanded;
 };
 
 app.module.controller('appAnnouncementController', app.AnnouncementController);

--- a/c2corg_ui/static/js/announcement.js
+++ b/c2corg_ui/static/js/announcement.js
@@ -43,7 +43,7 @@ app.AnnouncementController = function(appApi, appLang) {
    * @type {boolean}
    * @export
    */
-  this.expanded = false;
+  this.isExpanded = false;
 
   /**
    * @type {boolean}
@@ -95,7 +95,7 @@ app.AnnouncementController.prototype.handleAnnouncement = function(response) {
  * @export
  */
 app.AnnouncementController.prototype.toggle = function() {
-  this.expanded = !this.expanded;
+  this.isExpanded = !this.isExpanded;
 };
 
 app.module.controller('appAnnouncementController', app.AnnouncementController);

--- a/c2corg_ui/static/js/announcement.js
+++ b/c2corg_ui/static/js/announcement.js
@@ -49,6 +49,12 @@ app.AnnouncementController = function(appApi, appLang) {
    * @type {boolean}
    * @export
    */
+  this.canExpand = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
   this.hasAnnouncement = false;
 
   /**
@@ -81,6 +87,7 @@ app.AnnouncementController.prototype.handleAnnouncement = function(response) {
   if (data['tags'].indexOf('visible') > -1) {
     this.hasAnnouncement = true;
     this.text = data['post_stream']['posts'][0]['cooked'];
+    this.canExpand = $(this.text).filter('p').length > 1;
   }
 };
 

--- a/c2corg_ui/static/partials/announcement.html
+++ b/c2corg_ui/static/partials/announcement.html
@@ -1,9 +1,12 @@
-<div class="announcement" ng-class="{'showAnnouncement': announcementCtrl.visible}" ng-if="announcementCtrl.hasAnnouncement">
-  <div class="encart">
-    <p>
-      <a href="#" class="btn btn-primary" ng-click="announcementCtrl.toggle()"><span ng-if="!announcementCtrl.visible" translate>Read the announcement</span><span ng-if="announcementCtrl.visible" translate>Close the announcement</span></a>
-      <span ng-bind-html="announcementCtrl.text" class="msg"></span>
-    </p>
-    <div class="closep" ng-click="announcementCtrl.toggle()"> <span class="btalp"><span class="glyphicon glyphicon-play "></span></span> </div>
-  </div>
+<div class="announcement" ng-class="{'showAnnouncement': announcementCtrl.expanded}"
+     ng-if="announcementCtrl.hasAnnouncement">
+  <div ng-bind-html="announcementCtrl.text" class="msg"></div>
+  <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
+          ng-show="!announcementCtrl.expanded">
+    <span class="glyphicon glyphicon-resize-full"></span> <span translate>Read the announcement</span>
+  </button>
+  <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
+          ng-show="announcementCtrl.expanded">
+    <span class="glyphicon glyphicon-resize-small"></span> <span translate>Close the announcement</span>
+  </button>
 </div>

--- a/c2corg_ui/static/partials/announcement.html
+++ b/c2corg_ui/static/partials/announcement.html
@@ -2,11 +2,11 @@
      ng-if="announcementCtrl.hasAnnouncement">
   <div ng-bind-html="announcementCtrl.text" class="msg"></div>
   <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
-          ng-show="!announcementCtrl.expanded">
+          ng-show="!announcementCtrl.expanded && annoucementCtrl.canExpand">
     <span class="glyphicon glyphicon-resize-full"></span> <span translate>Read the announcement</span>
   </button>
   <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
-          ng-show="announcementCtrl.expanded">
+          ng-show="announcementCtrl.expanded && annoucementCtrl.canExpand">
     <span class="glyphicon glyphicon-resize-small"></span> <span translate>Close the announcement</span>
   </button>
 </div>

--- a/c2corg_ui/static/partials/announcement.html
+++ b/c2corg_ui/static/partials/announcement.html
@@ -1,12 +1,12 @@
-<div class="announcement" ng-class="{'showAnnouncement': announcementCtrl.expanded}"
+<div class="announcement" ng-class="{'showAnnouncement': announcementCtrl.isExpanded}"
      ng-if="announcementCtrl.hasAnnouncement">
   <div ng-bind-html="announcementCtrl.text" class="msg"></div>
   <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
-          ng-show="!announcementCtrl.expanded && annoucementCtrl.canExpand">
-    <span class="glyphicon glyphicon-resize-full"></span> <span translate>Read the announcement</span>
+          ng-show="announcementCtrl.canExpand && !announcementCtrl.isExpanded">
+    <span class="glyphicon glyphicon-chevron-down"></span> <span translate>Read the announcement</span>
   </button>
   <button class="btn btn-primary" ng-click="announcementCtrl.toggle()"
-          ng-show="announcementCtrl.expanded && annoucementCtrl.canExpand">
-    <span class="glyphicon glyphicon-resize-small"></span> <span translate>Close the announcement</span>
+          ng-show="announcementCtrl.isExpanded">
+    <span class="glyphicon glyphicon-chevron-up"></span> <span translate>Close the announcement</span>
   </button>
 </div>

--- a/less/announcement.less
+++ b/less/announcement.less
@@ -8,11 +8,10 @@ app-announcement {
     border-bottom: 1px solid #b8daff;
 
     display: flex;
-    flex-flow: column;
     align-items: flex-end;
 
     .msg {
-      align-self: stretch;
+      flex-grow: 1;
       margin-bottom: 5px;
       font-size: 18px;
 
@@ -30,9 +29,17 @@ app-announcement {
     }
 
     button {
+      margin-left: 5px;
+      align-self: flex-end;
       .blue-btn;
-      @media @phone {
-        width: 100%;
+
+      @media only screen and (max-width: @tablet-max) {
+        span.glyphicon {
+          margin-right: 0;
+        }
+        span:not(.glyphicon) {
+          display: none;
+        }
       }
     }
 

--- a/less/announcement.less
+++ b/less/announcement.less
@@ -1,67 +1,43 @@
 app-announcement {
-  display: block;
-
-  .ttr {
-    text-align: right;
-  }
   .announcement {
-
     background-color: #cce5ff;
-    margin: 0 20px 20px 20px;
+    color: #004085;
+
     padding: 10px;
     border-radius: 0 0 2px 2px;
-    height: 55px;
     border-bottom: 1px solid #b8daff;
-    overflow: hidden;
 
-    @media print {
-        display: none;
-    }
+    display: flex;
+    flex-flow: column;
+    align-items: flex-end;
 
-    &.showAnnouncement {
-      height: auto !important;
-        .encart {
-          p {
-            line-height: normal;
-          }
-        }
-    }
-    .shtdesc {
-      margin-top: 10px;
-    }
-    .encart {
-      color: #004085;
+    .msg {
+      align-self: stretch;
+      margin-bottom: 5px;
+      font-size: 18px;
+
+      @media @phone {
+        font-size: 15px;
+      }
+
       p {
+        text-align: justify;
 
-        margin-bottom: 5px;
-        font-size: 18px;
-        line-height: 40px;
-        @media @phone {
-          font-size: 15px;
-
-        }
-        .msg { p {
-            display: inline;
-            text-align: justify;
-          }
-        }
-      }
-      .btn {
-        float: right;
-        margin: 0px 0px 0px 10px;
-        @media @phone {
-          margin: 5px 0px 0px 10px;
+        &:not(:first-child) {
+          display: none;
         }
       }
     }
 
-    .closep {
-      text-align: right;
-      .glyphicon  {
-        color: #fff;
-        transform: rotate(270deg);
-        cursor: pointer;
+    button {
+      .blue-btn;
+      @media @phone {
+        width: 100%;
       }
+    }
+
+    &.showAnnouncement p {
+      display: block !important;
     }
   }
 }

--- a/less/homepage.less
+++ b/less/homepage.less
@@ -5,17 +5,6 @@
 
 .home-page {
 
-  button {
-    margin: 5px;
-    @media @phone {
-      width: 100%;
-    }
-    .small {
-      text-transform: none;
-      font-size: 1.2em;
-    }
-  }
-
   .site-intro {
     display: none;
     background-color: rgba(229, 229, 229, 0.3);
@@ -63,6 +52,16 @@
       }
       p {
         font-size: 1.5em;
+      }
+      button {
+        margin: 5px;
+        @media @phone {
+          width: 100%;
+        }
+        .small {
+          text-transform: none;
+          font-size: 1.2em;
+        }
       }
     }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,12 +1,23 @@
-@verybig: ~"only screen and (min-width: 2000px)";
-@big: ~"only screen and (min-width: 1600px)";
-@desktop-little: ~"only screen and (min-width: 1100px) and (max-width: 1399px)";
-@desktop-medium: ~"only screen and (min-width: 1400px) and (max-width: 1599px)";
-@desktop: ~"only screen and (min-width: 1100px) and (max-width: 1599px)";
-@tablet: ~"only screen and (min-width: 769px) and (max-width: 1099px)";
-@phone: ~"only screen and (max-width: 768px)";
 @phone-max: 768px;
+@tablet-min: @phone-max + 1px;
 @tablet-max: 1099px;
+@desktop-min: @tablet-max + 1px;
+@desktop-max: 1599px;
+@big-min: @desktop-max + 1px;
+@phone: ~"only screen and (max-width: @{phone-max})";
+@tablet: ~"only screen and (min-width: @{tablet-min}) and (max-width: @{tablet-max})";
+@desktop: ~"only screen and (min-width: @{desktop-min}) and (max-width: @{desktop-max})";
+@big: ~"only screen and (min-width: 1600px)";
+
+@desktop-little-min: @desktop-min;
+@desktop-little-max: 1399px;
+@desktop-medium-min: @desktop-little-max + 1px;
+@desktop-medium-max: @desktop-max;
+@verybig-min: 2000px;
+@desktop-little: ~"only screen and (min-width: @{desktop-little-min}) and (max-width: @{desktop-little-max})";
+@desktop-medium: ~"only screen and (min-width: @{desktop-medium-min}) and (max-width: @{desktop-medium-max})";
+@verybig: ~"only screen and (min-width: @{verybig-min})";
+
 @lightgray: #F0F0F0;
 @gray: #A9A9A9;
 @darkgray: #6D6D6D;


### PR DESCRIPTION
* no right and left margin, use full space (there is a problem with the preferences and personal feed configuration buttons, but this is already the case anyway)
* only first paragraph is show by default, other are hidden and shown only when expanded.
  This implies the annoucement consists only of paragraphs! But the advantage is that we are not limited to a single line anymore (which was moreover cut so this is problematic e.g. on mobile)
* cleanup and simplify HTML and CSS
* use only one button to expand and reduce
* remove useless scope variable in JS
* rename visible atrribute in JS with expanded, which is more explicit

![snapshot6](https://user-images.githubusercontent.com/2234024/33807623-f4059c50-ddd9-11e7-898d-3ff7f6fc8180.png)
![snapshot7](https://user-images.githubusercontent.com/2234024/33807622-f3ea0f58-ddd9-11e7-8938-c100a958e2d9.png)
![snapshot8](https://user-images.githubusercontent.com/2234024/33807621-f3ce6424-ddd9-11e7-89d9-945a61ccddf9.png)
![snapshot9](https://user-images.githubusercontent.com/2234024/33807620-f3aecf2e-ddd9-11e7-8e18-0bd21fe63b9b.png)
![snapshot10](https://user-images.githubusercontent.com/2234024/33807646-45d98bea-ddda-11e7-9199-676b32d1df39.png)
![snapshot11](https://user-images.githubusercontent.com/2234024/33807647-45faf780-ddda-11e7-94a5-74e16d7c1273.png)

