### PR TITLE
Fix weird markdown issues

### DIFF
--- a/c2corg_ui/tests/format/test/weirds.json
+++ b/c2corg_ui/tests/format/test/weirds.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "markdwon bug",
+    "text": "{@{=}",
+    "expected": "<p>{@{=}</p>"
+  },
+  {
+    "id": "bleach bug",
+    "text": "<d {c}>",
+    "expected": "\n<div class=\"md-alert md-alert-danger\" style=\"font-weight:bold\">\nParser error, please send a mail to\n<a href=\"mailto:dev@camptocamp.org\">dev@camptocamp.org</a>\nor post a message on\n<a href=\"https://forum.camptocamp.org/c/site-et-association/v6-suggestions-bugs-et-problemes\">\nforum</a>.\n</div>\n"
+  }
+]


### PR DESCRIPTION
This markdown should be interpreted as is : 

    {@{=}

Result : `{@{=}`

And this one produce an exception, but no more a server error : 

    <d {c}>

result : 

![image](https://user-images.githubusercontent.com/11915659/36629391-83695344-1955-11e8-9401-bb4518e11a8f.png)
 