### PR TITLE
set content top limit under menu bar

### DIFF
--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -38,7 +38,8 @@ html, body{
   padding: 0;
   margin: 0;
   width: 100%;
-  overflow-x: hidden;
+  height: 100%;
+  overflow: hidden;
   background-color: @body-color;
   @media @phone {
     font-size: 0.9em;
@@ -662,6 +663,8 @@ app-simple-search {
 .page-content {
   margin-top: @page-header-height;
   margin-left: @menu-width;
+  height: calc(100% - @page-header-height);
+  overflow-y: auto;
 
   @media (max-width: @tablet-max) {
     margin-left: 0;


### PR DESCRIPTION
To avoid that a sub-title is masked by the menu bar, when we access to an article using a link with an internal anchor.