### PR TITLE
Top navbar offset for anchors

### DIFF
--- a/less/anchors.less
+++ b/less/anchors.less
@@ -1,0 +1,18 @@
+// ensure that anchors take into account the fixed top navbar
+// see https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033
+
+// restrict this to titles h3 to h6 in view details sections
+
+@anchor-top-margin: 5px;
+
+.view-details-section {
+  h2, h3, h4, h5, h6 {
+    &[id]:before {
+      display: block;
+      content: " ";
+      margin-top: calc(~'-@{page-header-height} - @{anchor-top-margin}');
+      height: @page-header-height + @anchor-top-margin; 
+      visibility: hidden;
+    }
+  }
+}

--- a/less/c2corg_ui.less
+++ b/less/c2corg_ui.less
@@ -1,6 +1,8 @@
 @import (inline) "../node_modules/openlayers/css/ol.css";
 @import "../node_modules/bootstrap/less/bootstrap.less";
 @icon-font-path: "bootstrap_fonts/";
+@import "variables.less";
+@import "anchors.less";
 @import "simplesearch.less";
 @import "lists.less";
 @import "diff.less";
@@ -25,7 +27,6 @@
 @import "map.less";
 @import "404.less";
 @import "homepage.less";
-@import "variables.less";
 @import "markdowneditor.less";
 @import "icon-date.less";
 @import "context-help.less";


### PR DESCRIPTION
Ensures that top fixed navbar offset is taken into account for anchors.
The solution used is to add an invisible block on top of items with an id, inspired by https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033
To limit the number of such blocks, we restrict it to h3 to h6 titles in the view-details-section part.