### PR TITLE
Ensure logo image is seen entirely on mobile

### DIFF
--- a/less/sidemenu.less
+++ b/less/sidemenu.less
@@ -93,7 +93,7 @@ body.menu-toggled #content-toggled {
 
   .logo {
     width: 140px;
-    margin-left: 10px;
+    margin-left: 2px;
     margin-top: 5px;
     margin-bottom: 5px;
   }


### PR DESCRIPTION
Relates to #1889 

Now

![snapshot18](https://user-images.githubusercontent.com/2234024/33878270-311d0c02-df2b-11e7-9823-bf414a26bd03.png)

Was

![snapshot19](https://user-images.githubusercontent.com/2234024/33878271-31968122-df2b-11e7-990b-fe91aee9d5d1.png)
