### PR TITLE
Add support of rate limiting message

### DIFF
--- a/c2corg_ui/static/js/apiservice.js
+++ b/c2corg_ui/static/js/apiservice.js
@@ -320,13 +320,13 @@ app.Api.prototype.getDocumentByIdAndDoctype = function(id, doctype, lang) {
  * @private
  */
 app.Api.prototype.errorSaveDocument_ = function(response) {
-  // FIXME: API does not return a valid JSON response for 500/403 errors.
-  // See https://github.com/c2corg/v6_api/issues/85
   let msg;
   if (response['data'] instanceof Object && 'errors' in response['data']) {
     msg = response;
   } else if (response['status'] === 403) {
-    msg = 'You have no permission to modify this document';
+    msg = 'You have no rights to edit this document.';
+  } else if (response['status'] === 429) {
+    msg = 'You have made too many changes recently and thus have been blocked';
   } else {
     msg = 'Failed saving the changes';
   }

--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -374,6 +374,8 @@
 
 ## errors from js files
 <span translate>You have no rights to edit this document.</span>
+<span translate>You have made too many changes recently and thus have been blocked.</span>
+<span translate>Failed saving the changes</span>
 <span translate>Form is not valid</span>
 <span translate>You must log in to edit this document.</span>
 <span translate>no associated routes</span>


### PR DESCRIPTION
As for now, when a contributor's edition is rejected because of the rate limiting tool (see https://github.com/c2corg/v6_api/pull/716), the default message "Failed saving changes" is displayed.

The aim of this PR is to show an explicit message when a user is rate limited.

The PR is still work in progress because it seems the existing ``errorSaveDocument_`` function (in the ``api `` service) does not work as expected: the status and addition data are indeed provided in the API response but are not provided as expected in the ``response`` argument of callback ``errorSaveDocument_``: 

![sans titre](https://user-images.githubusercontent.com/1192331/35578479-80a9780c-05e4-11e8-9561-a8c7f66f3770.png)

We have the same problem when creating a document, and when the user is blocked (403 status instead of 429) or when the API crashes with a 500 error => "Failed saving changes" is always displayed instead of the expected detailed message.
