### PR TITLE
Hide empty outings in feed

### DIFF
--- a/c2corg_ui/static/partials/feed.html
+++ b/c2corg_ui/static/partials/feed.html
@@ -16,17 +16,17 @@
   <h3 class="title-feed" translate>Activity feed</h3>
   <div class="in-feed-col-1">
     <article ng-repeat="doc in feedCtrl.documentsCol[0] track by doc.id">
-      <app-card app-card-doc="::doc"></app-card>
+      <app-card ng-if="doc['document']['quality']!='empty' || feedCtrl.userId" app-card-doc="::doc"></app-card>
     </article>
   </div>
   <div class="in-feed-col-2">
     <article ng-repeat="doc in feedCtrl.documentsCol[1] track by doc.id">
-      <app-card app-card-doc="::doc"></app-card>
+      <app-card ng-if="doc['document']['quality']!='empty' || feedCtrl.userId" app-card-doc="::doc"></app-card>
     </article>
   </div>
   <div class="in-feed-col-3">
     <article ng-repeat="doc in feedCtrl.documentsCol[2] track by doc.id">
-      <app-card app-card-doc="::doc"></app-card>
+      <app-card ng-if="doc['document']['quality']!='empty' || feedCtrl.userId" app-card-doc="::doc"></app-card>
     </article>
   </div>
   <div style="clear:both">&nbsp;</div>


### PR DESCRIPTION
This small modification will hide empty outings in home page.

It handle the case where cards are on user page, and in this case, it won't hide anything.