### PR TITLE
Add outing to i18n strings

### DIFF
--- a/c2corg_ui/templates/i18n.html
+++ b/c2corg_ui/templates/i18n.html
@@ -23,6 +23,9 @@
 <span translate>via_ferrata</span>
 <span translate>slacklining</span>
 
+## document types
+<span translate>outing</span>
+
 ## waypoint_types
 <span translate>summit</span>
 <span translate>pass</span>


### PR DESCRIPTION
Needed for instance to have the outing badge (near the outing title) translated.

Since the string seems to not be available explicitely with a "translate" tag in the templates or partials, it is not listed in Transifex and has not been translated. This change artificially marks the string as to be translated.

Related to https://github.com/c2corg/v6_ui/issues/1947