### PR TITLE
 [LTag] Add absolute numbering feature

### DIFF
--- a/c2corg_ui/tests/format/test/ltags.json
+++ b/c2corg_ui/tests/format/test/ltags.json
@@ -32,6 +32,11 @@
     {
         "id": "Header and simple Ltags",
         "text": "L#= | Numerotation\nL# |1\nL#| 2",
-        "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<td></td>\n<th>Numerotation</th>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
+        "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<th></th>\n<th>Numerotation</th>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
+    },
+    {
+        "id": "Absolute numbering",
+        "text": "L# | 5a | L#2 and L#3 are joined to L#\nL#4| 5b+ | Awesome pitch !",
+        "expected": "<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n<td>5a</td>\n<td><span class=\"pitch\"><span translate=\"\">L</span>2</span> and <span class=\"pitch\"><span translate=\"\">L</span>3</span> are joined to <span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>4</span></td>\n<td>5b+</td>\n<td>Awesome pitch !</td>\n</tr>\n</tbody>\n</table>"
     }
 ]


### PR DESCRIPTION
Pending #1931 merge

## Absolute numbering

```
## La voie

L#= | Cotation | Description de la longueur
L# | 5b+ | tout droit, courte longueur à enchaîner avec L#2 & L#3 jointes à L# (Yakafokon part à droite)
L#4 | 6a+ | un petit toit (pas de bloc) puis un dièdre court et technique.
L# | 6a | traverse à gauche, remonte un dièdre et retraverse à gauche les pieds dans une dalle patinée pour contourner un toit.
L#= | Cotation | Description de la longueur
L#12 | 6a | tout droit, court passage athlétique puis facile pour rejoindre un dièdre puis une traversée en dalle sous un gros toit.
L# | 6b+ | contourne le toit par la gauche, athlétique et soutenu ; très bien protégé.
L# | 6a | un pas à gauche puis tout droit dans un dièdre évasé pour sortir sur une large vire.
L#~ Descendre de quelques mètres sur la vire pour trouver la dernière longueur.
Blabla
Blabli
L# | 5c | grande longueur en ascendance à droite dans un système de dièdres/blocs puis dalle à silex.

## Descente
On peut rejoindre la sortie de Nid d'Aigle 50m à droite en sortant de la voie. Une corde statique permet d'accéder au premier rappel. 
- Corde de 2x50m : deux rappels (le premier faisant 48m). 

R# | Premier rappel
R# | Second rappel
```

<img width="802" alt="capture d ecran 2018-01-03 a 15 18 47" src="https://user-images.githubusercontent.com/1516110/34523902-bf8be966-f099-11e7-9d1d-6234c4f53f03.png">