### PR TITLE
Do not include <figure> inside a <p> tag

### DIFF
--- a/c2corg_ui/tests/format/test/img_tag.json
+++ b/c2corg_ui/tests/format/test/img_tag.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "img",
+    "text": "[img=123/]",
+    "expected": "<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>"
+  },
+  {
+    "id": "two images, two figures",
+    "text": "[img=123/][img=123/]",
+    "expected": "<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>\n<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>"
+  },
+  {
+    "id": "even new line changes nothing",
+    "text": "[img=123/]\n[img=123/]",
+    "expected": "<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>\n<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>"
+  },
+  {
+    "id": "figure after p",
+    "text": "a\n[img=123/]",
+    "expected": "<p>a</p>\n<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>"
+  },
+  {
+    "id": "figure between p",
+    "text": "a\n[img=123/]\nb",
+    "expected": "<p>a</p>\n<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>\n<p>b</p>"
+  },
+  {
+    "id": "figure between p, and with empty lines",
+    "text": "a\n\n[img=123/]\n\nb",
+    "expected": "<p>a</p>\n<figure class=\"embedded_inline MI\" ng-click=\"detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)\"><img alt=\"123\" class=\"thumbnail embedded-image \" img-id=\"123\" src=\"https://api.camptocamp.org//images/proxy/123?size=MI\"></figure>\n<p>b</p>"
+  },
+  {
+    "id": "Inside a paragraph, do not parse",
+    "text": "a [img=123/] b",
+    "expected": "<p>a [img=123/] b</p>"
+  },
+  {
+    "id": "Do not parse",
+    "text": "En code `[img=123/]`.\n\n     [img=123/]",
+    "expected": "<p>En code <code>[img=123/]</code>.</p>\n<pre><code> [img=123/]\n</code></pre>"
+  }
+
+]

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -11,10 +11,8 @@ Some <strong>bold text</strong> and <em>italic</em> and small <small>text</small
 Use the <code>printf()</code> function.<br>
 and <br> is allowed</p>
 <p><a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#97;&#100;&#100;&#114;&#101;&#115;&#115;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;">&#97;&#100;&#100;&#114;&#101;&#115;&#115;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;</a></p>
-<p>
-</p><figure class="embedded_inline MI" ng-click="detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)"><img alt="image" class="thumbnail embedded-image " img-id="123" src="https://api.camptocamp.org//images/proxy/123?size=MI"><figcaption>image</figcaption>
+<figure class="embedded_inline MI" ng-click="detailsCtrl.openEmbeddedImage(&quot;https://api.camptocamp.org//images/proxy/123?size=MI&quot;, &quot;123&quot;)"><img alt="image" class="thumbnail embedded-image " img-id="123" src="https://api.camptocamp.org//images/proxy/123?size=MI"><figcaption>image</figcaption>
 </figure>
-<p></p>
 <p>
 </p><div class="embed-responsive embed-responsive-4by3 video"><iframe class="embed-reponsive-item" src="//www.youtube.com/embed/qEpdQDqaQdo"></iframe></div>
 <p></p>


### PR DESCRIPTION
The root cause is that `<figure> `HTML element is a block element, but is parsed by inline MD parser. In consequence, it's included in a `<p>` element, which is not a valid HTML. Try for instance to put this html in your browser:

    <p><figure></figure></p>

it will be rendered as : 

    <p></p><figure></figure><p></p>
  
I've also added some unit tests in img_tag.json