### PR TITLE
If not a toc, display raw MD

### DIFF
--- a/c2corg_ui/format/toc.py
+++ b/c2corg_ui/format/toc.py
@@ -46,7 +46,7 @@ class C2CTocTreeprocessor(TocTreeprocessor):
             # To keep the output from screwing up the
             # validation by putting a <div> inside of a <p>
             # we actually replace the <p> in its entirety.
-            if c.text and c.text.strip() == self.marker:
+            if c.text and c.text.strip() == self.marker and len(c) == 0:
                 for i in range(len(p)):
                     if p[i] == c:
                         p[i] = elem

--- a/c2corg_ui/tests/format/test/toc.json
+++ b/c2corg_ui/tests/format/test/toc.json
@@ -48,5 +48,10 @@
     "id": "weird 5",
     "text": "# [toc]\n[toc]",
     "expected": "<h2 id=\"toc\">[toc]</h2>\n<div class=\"toc\">\n<ul>\n<li><a href=\"#toc\">[toc]</a></li>\n</ul>\n</div>"
+  },
+  {
+    "id": "not toc",
+    "text": "[toc]\nx",
+    "expected": "<p>[toc]<br>\nx</p>"
   }
 ]


### PR DESCRIPTION
Toc tag must be on a single line. Otherwise, it must be rendered as is.

    [toc]
    x

must give

[toc]
x