### PR TITLE
fix position of bottom buttons in fullscreen map on mobile

### DIFF
--- a/less/map.less
+++ b/less/map.less
@@ -224,3 +224,15 @@ app-map-search { /* stylelint-disable-line selector-type-no-unknown */
     }
   }
 }
+
+@media @phone {
+  .map-fullscreen {
+    .ol-attribution {
+      bottom: calc(65px + 0.5em);
+    }
+
+    .ol-scale-line {
+      bottom: 75px;
+    }
+  }
+}

--- a/less/map/layertreeselector.less
+++ b/less/map/layertreeselector.less
@@ -21,3 +21,9 @@ app-layertree-selector { /* stylelint-disable-line selector-type-no-unknown */
     width: auto;
   }
 }
+
+@media @phone {
+  .map-fullscreen app-layertree-selector { /* stylelint-disable-line selector-type-no-unknown */
+    bottom: 75px;
+  }
+}


### PR DESCRIPTION
Buttons are hidden by bottom user tollbar when map is fullscreen on mobile. This commit move the bottom elements up by 65px in this case.