### PR TITLE
add a div clear:both add the end of any markdown field

### DIFF
--- a/c2corg_ui/templates/utils/__init__.py
+++ b/c2corg_ui/templates/utils/__init__.py
@@ -31,7 +31,16 @@ def get_attr(obj, key, parse):
     """
     attr = obj[key] if key in obj else None
     if attr and isinstance(attr, str):
-        attr = parse_code(attr) if parse else attr
+
+        # markdown data may contain float elements that could
+        # potentialy goes under the end of container element
+        # we must add a div with style clear:both at the very end
+        # of produced html in order to force the container
+        # to ends at the very bottom of parsed HTML
+
+        if parse:
+            attr = "".join((parse_code(attr),
+                            '<div style="clear:both"></div>'))
     return attr
 
 


### PR DESCRIPTION
How to test? Go to all links present on #1986 and check that all div thta contains markdown ends AFTER the floating image. 

For an exemple of he ugly situation, got to  Kryst0f page on prod : https://www.camptocamp.org/profiles/2674/fr
 