### PR TITLE
allow es6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,10 @@
   "parserOptions": {
     "ecmaVersion": 6
   },
-  "extends": "openlayers",
+  "extends": [
+    "eslint:recommended",
+    "openlayers"
+  ],
   "globals": {
     "app": false,
     "goog": false,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "extends": "openlayers",
   "globals": {
     "app": false,

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.egg-info
 *.po~
 Dockerfile_deployment_environment
+package-lock.json

--- a/.jshintrc
+++ b/.jshintrc
@@ -2,5 +2,6 @@
   // suppresses warnings about using [] notation (person['name']) W069
   "sub": true,
   // suppresses errors that occur when adding @typedef
-  "-W030": true
+  "-W030": true,
+  "esversion": 6
 }

--- a/build.json
+++ b/build.json
@@ -65,7 +65,8 @@
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
     "generate_exports": true,
-    "language_in": "ECMASCRIPT5_STRICT",
+    "language_in": "ECMASCRIPT6_STRICT",
+    "language_out": "ECMASCRIPT5_STRICT",
     "output_wrapper": "(function(){%output%}).call(window);",
     "export_local_property_definitions": true,
     "use_types_for_optimization": true

--- a/c2corg_ui/static/js/accountcontroller.js
+++ b/c2corg_ui/static/js/accountcontroller.js
@@ -14,7 +14,7 @@ goog.require('app.Alerts');
  * @ngInject
  */
 app.AccountController = function($scope, appAuthentication, appAlerts,
-    appApi, authUrl) {
+  appApi, authUrl) {
 
   /**
    * @type {angular.Scope}

--- a/c2corg_ui/static/js/alertservice.js
+++ b/c2corg_ui/static/js/alertservice.js
@@ -46,7 +46,7 @@ app.Alerts.prototype.add = function(data) {
   this.addLoading_(timeout);
   var msg = data['msg'];
   msg = msg instanceof Object ? this.formatErrorMsg_(msg) :
-      this.filterStr_(msg);
+    this.filterStr_(msg);
   this.alerts_.push({
     type: data['type'] || 'warning',
     msg: msg,

--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -245,10 +245,10 @@ app.Api.prototype.readDocument = function(module, id, lang, editing) {
   var alerts = this.alerts_;
   editing = typeof editing === 'undefined' ? false : editing;
   var url = '/{module}/{id}?l={lang}{editing}'
-  .replace('{module}', module)
-  .replace('{id}', String(id))
-  .replace('{lang}', lang)
-  .replace('{editing}', editing ? '&e=1' : '');
+    .replace('{module}', module)
+    .replace('{id}', String(id))
+    .replace('{lang}', lang)
+    .replace('{editing}', editing ? '&e=1' : '');
 
   var promise = this.getJson_(url);
   promise.catch(function(response) {
@@ -266,8 +266,8 @@ app.Api.prototype.readDocument = function(module, id, lang, editing) {
  */
 app.Api.prototype.updateDocument = function(module, id, json) {
   var url = '/{module}/{id}'
-  .replace('{module}', module)
-  .replace('{id}', String(id));
+    .replace('{module}', module)
+    .replace('{id}', String(id));
 
   var promise = this.putJson_(url, json);
   promise.catch(this.errorSaveDocument_.bind(this));
@@ -283,9 +283,9 @@ app.Api.prototype.updateDocument = function(module, id, json) {
  */
 app.Api.prototype.listDocuments = function(module, qstr, cancelerPromise) {
   var url = '/{module}{qmark}{qstr}'
-  .replace('{module}', module)
-  .replace('{qmark}', qstr ? '?' : '')
-  .replace('{qstr}', qstr);
+    .replace('{module}', module)
+    .replace('{qmark}', qstr ? '?' : '')
+    .replace('{qstr}', qstr);
   var alerts = this.alerts_;
   var promise = this.getJson_(url, cancelerPromise);
   promise.catch(function(response) {

--- a/c2corg_ui/static/js/auth/auth.js
+++ b/c2corg_ui/static/js/auth/auth.js
@@ -41,8 +41,7 @@ app.module.directive('appAuth', app.authDirective);
  * @ngInject
  */
 app.AuthController = function($scope, appApi, appAuthentication,
-    ngeoLocation, appAlerts, gettextCatalog, $q, appLang,
-    vcRecaptchaService) {
+  ngeoLocation, appAlerts, gettextCatalog, $q, appLang, vcRecaptchaService) {
 
   /**
    * @type {VCRecaptcha}
@@ -225,7 +224,7 @@ app.AuthController.prototype.successLogin_ = function(remember, response) {
 
   var discourse_url = data['redirect_internal'];
   var promise = discourse_url ? this.loginToDiscourse_(discourse_url) :
-      this.q_.when(true);
+    this.q_.when(true);
 
   if (!this.ngeoLocation_.hasParam('no_redirect')) {
     promise.finally(this.redirect_.bind(this, data.redirect));
@@ -244,9 +243,9 @@ app.AuthController.prototype.register = function() {
 
   this.api_.register(form).then(function() {
     var msg = alerts.gettext(
-        'Thank you for your registration! ' +
-        'We sent you an email, please click on the link to activate ' +
-        'your account.');
+      'Thank you for your registration! ' +
+      'We sent you an email, please click on the link to activate ' +
+      'your account.');
     alerts.addSuccess(msg);
   }, function() {
     // The captcha can be used only once
@@ -266,7 +265,7 @@ app.AuthController.prototype.requestPasswordChange = function() {
   var data = this.scope_['requestChangePassword'];
   this.api_.requestPasswordChange(data.email).then(function() {
     var msg = alerts.gettext(
-        'We sent you an email, please click on the link to reset password.');
+      'We sent you an email, please click on the link to reset password.');
     alerts.addSuccess(msg);
   });
 };

--- a/c2corg_ui/static/js/auth/httpinterceptor.js
+++ b/c2corg_ui/static/js/auth/httpinterceptor.js
@@ -14,26 +14,26 @@ goog.require('app.Authentication');
 app.HttpAuthenticationInterceptor = function(apiUrl, appAuthentication) {
   return {
     'request': (
-        /**
-         * @param {!angular.$http.Config} config
-         * @return {!angular.$http.Config}
-         */
-        function(config) {
-          var method = config.method;
-          var url = config.url;
-          goog.asserts.assert(method && url);
-          if (appAuthentication.needAuthorization(method, url)) {
-            config.headers = config.headers || {};
-            appAuthentication.addAuthorizationToHeaders(url, config.headers);
-          }
-          return config;
+      /**
+       * @param {!angular.$http.Config} config
+       * @return {!angular.$http.Config}
+       */
+      function(config) {
+        var method = config.method;
+        var url = config.url;
+        goog.asserts.assert(method && url);
+        if (appAuthentication.needAuthorization(method, url)) {
+          config.headers = config.headers || {};
+          appAuthentication.addAuthorizationToHeaders(url, config.headers);
         }
+        return config;
+      }
     )
   };
 };
 
 app.module.factory('appHttpAuthenticationInterceptor',
-    app.HttpAuthenticationInterceptor);
+  app.HttpAuthenticationInterceptor);
 
 
 /**

--- a/c2corg_ui/static/js/card.js
+++ b/c2corg_ui/static/js/card.js
@@ -298,9 +298,11 @@ app.CardController.prototype.createAreaURL = function(areas) {
       doc = orderedAreas['country'][0];
     }
 
-    return this.url_.buildDocumentUrl(app.utils.getDoctype(doc['type']),
-                                      doc['document_id'],
-                                      doc['locales'][0]);
+    return this.url_.buildDocumentUrl(
+      app.utils.getDoctype(doc['type']),
+      doc['document_id'],
+      doc['locales'][0]
+    );
   }
 };
 

--- a/c2corg_ui/static/js/deleteassociation.js
+++ b/c2corg_ui/static/js/deleteassociation.js
@@ -48,7 +48,7 @@ app.module.directive('appDeleteAssociation', app.deleteAssociationDirective);
  * @struct
  */
 app.DeleteAssociationController = function($rootScope, $scope, $compile,
-    $uibModal, appApi, appDocument) {
+  $uibModal, appApi, appDocument) {
 
   /**
    * @type {angular.$compile}

--- a/c2corg_ui/static/js/deletedocument.js
+++ b/c2corg_ui/static/js/deletedocument.js
@@ -85,12 +85,12 @@ app.DeleteDocumentController = function(documentData, appApi, appAlerts, gettext
  */
 app.DeleteDocumentController.prototype.deleteDocument = function() {
   this.appApi_.deleteDocument(this.documentData.document_id).then(
-      function(response) {
-        this.closeDialog();
-        this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
-            'Document successfully deleted'
-        ));
-      }.bind(this)
+    function(response) {
+      this.closeDialog();
+      this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
+        'Document successfully deleted'
+      ));
+    }.bind(this)
   );
 };
 
@@ -100,12 +100,12 @@ app.DeleteDocumentController.prototype.deleteDocument = function() {
  */
 app.DeleteDocumentController.prototype.deleteLocale = function() {
   this.appApi_.deleteLocale(this.documentData.document_id, this.lang).then(
-      function(response) {
-        this.closeDialog();
-        this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
-            'Locale successfully deleted'
-        ));
-      }.bind(this)
+    function(response) {
+      this.closeDialog();
+      this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
+        'Locale successfully deleted'
+      ));
+    }.bind(this)
   );
 };
 

--- a/c2corg_ui/static/js/editing/articleediting.js
+++ b/c2corg_ui/static/js/editing/articleediting.js
@@ -26,12 +26,12 @@ goog.require('app.Document');
  * @ngInject
  */
 app.ArticleEditingController = function($scope, $element, $attrs, $http,
-        $uibModal, $compile, appLang, appAuthentication, ngeoLocation,
-        appAlerts, appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
-          appLang, appAuthentication, ngeoLocation, appAlerts, appApi,
-          authUrl, appDocument, appUrl, imageUrl);
+    appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
+    appDocument, appUrl, imageUrl);
 
   /**
    * @type {?string}

--- a/c2corg_ui/static/js/editing/documentediting.js
+++ b/c2corg_ui/static/js/editing/documentediting.js
@@ -67,8 +67,8 @@ app.module.directive('appDocumentEditing', app.documentEditingDirective);
  * @ngInject
  */
 app.DocumentEditingController = function($scope, $element, $attrs, $http,
-    $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
-    appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   /**
    * @type {app.Document}
@@ -177,11 +177,11 @@ app.DocumentEditingController = function($scope, $element, $attrs, $http,
 
   if (this.auth.isAuthenticated()) {
     if (this.id && this.lang_) {
-     // Get document attributes from the API to feed the model:
+      // Get document attributes from the API to feed the model:
       goog.asserts.assert(!goog.isNull(this.id));
       goog.asserts.assert(!goog.isNull(this.lang_));
       this.api_.readDocument(this.module_, this.id, this.lang_, true).then(
-          this.successRead.bind(this)
+        this.successRead.bind(this)
       );
     } else if (!this.id) {
       // new doc lang = user interface lang
@@ -307,8 +307,10 @@ app.DocumentEditingController.prototype.submitForm = function(isValid) {
     var lonlat = data['lonlat'];
     if ('longitude' in lonlat && 'latitude' in lonlat) {
       var point = new ol.geom.Point([lonlat['longitude'], lonlat['latitude']]);
-      point.transform(app.constants.documentEditing.FORM_PROJ,
-                      app.constants.documentEditing.DATA_PROJ);
+      point.transform(
+        app.constants.documentEditing.FORM_PROJ,
+        app.constants.documentEditing.DATA_PROJ
+      );
       // If creating a new document, the model has no geometry attribute yet:
       data['geometry'] = data['geometry'] || {};
 
@@ -432,7 +434,7 @@ app.DocumentEditingController.prototype.handleMapFeaturesChange_ = function(feat
     if (isPoint) {
       data['geometry']['geom'] = this.geojsonFormat_.writeGeometry(geometry);
       var coords = this.getCoordinatesFromPoint_(
-          /** @type {ol.geom.Point} */ (geometry.clone()));
+        /** @type {ol.geom.Point} */ (geometry.clone()));
       data['lonlat'] = {
         'longitude': coords[0],
         'latitude': coords[1]
@@ -477,9 +479,11 @@ app.DocumentEditingController.prototype.handleMapFeaturesReset_ = function(initi
  * @private
  */
 app.DocumentEditingController.prototype.getCoordinatesFromPoint_ = function(
-    geometry) {
-  geometry.transform(app.constants.documentEditing.DATA_PROJ,
-                     app.constants.documentEditing.FORM_PROJ);
+  geometry) {
+  geometry.transform(
+    app.constants.documentEditing.DATA_PROJ,
+    app.constants.documentEditing.FORM_PROJ
+  );
   var coords = geometry.getCoordinates();
   return goog.array.map(coords, function(coord) {
     return Math.round(coord * 1000000) / 1000000;

--- a/c2corg_ui/static/js/editing/imageediting.js
+++ b/c2corg_ui/static/js/editing/imageediting.js
@@ -26,12 +26,12 @@ goog.require('app.Document');
  * @ngInject
  */
 app.ImageEditingController = function($scope, $element, $attrs, $http,
-        $uibModal, $compile, appLang, appAuthentication, ngeoLocation,
-        appAlerts, appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
-          appLang, appAuthentication, ngeoLocation, appAlerts, appApi,
-          authUrl, appDocument, appUrl, imageUrl);
+    appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
+    appDocument, appUrl, imageUrl);
 
   /**
    * @type {Date}

--- a/c2corg_ui/static/js/editing/outingediting.js
+++ b/c2corg_ui/static/js/editing/outingediting.js
@@ -28,8 +28,8 @@ goog.require('app.Lang');
  * @ngInject
  */
 app.OutingEditingController = function($scope, $element, $attrs, $http,
-    $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
-    appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
     appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
@@ -74,9 +74,11 @@ app.OutingEditingController = function($scope, $element, $attrs, $http,
       var routeId = parseInt(ngeoLocation.getFragmentParam('r'), 10);
       appApi.getDocumentByIdAndDoctype(routeId, 'r', appLang.getLang()).then(
         function(doc) {
-          this.documentService.pushToAssociations(doc.data['routes'].documents[0],
-                                                  'routes',
-                                                  this.handleAssociation);
+          this.documentService.pushToAssociations(
+            doc.data['routes'].documents[0],
+            'routes',
+            this.handleAssociation
+          );
         }.bind(this)
       );
     }
@@ -266,7 +268,7 @@ app.OutingEditingController.prototype.initConditionsLevels_ = function() {
  * @export
  */
 app.OutingEditingController.prototype.handleAssociation = function(data, doc,
-    doctype) {
+  doctype) {
   doctype = doctype || app.utils.getDoctype(doc['type']);
 
   // When creating an outing, set the default title and ratings using

--- a/c2corg_ui/static/js/editing/routeediting.js
+++ b/c2corg_ui/static/js/editing/routeediting.js
@@ -31,8 +31,8 @@ goog.require('app.lengthConverterDirective');
  * @ngInject
  */
 app.RouteEditingController = function($scope, $element, $attrs, $http,
-    $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
-    appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
     appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
@@ -44,9 +44,11 @@ app.RouteEditingController = function($scope, $element, $attrs, $http,
       var waypointId = parseInt(ngeoLocation.getFragmentParam('w'), 10);
       appApi.getDocumentByIdAndDoctype(waypointId, 'w', appLang.getLang()).then(
         function(doc) {
-          this.documentService.pushToAssociations(doc.data['waypoints'].documents[0],
-                                                  'waypoints',
-                                                  this.handleAssociation);
+          this.documentService.pushToAssociations(
+            doc.data['waypoints'].documents[0],
+            'waypoints',
+            this.handleAssociation
+          );
         }.bind(this)
       );
     }
@@ -90,7 +92,7 @@ app.RouteEditingController.prototype.showRatings = function() {
  * @export
  */
 app.RouteEditingController.prototype.handleAssociation = function(data, doc,
-    doctype) {
+  doctype) {
   // when creating a route, make the first associated wp a main one
   if (!data.document_id && data.associations.waypoints.length === 1) {
     data['main_waypoint_id'] = doc['document_id'];

--- a/c2corg_ui/static/js/editing/xreportediting.js
+++ b/c2corg_ui/static/js/editing/xreportediting.js
@@ -25,14 +25,14 @@ goog.require('app.Document');
  * @ngInject
  */
 app.XreportEditingController = function($scope, $element, $attrs, $http,
-        $uibModal, $compile, appLang, appAuthentication, ngeoLocation,
-        appAlerts, appApi, authUrl, appDocument, appUrl, imageUrl) {
+  $uibModal, $compile, appLang, appAuthentication, ngeoLocation, appAlerts,
+  appApi, authUrl, appDocument, appUrl, imageUrl) {
 
   goog.base(this, $scope, $element, $attrs, $http, $uibModal, $compile,
-          appLang, appAuthentication, ngeoLocation, appAlerts, appApi,
-          authUrl, appDocument, appUrl, imageUrl);
+    appLang, appAuthentication, ngeoLocation, appAlerts, appApi, authUrl,
+    appDocument, appUrl, imageUrl);
 
-    /**
+  /**
    * Start cannot be after today nor end_date.
    * @type {Date}
    * @export

--- a/c2corg_ui/static/js/forumfeed.js
+++ b/c2corg_ui/static/js/forumfeed.js
@@ -30,14 +30,14 @@ app.ForumFeedController = function(appApi) {
   this.errorForum = false;
 
   appApi.readLatestForumTopics()
-        .then(response => {
-          this.busyForum = false;
-          this.handleTopics_(response);
-        })
-        .catch(() => { // Error msg is shown in the api service
-          this.busyForum = false;
-          this.errorForum = true;
-        });
+    .then(response => {
+      this.busyForum = false;
+      this.handleTopics_(response);
+    })
+    .catch(() => { // Error msg is shown in the api service
+      this.busyForum = false;
+      this.errorForum = true;
+    });
 };
 
 

--- a/c2corg_ui/static/js/forumfeed.js
+++ b/c2corg_ui/static/js/forumfeed.js
@@ -29,13 +29,15 @@ app.ForumFeedController = function(appApi) {
    */
   this.errorForum = false;
 
-  appApi.readLatestForumTopics().then(function(response) {
-    this.busyForum = false;
-    this.handleTopics_(response);
-  }.bind(this), function() { // Error msg is shown in the api service
-    this.busyForum = false;
-    this.errorForum = true;
-  }.bind(this));
+  appApi.readLatestForumTopics()
+        .then(response => {
+          this.busyForum = false;
+          this.handleTopics_(response);
+        })
+        .catch(() => { // Error msg is shown in the api service
+          this.busyForum = false;
+          this.errorForum = true;
+        });
 };
 
 

--- a/c2corg_ui/static/js/imageuploader.js
+++ b/c2corg_ui/static/js/imageuploader.js
@@ -49,7 +49,7 @@ app.module.directive('appImageUploader', app.imageUploaderDirective);
  * @ngInject
  */
 app.ImageUploaderController = function($scope, $uibModal, $compile, $q,
-    appAlerts, appApi, appDocument, imageUrl, appUrl, appAuthentication) {
+  appAlerts, appApi, appDocument, imageUrl, appUrl, appAuthentication) {
 
   /**
    * @type {app.Document}
@@ -296,28 +296,28 @@ app.ImageUploaderController.prototype.save = function() {
   var defer = this.q_.defer();
 
   this.api_.createImages(this.files, this.documentService.document)
-  .then(function(data) {
-    var images = data['config']['data']['images'];
-    var imageIds = data['data']['images']; // newly created document_id
+    .then(function(data) {
+      var images = data['config']['data']['images'];
+      var imageIds = data['data']['images']; // newly created document_id
 
-    $('.img-container').each(function(i) {
-      var id = imageIds[i]['document_id'];
-      images[i]['image_id'] = 'image-' + id;
-      var element = app.utils.createImageSlide(images[i],this.imageUrl_);
-      $('.photos').append(element);
+      $('.img-container').each(function(i) {
+        var id = imageIds[i]['document_id'];
+        images[i]['image_id'] = 'image-' + id;
+        var element = app.utils.createImageSlide(images[i],this.imageUrl_);
+        $('.photos').append(element);
 
-      var scope = this.scope_.$new(true);
-      scope['photo'] = images[i];
-      scope['photo']['image_id'] = 'image-' + id;
-      this.documentService.document.associations['images'].push(scope['photo']);
-      this.compile_($('#image-' + id).contents())(scope); // compile the figure thumbnail with <app-slide-info>
+        var scope = this.scope_.$new(true);
+        scope['photo'] = images[i];
+        scope['photo']['image_id'] = 'image-' + id;
+        this.documentService.document.associations['images'].push(scope['photo']);
+        this.compile_($('#image-' + id).contents())(scope); // compile the figure thumbnail with <app-slide-info>
 
-    }.bind(this));
+      }.bind(this));
 
-    defer.resolve();
-  }.bind(this), function() {
-    defer.reject();
-  });
+      defer.resolve();
+    }.bind(this), function() {
+      defer.reject();
+    });
 
   return defer.promise;
 };
@@ -499,7 +499,7 @@ app.ImageUploaderController.prototype.selectOption = function(object, property, 
  * @export
  */
 app.ImageUploaderController.prototype.resizeIf = function(
-    file, width, height) {
+  file, width, height) {
   if (file.type === 'image/jpeg' || file.type === 'image/png') {
     return file.size > 2 * 1024 * 1024; /** 2 MB */
   }

--- a/c2corg_ui/static/js/langservice.js
+++ b/c2corg_ui/static/js/langservice.js
@@ -127,7 +127,7 @@ app.Lang.prototype.gettext = function(str) {
 app.Lang.prototype.updateLang = function(lang, opt_syncWithApi) {
   this.gettextCatalog_.setCurrentLanguage(lang);
   this.gettextCatalog_.loadRemote(
-          this.langUrlTemplate_.replace('__lang__', lang));
+    this.langUrlTemplate_.replace('__lang__', lang));
   // store the interface language as cookie, so that it is available on the
   // server side.
   var d = new Date();

--- a/c2corg_ui/static/js/lengthconverter.js
+++ b/c2corg_ui/static/js/lengthconverter.js
@@ -12,12 +12,12 @@ app.lengthConverterDirective = function() {
   return {
     require: 'ngModel',
     link:
-     /**
-      * @param {angular.Scope} scope Scope.
-      * @param {angular.JQLite} el Element.
-      * @param {angular.Attributes} attrs Atttributes.
-      * @param {angular.NgModelController} ngModel ngModel.
-      */
+    /**
+    * @param {angular.Scope} scope Scope.
+    * @param {angular.JQLite} el Element.
+    * @param {angular.Attributes} attrs Atttributes.
+    * @param {angular.NgModelController} ngModel ngModel.
+    */
     function(scope, el, attrs, ngModel) {
       ngModel.$parsers.push(function(value) {
         return value * 1000;

--- a/c2corg_ui/static/js/map/map.js
+++ b/c2corg_ui/static/js/map/map.js
@@ -75,7 +75,7 @@ app.module.directive('appMap', app.mapDirective);
  * @ngInject
  */
 app.MapController = function($scope, mapFeatureCollection, ngeoLocation,
-                              ngeoDebounce, appUrl, imgPath) {
+  ngeoDebounce, appUrl, imgPath) {
 
   /**
    * @type {number}
@@ -285,10 +285,10 @@ app.MapController = function($scope, mapFeatureCollection, ngeoLocation,
       this.toggleFeatureHighlight_(id, false);
     }.bind(this));
 
-    this.view_.on('propertychange',
-                  ngeoDebounce(
+    this.view_.on('propertychange', ngeoDebounce(
       this.handleMapSearchChange_.bind(this),
-      500, /* invokeApply */ true));
+      500, /* invokeApply */ true
+    ));
 
     this.scope_.$watch(function() {
       return this.enableMapFilter;
@@ -418,11 +418,11 @@ app.MapController.prototype.getVectorLayer_ = function() {
  */
 app.MapController.prototype.createStyleFunction_ = function() {
   return (
-      /**
-       * @param {ol.Feature|ol.render.Feature} feature
-       * @param {number} resolution
-       * @return {ol.style.Style|Array.<ol.style.Style>}
-       */
+    /**
+     * @param {ol.Feature|ol.render.Feature} feature
+     * @param {number} resolution
+     * @return {ol.style.Style|Array.<ol.style.Style>}
+     */
     function(feature, resolution) {
       var module = /** @type {string} */ (feature.get('module'));
       switch (module) {
@@ -912,8 +912,8 @@ app.MapController.prototype.handleMapFeatureHover_ = function(event) {
  * @param {boolean} was_enabled Former value.
  * @private
  */
-app.MapController.prototype.handleMapFilterSwitchChange_ = function(enabled,
-                                                                     was_enabled) {
+app.MapController.prototype.handleMapFilterSwitchChange_ = function(
+  enabled, was_enabled) {
   if (enabled === was_enabled) {
     // initial setting of the filter switch
     // * do nothing if the filter is enabled by default
@@ -1008,8 +1008,8 @@ app.MapController.prototype.resetFeature = function() {
  * @export
  */
 app.MapController.prototype.canDelete = function() {
-  return this.edit && this.getVectorLayer_().getSource().getFeatures().length > 0
-      && this.initialGeometry_ && this.initialGeometry_['geom'];
+  return this.edit && this.getVectorLayer_().getSource().getFeatures().length > 0 &&
+      this.initialGeometry_ && this.initialGeometry_['geom'];
 };
 
 

--- a/c2corg_ui/static/js/map/search.js
+++ b/c2corg_ui/static/js/map/search.js
@@ -206,7 +206,7 @@ app.MapSearchController.select_ = function(event, suggestion, dataset) {
 
   var mapSize = /** @type {ol.Size} */ (map.getSize());
   map.getView().fit(geomOrExtent, mapSize,
-      /** @type {olx.view.FitOptions} */ ({maxZoom: 12}));
+    /** @type {olx.view.FitOptions} */ ({maxZoom: 12}));
 };
 
 

--- a/c2corg_ui/static/js/mergedocuments.js
+++ b/c2corg_ui/static/js/mergedocuments.js
@@ -99,14 +99,15 @@ app.MergeDocumentsController.prototype.mergeDocuments = function() {
   var msg = this.gettextCatalog_.getString('Are you sure you want to merge?');
   if (window.confirm(msg)) {
     this.appApi_.mergeDocuments(
-        this.sourceDocument.document_id, this.targetDocument.document_id).then(
-          function(response) {
-            this.closeDialog();
-            this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
-                'Documents successfully merged'
-            ));
-          }.bind(this)
-    );
+      this.sourceDocument.document_id, this.targetDocument.document_id)
+      .then(
+        function(response) {
+          this.closeDialog();
+          this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
+            'Documents successfully merged'
+          ));
+        }.bind(this)
+      );
   }
 };
 

--- a/c2corg_ui/static/js/outingscsvdownload.js
+++ b/c2corg_ui/static/js/outingscsvdownload.js
@@ -32,7 +32,7 @@ app.module.directive('appOutingsCsvDownload', app.outingsCsvDownloadDirective);
  * @ngInject
  */
 app.OutingsCsvDownloadController = function(appAuthentication, appApi, $q,
-    appLang) {
+  appLang) {
 
   /**
    * @type {app.Authentication}
@@ -128,7 +128,7 @@ app.OutingsCsvDownloadController.prototype.getOutings_ = function() {
         var additionalRequests = [];
         offsets.forEach(function(offset) {
           additionalRequests.push(appApi.listDocuments('outings',
-              'u=' + userId + '&offset=' + offset, promise));
+            'u=' + userId + '&offset=' + offset, promise));
         });
         return $q.all(additionalRequests).then(function(results) {
           results.forEach(function(result) {

--- a/c2corg_ui/static/js/preferences.js
+++ b/c2corg_ui/static/js/preferences.js
@@ -31,7 +31,7 @@ app.module.directive('appPreferences', app.preferencesDirective);
  * @ngInject
  */
 app.PreferencesController = function($scope, appAuthentication, appApi,
-    authUrl) {
+  authUrl) {
 
   /**
    * @type {angular.Scope}

--- a/c2corg_ui/static/js/protectdocument.js
+++ b/c2corg_ui/static/js/protectdocument.js
@@ -32,7 +32,7 @@ app.module.directive('appProtectDocument', app.protectDocumentDirective);
  * @struct
  */
 app.ProtectDocumentController = function(appAuthentication, appApi,
-    appAlerts, gettextCatalog, documentData) {
+  appAlerts, gettextCatalog, documentData) {
 
   /**
    * @type {app.Api}
@@ -74,7 +74,7 @@ app.ProtectDocumentController.prototype.protect = function() {
     this.api_.protectDocument(this.documentData.document_id).then(function(response) {
       this.documentData['protected'] = true;
       this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
-          'Document is now protected'
+        'Document is now protected'
       ));
     }.bind(this));
   }
@@ -89,7 +89,7 @@ app.ProtectDocumentController.prototype.unprotect = function() {
     this.api_.unprotectDocument(this.documentData.document_id).then(function(response) {
       this.documentData['protected'] = false;
       this.appAlerts_.addSuccess(this.gettextCatalog_.getString(
-          'Document is no longer protected'
+        'Document is no longer protected'
       ));
     }.bind(this));
   }

--- a/c2corg_ui/static/js/protectedurlbtn.js
+++ b/c2corg_ui/static/js/protectedurlbtn.js
@@ -50,8 +50,8 @@ app.ProtectedUrlBtnController.prototype.redirectToProtectedUrl = function(url) {
     window.location.href = url;
   } else {
     window.location.href = '{authUrl}#to={redirect}'
-        .replace('{authUrl}', this.authUrl_)
-        .replace('{redirect}', encodeURIComponent(url));
+      .replace('{authUrl}', this.authUrl_)
+      .replace('{redirect}', encodeURIComponent(url));
   }
 };
 

--- a/c2corg_ui/static/js/revertdocument.js
+++ b/c2corg_ui/static/js/revertdocument.js
@@ -26,7 +26,7 @@ app.module.directive('appRevertDocument', app.revertDocumentDirective);
  * @ngInject
  */
 app.RevertDocumentController = function(
-    appAuthentication, appApi, appAlerts, gettextCatalog) {
+  appAuthentication, appApi, appAlerts, gettextCatalog) {
 
   /**
    * @type {app.Authentication}
@@ -61,7 +61,7 @@ app.RevertDocumentController = function(
  * @export
  */
 app.RevertDocumentController.prototype.revert = function(
-    documentId, lang, versionId) {
+  documentId, lang, versionId) {
   var catalog = this.gettextCatalog_;
   var gettext = function(str) {
     return catalog.getString(str);

--- a/c2corg_ui/static/js/search/advancedsearch.js
+++ b/c2corg_ui/static/js/search/advancedsearch.js
@@ -43,7 +43,7 @@ app.module.directive('appAdvancedSearch', app.advancedSearchDirective);
  * @ngInject
  */
 app.AdvancedSearchController = function($scope, appApi, ngeoLocation,
-    gettextCatalog, $q) {
+  gettextCatalog, $q) {
 
   /**
    * @type {angular.Scope}

--- a/c2corg_ui/static/js/search/outingfilters.js
+++ b/c2corg_ui/static/js/search/outingfilters.js
@@ -14,7 +14,7 @@ goog.require('app.SearchFiltersController');
  * @ngInject
  */
 app.OutingFiltersController = function($scope, ngeoLocation, ngeoDebounce,
-    advancedSearchFilters) {
+  advancedSearchFilters) {
 
   /**
    * @type {Array.<Date>}

--- a/c2corg_ui/static/js/search/pagination.js
+++ b/c2corg_ui/static/js/search/pagination.js
@@ -87,7 +87,7 @@ app.PaginationController.MAX_RESULT_OFFSET = 10000;
  * @private
  */
 app.PaginationController.prototype.handleSearchChange_ = function(event,
-    features, total, recenter) {
+  features, total, recenter) {
   this.total = total;
   this.offset = this.location_.getFragmentParamAsInt('offset') || 0;
   // don't show the "Go to last page" button if the offset is above

--- a/c2corg_ui/static/js/search/searchfilters.js
+++ b/c2corg_ui/static/js/search/searchfilters.js
@@ -55,7 +55,7 @@ app.module.directive('appSearchFilters', app.searchFiltersDirective);
  * @ngInject
  */
 app.SearchFiltersController = function($scope, ngeoLocation, ngeoDebounce,
-    advancedSearchFilters) {
+  advancedSearchFilters) {
 
   /**
    * @type {angular.Scope}
@@ -114,15 +114,15 @@ app.SearchFiltersController = function($scope, ngeoLocation, ngeoDebounce,
   this.scope_.$watch(function() {
     return this.filters;
   }.bind(this), ngeoDebounce(
-      this.handleFiltersChange_.bind(this),
-      500, /* invokeApply */ true),
+    this.handleFiltersChange_.bind(this),
+    500, /* invokeApply */ true),
     /* deep watch */ true
   );
   this.scope_.$watch(function() {
     return this.checkboxes_;
   }.bind(this), ngeoDebounce(
-      this.handleCheckboxesChange_.bind(this),
-      700, /* invokeApply */ true),
+    this.handleCheckboxesChange_.bind(this),
+    700, /* invokeApply */ true),
     /* deep watch */ true
   );
 
@@ -267,7 +267,7 @@ app.SearchFiltersController.prototype.clear = function() {
  * @export
  */
 app.SearchFiltersController.prototype.toggleOrientation = function(orientation,
-    ctrl, e, filterName) {
+  ctrl, e, filterName) {
   if (this.orientations.indexOf(orientation) === -1) {
     this.orientations.push(orientation);
   } else {

--- a/c2corg_ui/static/js/search/simplesearch.js
+++ b/c2corg_ui/static/js/search/simplesearch.js
@@ -100,7 +100,7 @@ app.module.directive('appSimpleSearch', app.simpleSearchDirective);
  * @ngInject
  */
 app.SimpleSearchController = function(appDocument, $scope, $compile, $attrs, apiUrl,
-    gettextCatalog, $templateCache, appAuthentication, appUrl) {
+  gettextCatalog, $templateCache, appAuthentication, appUrl) {
 
   /**
    * @type {app.Document}
@@ -313,8 +313,8 @@ app.SimpleSearchController.prototype.createDataset_ = function(type) {
         if ($('.header.empty').length === 0) {
           var partialFile = this.isStandardSearch ? 'create' : 'empty';
           var template = app.utils.getTemplate(
-              '/static/partials/suggestions/' + partialFile + '.html',
-              this.templatecache_);
+            '/static/partials/suggestions/' + partialFile + '.html',
+            this.templatecache_);
           return this.compile_(template)(this.scope_);
         }
       }.bind(this)
@@ -361,7 +361,7 @@ app.SimpleSearchController.prototype.createAndInitBloodhound_ = function(type) {
 
       filter: (function(/** appx.SimpleSearchResponse */ resp) {
         var documentResponse =
-                /** @type {appx.SimpleSearchDocumentResponse} */ (resp[type]);
+          /** @type {appx.SimpleSearchDocumentResponse} */ (resp[type]);
         if (documentResponse) {
           this.nbResults_[type] = documentResponse.total;
           var documents = documentResponse.documents;

--- a/c2corg_ui/static/js/search/xreportfilters.js
+++ b/c2corg_ui/static/js/search/xreportfilters.js
@@ -14,7 +14,7 @@ goog.require('app.SearchFiltersController');
  * @ngInject
  */
 app.XreportFiltersController = function($scope, ngeoLocation, ngeoDebounce,
-    advancedSearchFilters) {
+  advancedSearchFilters) {
 
   /**
    * @type {Array.<Date>}

--- a/c2corg_ui/static/js/urlservice.js
+++ b/c2corg_ui/static/js/urlservice.js
@@ -41,8 +41,8 @@ app.Url.prototype.buildDocumentUrl = function(documentType, documentId, locale, 
 
   if (documentType === 'profiles' || documentType === 'users') {
     return '/profiles/{id}/{lang}'
-    .replace('{id}', String(documentId))
-    .replace('{lang}', lang);
+      .replace('{id}', String(documentId))
+      .replace('{lang}', lang);
   }
 
   var title = '';

--- a/c2corg_ui/static/js/user.js
+++ b/c2corg_ui/static/js/user.js
@@ -39,7 +39,7 @@ app.module.directive('appUser', app.userDirective);
  * @ngInject
  */
 app.UserController = function(appAuthentication, ngeoLocation,
-    appAlerts, appApi, authUrl, gettext) {
+  appAlerts, appApi, authUrl, gettext) {
 
   /**
    * @type {app.Authentication}
@@ -118,7 +118,7 @@ app.UserController.prototype.logout = function() {
  * @export
  */
 app.UserController.prototype.hasEditRights = function(doctype, options,
-    opt_protected) {
+  opt_protected) {
   if (opt_protected && !this.isModerator()) {
     return false;
   }

--- a/c2corg_ui/static/js/utils.js
+++ b/c2corg_ui/static/js/utils.js
@@ -258,8 +258,8 @@ app.utils.redirectToLogin = function(authUrl) {
     current_url = '/';
   }
   location.href = '{login}#to={current}'
-      .replace('{login}', authUrl)
-      .replace('{current}', encodeURIComponent(current_url));
+    .replace('{login}', authUrl)
+    .replace('{current}', encodeURIComponent(current_url));
 };
 
 

--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -53,7 +53,7 @@ app.module.directive('appViewDetails', app.viewDetailsDirective);
  * @ngInject
  */
 app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
-                                     appDocument, documentData, imageUrl, discourseUrl, appUrl, appLang) {
+  appDocument, documentData, imageUrl, discourseUrl, appUrl, appLang) {
 
   /**
    * @type {app.Document}
@@ -140,10 +140,10 @@ app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
    */
   this.discourseUrl = discourseUrl;
 
-    /**
-    * @type {boolean}
-    * @export
-    */
+  /**
+  * @type {boolean}
+  * @export
+  */
   this.showMobileBlock = /** @type {boolean} */ (JSON.parse(window.localStorage.getItem('showMobileBlock') || 'true'));
 
   /**
@@ -457,13 +457,15 @@ app.ViewDetailsController.prototype.handleCommentsForum_ = function(response) {
       if (data['posts'][i]['name'] == 'system') {
         continue;
       }
-      this.comments.push({'id':data['posts'][i]['id'],
-                          'username':data['posts'][i]['username'],
-                          'avatar_template':data['posts'][i]['avatar_template'].replace('{size}','24'),
-                          'cooked':data['posts'][i]['cooked'].replace(/<a class="mention" href="/g,'<a class="mention" href="' + this.discourseUrl),
-                          'created_at':data['posts'][i]['created_at'],
-                          'reply_count':data['posts'][i]['reply_count'],
-                          'reply_to_user':data['posts'][i]['reply_to_user']});
+      this.comments.push({
+        'id':data['posts'][i]['id'],
+        'username':data['posts'][i]['username'],
+        'avatar_template':data['posts'][i]['avatar_template'].replace('{size}','24'),
+        'cooked':data['posts'][i]['cooked'].replace(/<a class="mention" href="/g,'<a class="mention" href="' + this.discourseUrl),
+        'created_at':data['posts'][i]['created_at'],
+        'reply_count':data['posts'][i]['reply_count'],
+        'reply_to_user':data['posts'][i]['reply_to_user']
+      });
     }
     this.documentService.document['topic_slug'] = data['posts'][0]['topic_slug'];
   }
@@ -573,8 +575,8 @@ app.ViewDetailsController.prototype.openEmbeddedImage = function(imgUrl, imgId) 
     }
   }
 
-  var pswp = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default, items,
-                                   $.extend(this.pswpOptions, {index: index}));
+  var pswp = new window.PhotoSwipe(pswpElement, window.PhotoSwipeUI_Default,
+    items, $.extend(this.pswpOptions, {index: index}));
   var lang = this.lang.getLang();
   pswp.listen('beforeChange', function() {
     var id = pswp['currItem']['id'];

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "angular-messages": "1.5.8",
     "angular-slug": "0.0.4",
     "corejs-typeahead": "1.0.1",
-    "eslint": "2.13.1",
+    "eslint": "4.13.0",
     "eslint-config-openlayers": "5.0.0",
     "file-saver": "1.3.3",
     "jquery": "3.2.1",


### PR DESCRIPTION
* closure transpiles from es6 strict to es5 strict (no need to be constrained to es3 anymore)
* update eslint and jshint configuration for es6 (and also packages)
* small test in forumfeed.js

Some alternate questions:

* could/should we think about updating closure-util too?
* what's the role of pyramid_closure in the process? I don't get it