### PR TITLE
License for screen and print media

### DIFF
--- a/c2corg_ui/static/js/viewdetails.js
+++ b/c2corg_ui/static/js/viewdetails.js
@@ -147,6 +147,12 @@ app.ViewDetailsController = function($scope, $compile, $uibModal, appApi,
   this.showMobileBlock = /** @type {boolean} */ (JSON.parse(window.localStorage.getItem('showMobileBlock') || 'true'));
 
   /**
+   * @type {Date}
+   * @export
+   */
+  this.date = new Date();
+
+  /**
    * @type {!angular.Scope}
    * @private
    */

--- a/c2corg_ui/templates/area/view.html
+++ b/c2corg_ui/templates/area/view.html
@@ -9,7 +9,8 @@ from json import dumps
     photoswipe_gallery, get_document_locale_text, show_badge,
     show_missing_langs_links, show_other_langs_links, show_archive_data,
     show_locale_title, show_float_buttons, get_document_description,
-    get_licence, show_merge_documents_dialog, generate_share_metadata"/>
+    get_licence, show_merge_documents_dialog, generate_share_metadata,
+    get_print_license"/>
 <%namespace file="helpers/view.html" import="get_area_general"/>
 <%
 area_id = area['document_id']
@@ -128,6 +129,8 @@ area['doctype'] = 'areas'
       </div>
 
       ${get_comments()}
+      
+      ${get_print_license(area)}
 
       ${show_float_buttons(area, lang, other_langs, missing_langs)}
     % endif

--- a/c2corg_ui/templates/article/view.html
+++ b/c2corg_ui/templates/article/view.html
@@ -10,8 +10,9 @@ from json import dumps
   show_archive_data, show_areas, show_float_buttons, show_locale_title,
   show_associated_waypoints, show_associated_outings, show_associated_routes,
   show_associated_articles, show_associated_books, show_associated_xreports,
-  delete_association_confirmation_modal, associated_images_featurelist, show_badge, get_licence,
-  show_merge_documents_dialog, show_delete_document_dialog, generate_share_metadata"/>
+  delete_association_confirmation_modal, associated_images_featurelist, show_badge,
+  get_licence, get_print_license, show_merge_documents_dialog,
+  show_delete_document_dialog, generate_share_metadata"/>
 <%namespace file="helpers/view.html" import="get_article_general, get_article_associated_users"/>
 
 <%
@@ -105,6 +106,8 @@ other_langs, missing_langs = get_lang_lists(article, lang)
                     ${show_associated_outings(article)}
 
                     ${get_comments()}
+
+                    ${get_print_license(article)}
                   </section>
                 </span>
               </div>

--- a/c2corg_ui/templates/book/view.html
+++ b/c2corg_ui/templates/book/view.html
@@ -12,7 +12,7 @@ from json import dumps
   show_associated_waypoints, show_associated_outings, show_associated_routes, show_associated_articles,
   delete_association_confirmation_modal, associated_images_featurelist,
   show_badge, get_document_description, get_licence, show_merge_documents_dialog,
-  show_delete_document_dialog, generate_share_metadata" />
+  show_delete_document_dialog, generate_share_metadata, get_print_license" />
 <%namespace file="helpers/view.html" import="get_book_general"/>
 
 <%
@@ -96,6 +96,8 @@ other_langs, missing_langs = get_lang_lists(book, lang)
 
 
         ${get_comments()}
+
+        ${get_print_license(book)}
 
         ${show_float_buttons(book, lang, other_langs, missing_langs)}
       % endif

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -7,48 +7,60 @@
 %>
 <%namespace file="common.html" import="generate_empty_list_items"/>
 
+<%def name="get_print_license(doc)">\
+  <div class="print-only">
+    <%
+        get_license_description(doc)
+    %>
+    <div>&ndash; <span translate>Printed on</span> {{detailsCtrl.date | date: "MM/dd/yyyy HH:mm"}}</div>
+  </div>
+</%def>
+
 <%def name="get_licence(doc)">\
+  <h3 ng-click="mainCtrl.animateHeaderIcon($event)" data-toggle="collapse" data-target="#licence"><span translate>Licence</span> <span class="glyphicon glyphicon-menu-down"></span></h3>
+  <div class="finfo" id="license">
+    <div class="ficontent">
+      <span class="detail-text accordion">
+        <article class="value">
+          <%
+              get_license_description(doc)
+          %>
+        </article>
+      </span>
+    </div>
+  </div>
+</%def>
+
+<%def name="get_license_description(doc)">
   <%
       personal = is_personal(doc)
       collaborative = is_collaborative(doc) if not personal else False
   %>
-    <h3 ng-click="mainCtrl.animateHeaderIcon($event)" class="collapsible-title"
-        data-toggle="collapse" data-target="#licence" aria-expanded="true" aria-controls="licence">
-      <span translate>Licence</span> <span class="glyphicon glyphicon-menu-down"></span>
-    </h3>
-    <div class="finfo collapse in" id="licence">
-      <div class="ficontent">
-        <span class="detail-text accordion">
-          <article class="value">
-            % if personal:
-              <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-nc-nd/3.0/deed.{{detailsCtrl.lang.getLang()}}">
-                <span class="creative-commons icon-BY green-text"
-                      uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
-                <span class="creative-commons icon-NC green-text"
-                      uib-tooltip="{{'NonCommercial — You may not use the material for commercial purposes.' | translate}}"></span>
-                <span class="creative-commons icon-ND green-text" tooltip-placement=''
-                      uib-tooltip="{{'NoDerivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.' | translate}}"></span>
-                <span class="cc-description" translate>This content is licensed under Creative Commons BY-NC-ND 3.0</span>
-              </a>
-            % elif collaborative:
-              <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-sa/3.0/deed.{{detailsCtrl.lang.getLang()}}">
-                <span class="creative-commons icon-BY green-text"
-                      uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
-                <span class="creative-commons icon-SA green-text"
-                      uib-tooltip="{{'ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.' | translate}}"></span>
-                <span class="cc-description" translate>This content is licensed under Creative Commons BY-SA 3.0</span>
-              </a>
-            % else:
-              <div class="creative-commons">
-                <span class="glyphicon glyphicon-ban-circle green-text"
-                      uib-tooltip="{{'This picture depicts a book cover. It is the property of its editor and/or author. It is presented here only for illustration purposes.' | translate}}"></span>
-                <span class="cc-description" translate>This book cover is the property of its editor and/or author</span>
-              </div>
-            % endif
-          </article>
-        </span>
-      </div>
-    </div>
+  % if personal:
+  <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-nc-nd/3.0/deed.{{detailsCtrl.lang.getLang()}}">
+    <span class="creative-commons icon-BY green-text"
+          uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
+    <span class="creative-commons icon-NC green-text"
+          uib-tooltip="{{'NonCommercial — You may not use the material for commercial purposes.' | translate}}"></span>
+    <span class="creative-commons icon-ND green-text" tooltip-placement=''
+          uib-tooltip="{{'NoDerivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.' | translate}}"></span>
+    <span class="cc-description" translate>This content is licensed under Creative Commons BY-NC-ND 3.0</span>
+  </a>
+  % elif collaborative:
+  <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-sa/3.0/deed.{{detailsCtrl.lang.getLang()}}">
+    <span class="creative-commons icon-BY green-text"
+          uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
+    <span class="creative-commons icon-SA green-text"
+          uib-tooltip="{{'ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.' | translate}}"></span>
+    <span class="cc-description" translate>This content is licensed under Creative Commons BY-SA 3.0</span>
+  </a>
+  % else:
+  <div class="creative-commons">
+    <span class="glyphicon glyphicon-ban-circle green-text"
+          uib-tooltip="{{'This picture depicts a book cover. It is the property of its editor and/or author. It is presented here only for illustration purposes.' | translate}}"></span>
+    <span class="cc-description" translate>This book cover is the property of its editor and/or author</span>
+  </div>
+  % endif
 </%def>
 
 <%def name="show_attr(obj, key, parse=True)">\

--- a/c2corg_ui/templates/helpers/view.html
+++ b/c2corg_ui/templates/helpers/view.html
@@ -23,11 +23,12 @@
             % if personal:
               <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-nc-nd/3.0/deed.{{detailsCtrl.lang.getLang()}}">
                 <span class="creative-commons icon-BY green-text"
-                    uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
-                <span class="creative-commons icon-ND green-text" tooltip-placement=''
-                    uib-tooltip="{{'NoDerivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.' | translate}}"></span>
+                      uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
                 <span class="creative-commons icon-NC green-text"
                       uib-tooltip="{{'NonCommercial — You may not use the material for commercial purposes.' | translate}}"></span>
+                <span class="creative-commons icon-ND green-text" tooltip-placement=''
+                      uib-tooltip="{{'NoDerivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.' | translate}}"></span>
+                <span class="cc-description" translate>This content is licensed under Creative Commons BY-NC-ND 3.0</span>
               </a>
             % elif collaborative:
               <a class="creative-commons" ng-href="https://creativecommons.org/licenses/by-sa/3.0/deed.{{detailsCtrl.lang.getLang()}}">
@@ -35,10 +36,14 @@
                       uib-tooltip="{{'Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.' | translate}}"></span>
                 <span class="creative-commons icon-SA green-text"
                       uib-tooltip="{{'ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.' | translate}}"></span>
+                <span class="cc-description" translate>This content is licensed under Creative Commons BY-SA 3.0</span>
               </a>
             % else:
-              <span class="glyphicon glyphicon-duplicate green-text"
-                    uib-tooltip="{{'This picture depicts a book cover. It is the property of its editor and/or author. It is presented here only for illustration purposes.' | translate}}"></span>
+              <div class="creative-commons">
+                <span class="glyphicon glyphicon-ban-circle green-text"
+                      uib-tooltip="{{'This picture depicts a book cover. It is the property of its editor and/or author. It is presented here only for illustration purposes.' | translate}}"></span>
+                <span class="cc-description" translate>This book cover is the property of its editor and/or author</span>
+              </div>
             % endif
           </article>
         </span>

--- a/c2corg_ui/templates/image/view.html
+++ b/c2corg_ui/templates/image/view.html
@@ -11,7 +11,7 @@ from json import dumps
     show_associated_waypoints, show_associated_routes, show_associated_articles,
     show_associated_outings, show_associated_books, delete_association_confirmation_modal,
     get_document_description, get_comments, get_licence, show_merge_documents_dialog,
-    show_delete_document_dialog, generate_share_metadata"/>
+    show_delete_document_dialog, generate_share_metadata, get_print_license"/>
 <%namespace file="helpers/view.html" import="get_image_general, get_image_camera_settings, show_image"/>
 
 <%
@@ -134,6 +134,8 @@ from json import dumps
                 </div>
 
                 ${get_comments()}
+
+                ${get_print_license(image)}
 
                 ${show_float_buttons(image, lang, other_langs, missing_langs)}
               % endif

--- a/c2corg_ui/templates/outing/view.html
+++ b/c2corg_ui/templates/outing/view.html
@@ -12,7 +12,8 @@ from json import dumps
     show_associated_waypoints, show_associated_routes, show_associated_articles,
     show_associated_xreports, delete_association_confirmation_modal,
     associated_images_featurelist, show_badge, get_licence, show_merge_documents_dialog,
-    show_delete_document_dialog, get_document_description, generate_share_metadata, display_app_smartphone_info"/>
+    show_delete_document_dialog, get_document_description, generate_share_metadata,
+    display_app_smartphone_info, get_print_license"/>
 <%namespace file="helpers/view.html" import="get_outing_snow, get_outing_access,
     get_outing_participants, get_outing_general, get_outing_heights,
     show_fulldate, get_conditions, get_outing_elevation_profile, get_outing_rating"/>
@@ -188,6 +189,8 @@ other_langs, missing_langs = get_lang_lists(outing, lang)
                 </div>
 
         ${get_comments(outing.get('disable_comments'))}
+
+        ${get_print_license(outing)}
 
         ${show_float_buttons(outing, lang, other_langs, missing_langs)}
       % endif

--- a/c2corg_ui/templates/route/view.html
+++ b/c2corg_ui/templates/route/view.html
@@ -14,8 +14,9 @@ from json import dumps
     show_associated_waypoints, show_associated_routes, show_associated_outings,
     show_associated_articles, show_associated_books, show_associated_xreports,
     delete_association_confirmation_modal, associated_waypoints_featurelist,
-    show_badge, get_document_description, get_licence, show_merge_documents_dialog,
-    show_delete_document_dialog, generate_share_metadata, display_app_smartphone_info" />
+    show_badge, get_document_description, get_licence, get_print_license,
+    show_merge_documents_dialog, show_delete_document_dialog,
+    generate_share_metadata, display_app_smartphone_info, get_print_license" />
 
 <%namespace file="helpers/view.html" import="get_route_location,
     get_route_glacier_gear, get_route_rating, get_route_general, get_route_heights,
@@ -179,6 +180,8 @@ other_langs, missing_langs = get_lang_lists(route, lang)
 
             ${get_comments()}
 
+            ${get_print_license(route)}
+
             ${show_float_buttons(route, lang, other_langs, missing_langs)}
           % endif
         </div>
@@ -196,7 +199,7 @@ other_langs, missing_langs = get_lang_lists(route, lang)
     ${show_delete_document_dialog('routes', lang, other_langs)}
   </div>
 
-    ${photoswipe_gallery()}
+  ${photoswipe_gallery()}
 
   <script>
     window.onload = function() {

--- a/c2corg_ui/templates/waypoint/view.html
+++ b/c2corg_ui/templates/waypoint/view.html
@@ -13,7 +13,8 @@ from json import dumps
     show_associated_books, show_associated_outings, show_associated_xreports,
     delete_association_confirmation_modal, associated_waypoints_featurelist,
     show_badge, get_document_description, get_licence, show_merge_documents_dialog,
-    show_delete_document_dialog, generate_share_metadata, display_app_smartphone_info"/>
+    show_delete_document_dialog, generate_share_metadata, display_app_smartphone_info,
+    get_print_license"/>
 <%namespace file="helpers/view.html" import="get_waypoint_equipment,
     get_waypoint_orientations, get_waypoint_contact, get_waypoint_style, get_waypoint_rating,
     get_waypoint_access, get_waypoint_heights, get_waypoint_location, get_waypoint_general,
@@ -188,6 +189,8 @@ waypoint['doctype'] = 'waypoints'
                   </section>
                 </span>
                 ${get_comments()}
+
+            ${get_print_license(waypoint)}
 
                 ${show_float_buttons(waypoint, lang, other_langs, missing_langs)}
                 </div>

--- a/c2corg_ui/templates/xreport/view.html
+++ b/c2corg_ui/templates/xreport/view.html
@@ -11,7 +11,7 @@ from json import dumps
   show_associated_waypoints, show_associated_outings, show_associated_routes, show_associated_xreports,
   show_associated_articles, show_float_buttons, generate_share_metadata,
   delete_association_confirmation_modal, associated_waypoints_featurelist,
-  associated_images_featurelist, show_badge, get_licence,
+  associated_images_featurelist, show_badge, get_licence, get_print_license,
   show_merge_documents_dialog, show_delete_document_dialog"/>
 <%namespace file="helpers/view.html" import="show_fulldate, get_xreport_general, get_xreport_participants"/>
 
@@ -158,6 +158,8 @@ other_langs, missing_langs = get_lang_lists(xreport, lang)
             </div>
 
             ${get_comments(xreport.get('disable_comments'))}
+
+            ${get_print_license(xreport)}
 
             ${show_float_buttons(xreport, lang, other_langs, missing_langs)}
           % endif

--- a/less-print/viewdetails.less
+++ b/less-print/viewdetails.less
@@ -133,6 +133,23 @@
   content: "SA";
 }
 
+.creative-commons {
+  display: inline-flex;
+  margin-left: 6px;
+
+  .cc-description,
+  + div {
+    line-height: 30px;
+  }
+
+  + div {
+    display: inline-block;
+    padding: 2px;
+    position: relative;
+    top: -9px;
+  }
+}
+
 .name-icon-value {
   border-bottom: none !important;
   min-height: 10px !important;

--- a/less/creativecommons.less
+++ b/less/creativecommons.less
@@ -9,19 +9,17 @@
   font-style: normal;
 }
 
-[class^="creative-commons icon-"], [class*="creative-commons icon-"], .creative-commons {
+[class^="creative-commons icon-"],
+[class*="creative-commons icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'icomoon' !important;
-  speak: none;
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
   text-transform: none;
+  font-size: 30px;
   line-height: 1;
-  font-size: 2.5em;
-  color: @C2C-orange;
 
-  /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -40,4 +38,32 @@
 }
 .icon-SA:before {
   content: "\1f300";
+}
+
+.creative-commons {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+
+  > span {
+    padding: 2px;
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
+
+  .cc-description {
+    flex-shrink: 1;
+    flex-grow: 1;
+    font-weight: normal;
+    color: @gray-dark;
+
+    @media @tablet {
+      padding-left: 5px;
+    }
+  }
+
+  .glyphicon {
+    font-size: 30px;
+    color: @bright-green;
+  }
 }

--- a/less/helpers.less
+++ b/less/helpers.less
@@ -432,3 +432,11 @@ p {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
+
+.print-only {
+  display: none;
+
+  @media print {
+    display: initial;
+  }
+}

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -305,9 +305,7 @@
   a {
     text-decoration: none;
   }
-  .creative-commons {
-    font-size: 1.5em;
-  }
+
   .orientation-svg {
     height: 110px;
   }
@@ -970,12 +968,6 @@
         left: -25%;
         top: 50%;
         width: 150%;
-      }
-    }
-    a.creative-commons {
-      font-size: 1em;
-      &:hover, &:focus {
-        text-decoration: none;
       }
     }
 


### PR DESCRIPTION
Relates to #1865.

* rework the way license is presented on documents
* add license info on guidebook documents prints

![snapshot24](https://user-images.githubusercontent.com/2234024/33896285-b88bdca4-df62-11e7-9ba1-2d08750ebe7d.png)
![snapshot25](https://user-images.githubusercontent.com/2234024/33896286-b8ad721a-df62-11e7-98c1-a38d86413ae6.png)
![snapshot26](https://user-images.githubusercontent.com/2234024/33896287-b8ce3c34-df62-11e7-8263-9678fe709f74.png)

![snapshot23](https://user-images.githubusercontent.com/2234024/33896290-bd779744-df62-11e7-9e9e-3eced4dfaafa.png)

