### PR TITLE
Remove deprecated bbcode module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ waitress==0.8.10
 requests==2.1.0
 Shapely==1.5.13
 htmlmin==0.1.10
-bbcode==1.0.21
 Markdown==2.6.5
 bleach==2.1.2
 dogpile.cache==0.6.1


### PR DESCRIPTION
No longer needed according to @cbeauchesne at https://github.com/c2corg/v6_ui/pull/1932#issuecomment-355894080