### PR TITLE
Toc with only 3 levels, and without emphasis

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -12,8 +12,8 @@ from c2corg_ui.format.warning import C2CWarningExtension
 from c2corg_ui.format.ltag import C2CLTagExtension
 from c2corg_ui.format.header_emphasis import HeaderEmphasisExtension
 from c2corg_ui.format.ptag import C2CPTagExtension
+from c2corg_ui.format.toc import C2CTocExtension
 from markdown.extensions.nl2br import Nl2BrExtension
-from markdown.extensions.toc import TocExtension
 
 
 def _get_secret():
@@ -112,7 +112,7 @@ def _get_markdown_parser():
             C2CImportantExtension(),
             C2CWarningExtension(),
             Nl2BrExtension(),
-            TocExtension(marker='[toc]', baselevel=2),
+            C2CTocExtension(marker='[toc]', baselevel=2),
             AutoLinkExtension(),
             C2CVideoExtension(iframe_secret_tag=_iframe_secret_tag),
             C2CLTagExtension(),

--- a/c2corg_ui/format/toc.py
+++ b/c2corg_ui/format/toc.py
@@ -1,0 +1,82 @@
+"""
+Table of Contents Extension for Python-Markdown
+===============================================
+
+See <https://pythonhosted.org/Markdown/extensions/toc.html>
+for documentation.
+
+Oringinal code Copyright 2008 [Jack Miller](http://codezen.org)
+
+All changes Copyright 2008-2014 The Python Markdown Project
+
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
+
+Modified for C2C : remove title emphasis, and only include <4 levels
+"""
+
+from markdown.extensions.toc import (TocExtension, TocTreeprocessor,
+                                     string_type, stashedHTML2text,
+                                     unique, nest_toc_tokens)
+
+
+class C2CTocTreeprocessor(TocTreeprocessor):
+    def run(self, doc):
+
+        def not_emphasis(elt):
+            return elt.attrib.get("class") != "header-emphasis"
+
+        # Get a list of id attributes
+        used_ids = set()
+        for el in doc.iter():
+            if "id" in el.attrib:
+                used_ids.add(el.attrib["id"])
+
+        toc_tokens = []
+        for el in doc.iter():
+            if isinstance(el.tag, string_type) and \
+                    self.header_rgx.match(el.tag):
+                self.set_level(el)
+
+                # modification for camptocamp
+                # orginal line was :
+                # text = ''.join(el.itertext()).strip()
+
+                text = ''.join([elt.text for elt in el.iter()
+                                if not_emphasis(elt)])
+
+                # Do not override pre-existing ids
+                if "id" not in el.attrib:
+                    innertext = stashedHTML2text(text, self.markdown)
+                    el.attrib["id"] = unique(self.slugify(innertext, self.sep),
+                                             used_ids)
+
+                level = int(el.tag[-1])
+                if level < 5:  # test for camptocamp
+                    toc_tokens.append({
+                        'level': level,
+                        'id': el.attrib["id"],
+                        'name': text
+                    })
+
+                if self.use_anchors:
+                    self.add_anchor(el, el.attrib["id"])
+                if self.use_permalinks:
+                    self.add_permalink(el, el.attrib["id"])
+
+        div = self.build_toc_div(nest_toc_tokens(toc_tokens))
+        if self.marker:
+            self.replace_marker(doc, div)
+
+        # serialize and attach to markdown instance.
+        toc = self.markdown.serializer(div)
+        for pp in self.markdown.postprocessors.values():
+            toc = pp.run(toc)
+        self.markdown.toc = toc
+
+
+class C2CTocExtension(TocExtension):
+    TreeProcessorClass = C2CTocTreeprocessor
+
+
+def makeExtension(*args, **kwargs):  # noqa
+    return C2CTocExtension(*args, **kwargs)

--- a/c2corg_ui/tests/format/test/headers.json
+++ b/c2corg_ui/tests/format/test/headers.json
@@ -25,17 +25,17 @@
 },{
   "id":"Emphasis",
   "text":"## Title # emphasis",
-  "expected":"<h3 id=\"title-emphasis\">Title <span class=\"header-emphasis\">emphasis</span></h3>"
+  "expected":"<h3 id=\"title\">Title <span class=\"header-emphasis\">emphasis</span></h3>"
 },{
   "id":"Emphasis on h5",
   "text":"#### Title # emphasis",
-  "expected":"<h5 id=\"title-emphasis\">Title <span class=\"header-emphasis\">emphasis</span></h5>"
+  "expected":"<h5 id=\"title\">Title <span class=\"header-emphasis\">emphasis</span></h5>"
 },{
   "id":"strange separator",
   "text":"## Title #### emphasis",
-  "expected":"<h3 id=\"title-emphasis\">Title <span class=\"header-emphasis\">emphasis</span></h3>"
+  "expected":"<h3 id=\"title\">Title <span class=\"header-emphasis\">emphasis</span></h3>"
 },{
   "id":"Strange title",
   "text":"## Title with # inside #### emphasis",
-  "expected":"<h3 id=\"title-with-inside-emphasis\">Title with # inside <span class=\"header-emphasis\">emphasis</span></h3>"
+  "expected":"<h3 id=\"title-with-inside\">Title with # inside <span class=\"header-emphasis\">emphasis</span></h3>"
 }]

--- a/c2corg_ui/tests/format/test/sample.html
+++ b/c2corg_ui/tests/format/test/sample.html
@@ -1,6 +1,6 @@
 <h2 id="title-1">Title 1</h2>
 <h3 id="title-2">Title 2</h3>
-<h4 id="title-3-small">Title 3 <span class="header-emphasis">small</span></h4>
+<h4 id="title-3">Title 3 <span class="header-emphasis">small</span></h4>
 <h5 id="title-4">Title 4</h5>
 <p>[b]Old bold BBcode en gras[/b] <br>
 old [url=<a href="http://example.com">http://example.com</a>]bbcode link[/url]</p>

--- a/c2corg_ui/tests/format/test/toc.json
+++ b/c2corg_ui/tests/format/test/toc.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "toc",
+    "text": "[toc]\n# title 1",
+    "expected": "<div class=\"toc\">\n<ul>\n<li><a href=\"#title-1\">title 1</a></li>\n</ul>\n</div>\n<h2 id=\"title-1\">title 1</h2>"
+  },
+  {
+    "id": "toc 2 and 3",
+    "text": "[toc]\n## title 2\n### title 3",
+    "expected": "<div class=\"toc\">\n<ul>\n<li><a href=\"#title-2\">title 2</a><ul>\n<li><a href=\"#title-3\">title 3</a></li>\n</ul>\n</li>\n</ul>\n</div>\n<h3 id=\"title-2\">title 2</h3>\n<h4 id=\"title-3\">title 3</h4>"
+  },
+  {
+    "id": "toc 2 and 3, but not 4",
+    "text": "[toc]\n## title 2\n### title 3\n#### title 4",
+    "expected": "<div class=\"toc\">\n<ul>\n<li><a href=\"#title-2\">title 2</a><ul>\n<li><a href=\"#title-3\">title 3</a></li>\n</ul>\n</li>\n</ul>\n</div>\n<h3 id=\"title-2\">title 2</h3>\n<h4 id=\"title-3\">title 3</h4>\n<h5 id=\"title-4\">title 4</h5>"
+  },
+  {
+    "id": "Not emphasis",
+    "text": "[toc]\n# title 1 ## with strange ## emphasis",
+    "expected": "<div class=\"toc\">\n<ul>\n<li><a href=\"#title-1-with-strange\">title 1 ## with strange </a></li>\n</ul>\n</div>\n<h2 id=\"title-1-with-strange\">title 1 ## with strange <span class=\"header-emphasis\">emphasis</span></h2>"
+  }
+]


### PR DESCRIPTION
Check page : 

https://www.camptocamp.org/articles/106728/fr/licence-des-contenus

* Title with level 1, 2 and 3 must be in toc (actually, only 2 and 3 are presents in this article)
* Emphasis (actually, old anchor tags that has not been migrated) should not appear in toc. They must end with a '{'