### PR TITLE
Map search query

### DIFF
--- a/c2corg_ui/static/js/map/search.js
+++ b/c2corg_ui/static/js/map/search.js
@@ -132,6 +132,7 @@ app.MapSearchController.SEARCH_URL = 'https://photon.komoot.de/api/';
 app.MapSearchController.prototype.createAndInitBloodhound_ = function() {
   let url = app.MapSearchController.SEARCH_URL;
   url += '?q=%QUERY';
+  // url += '&osm_tag=place:city&osm_tag=place:town&osm_tag=place:village';
 
   const bloodhound = new Bloodhound(/** @type {BloodhoundOptions} */({
     limit: 10,

--- a/c2corg_ui/static/js/map/search.js
+++ b/c2corg_ui/static/js/map/search.js
@@ -131,8 +131,7 @@ app.MapSearchController.SEARCH_URL = 'https://photon.komoot.de/api/';
  */
 app.MapSearchController.prototype.createAndInitBloodhound_ = function() {
   let url = app.MapSearchController.SEARCH_URL;
-  url += '?q=%QUERY';
-  // url += '&osm_tag=place:city&osm_tag=place:town&osm_tag=place:village';
+  url += '?q=%QUERY&distance_sort=false';
 
   const bloodhound = new Bloodhound(/** @type {BloodhoundOptions} */({
     limit: 10,


### PR DESCRIPTION
Fix for [issue 1954](https://github.com/c2corg/v6_ui/issues/1954). The request is filtered to give results that correspond to the following OSM tags: city, town and village. This remove all street's adresses from the search result.