### PR TITLE
Add LTag Header feature

### DIFF
--- a/c2corg_ui/tests/format/test/ltags.json
+++ b/c2corg_ui/tests/format/test/ltags.json
@@ -28,5 +28,10 @@
         "id": "Text in the middle",
         "text": "L# | 1 \nL#~ text in\nthe middle\nL# | 2 ",
         "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td colspan=\"2\">text in<br/>the middle</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
+    },
+    {
+        "id": "Header and simple Ltags",
+        "text": "L#= | Numerotation\nL# |1\nL#| 2",
+        "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<td></td>\n<th>Numerotation</th>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate>L</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
     }
 ]

--- a/less/viewdetails.less
+++ b/less/viewdetails.less
@@ -1693,7 +1693,8 @@ app-add-association { /* stylelint-disable-line selector-type-no-unknown */
     font-weight: bold;
   }
 
-  td {
+  td,
+  th {
     vertical-align: top;
     word-wrap: normal;
     word-break: normal;
@@ -1716,7 +1717,8 @@ app-add-association { /* stylelint-disable-line selector-type-no-unknown */
       }
     }
 
-    td {
+    td,
+    th {
       padding-top: 0;
       padding-bottom: 0;
     }


### PR DESCRIPTION
Add LTag Header feature as described in [documentation](https://www.camptocamp.org/articles/305462/fr/aide-topoguide-l-balise-de-description-des-longueurs#titre-de-colonne)

```
L#= | Cotation | Description de la longueur
L# | 5b+ | tout droit, courte longueur à enchaîner avec L2 (Yakafokon part à droite)
L# | 6a+ | un petit toit (pas de bloc) puis un dièdre court et technique.
L# | 6a | traverse à gauche, remonte un dièdre et retraverse à gauche les pieds dans une dalle patinée pour contourner un toit.
L#= | Cotation | Description de la longueur
L# | 6a | tout droit, court passage athlétique puis facile pour rejoindre un dièdre puis une traversée en dalle sous un gros toit.
L# | 6b+ | contourne le toit par la gauche, athlétique et soutenu ; très bien protégé.
L# | 6a | un pas à gauche puis tout droit dans un dièdre évasé pour sortir sur une large vire.
L#~ Descendre de quelques mètres sur la vire pour trouver la dernière longueur.
L# | 5c | grande longueur en ascendance à droite dans un système de dièdres/blocs puis dalle à silex.
```

is converted to

<img width="810" alt="capture d ecran 2017-12-29 a 17 21 02" src="https://user-images.githubusercontent.com/1516110/34441643-5f670104-ecbd-11e7-9d1c-5d3490f0d894.png">
