### PR TITLE
List route optimization

### DIFF
--- a/c2corg_ui/static/partials/cards/routes.html
+++ b/c2corg_ui/static/partials/cards/routes.html
@@ -82,6 +82,9 @@
           </a>
         </div>
       </div>
+      <div class="parent-bubble" ng-if="doc['geometry']['has_geom_detail']" uib-tooltip="{{ 'GPS Track'| translate}}" tooltip-append-to-body="true">
+        <span class="glyphicon glyphicon-flag"></span>
+      </div>
       <div class="grow"></div>
       <div class="group-infop">
         <div class="parent-bubble topsubicon">
@@ -94,13 +97,6 @@
         <div class="text-bubble" ng-if="doc['orientations'].length">
           {{cardCtrl.showOrientation(doc['orientations'])}}
         </div>
-      </div>
-      <div class="parent-bubble">
-        <a href="#" class="link" ng-if="doc['condition_rating']"
-           uib-tooltip="{{'condition_rating' | translate}} : {{doc['condition_rating'] | translate}}"
-           tooltip-append-to-body="true">
-          <div class="condition-rating" ng-class="::doc['condition_rating']" ></div>
-        </a>
       </div>
       <div class="parent-bubble">
         <div class="bubble bquality" ng-if="doc['quality']">

--- a/less/cards.less
+++ b/less/cards.less
@@ -575,9 +575,8 @@
 
   .row-list {
     .cotationbox {
-      width:  90px;
+      width: 150px;
     }
-    .outings {}
     .post.route {
       height: auto;
     }
@@ -602,8 +601,16 @@
 
         .parent-infop {
           &.large {
-            width: 35%;
+            width: 370px;
           }
+        }
+        .area {
+          width: 10%;  
+        }
+        .orientation{
+          width: 30px;
+          text-overflow: ellipsis;
+          overflow: hidden;
         }
       }
       &.card-outing {


### PR DESCRIPTION
- add GPS track flag #1549 
- optimize display (show complete cotation, optimize to show a route on one line) #1808 

before 1200px : 
![capture d ecran 2017-12-11 a 22 06 22](https://user-images.githubusercontent.com/3962997/33853804-9651ad88-debf-11e7-84f4-c0128bf7bcfd.png)


After 1200px : 
![capture d ecran 2017-12-11 a 21 53 44](https://user-images.githubusercontent.com/3962997/33853712-38588080-debf-11e7-9b5e-b44f741db72b.png)

After 1700px : 
![capture d ecran 2017-12-11 a 21 48 31](https://user-images.githubusercontent.com/3962997/33853714-38a60ed6-debf-11e7-8d4a-4cf0e5315303.png)
