### PR TITLE
Non breakable spaces must follow arabic numbers

### DIFF
--- a/c2corg_ui/format/__init__.py
+++ b/c2corg_ui/format/__init__.py
@@ -15,6 +15,7 @@ from c2corg_ui.format.ptag import C2CPTagExtension
 from c2corg_ui.format.alerts import AlertExtension
 from c2corg_ui.format.toc import C2CTocExtension
 from c2corg_ui.format.emojis import C2CEmojiExtension
+from c2corg_ui.format.nbsp import C2CNbspExtension
 from markdown.extensions.nl2br import Nl2BrExtension
 
 
@@ -122,6 +123,7 @@ def _get_markdown_parser():
             C2CPTagExtension(),
             AlertExtension(),
             C2CEmojiExtension(),
+            C2CNbspExtension(),
         ]
         _markdown_parser = markdown.Markdown(output_format='xhtml5',
                                              extensions=extensions)

--- a/c2corg_ui/format/nbsp.py
+++ b/c2corg_ui/format/nbsp.py
@@ -1,0 +1,19 @@
+from markdown import Extension
+from markdown.inlinepatterns import Pattern
+
+
+class NbspPattern(Pattern):
+    def handleMatch(self, m):  # noqa
+        placeholder = self.markdown.htmlStash.store("&nbsp;")
+        return "".join((m.group(2), placeholder, m.group(3)))
+
+
+class C2CNbspExtension(Extension):
+    def extendMarkdown(self, md, md_globals):  # noqa
+        md.inlinePatterns.add('c2c_nbsp',
+                              NbspPattern(r'(\d) +([a-z])', md),
+                              '<strong')
+
+
+def makeExtension(*args, **kwargs):  # noqa
+    return C2CNbspExtension(*args, **kwargs)

--- a/c2corg_ui/tests/format/test/ltags.json
+++ b/c2corg_ui/tests/format/test/ltags.json
@@ -17,7 +17,7 @@
     {
         "id": "LTags and RTags separated by text",
         "text": "Hello\n\n L# |1\nL#| 2 then R#\n\nGreat !\n\nR# |1\nR#| 2",
-        "expected": "<p>Hello</p>\n<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>2</span></td>\n<td>2 then <span class=\"pitch\"><span translate=\"\">R</span>2</span></td>\n</tr>\n</tbody>\n</table>\n<p>Great !</p>\n<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">R</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">R</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
+        "expected": "<p>Hello</p>\n<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">L</span>2</span></td>\n<td>2&nbsp;then <span class=\"pitch\"><span translate=\"\">R</span>2</span></td>\n</tr>\n</tbody>\n</table>\n<p>Great !</p>\n<table class=\"ltag\">\n<tbody>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">R</span>1</span></td>\n<td>1</td>\n</tr>\n<tr>\n<td><span class=\"pitch\"><span translate=\"\">R</span>2</span></td>\n<td>2</td>\n</tr>\n</tbody>\n</table>"
     },
     {
         "id": "Unsupported LTag",

--- a/c2corg_ui/tests/format/test/nbsp.json
+++ b/c2corg_ui/tests/format/test/nbsp.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "main",
+    "text": "I&nbsp;know 123 cows, I count 1, and 2 3 and I'm 3.",
+    "expected": "<p>I&nbsp;know 123&nbsp;cows, I count 1, and 2 3&nbsp;and I'm 3.</p>"
+  },
+  {
+    "id": "code",
+    "text": "I know `123 cows`\n\n    123 cows",
+    "expected": "<p>I know <code>123 cows</code></p>\n<pre><code>123 cows\n</code></pre>"
+  }
+]


### PR DESCRIPTION
This markdown : `123 cows` must give this html : `123&nbsp;cows`