### PR TITLE
Without this line, any git command will fail. See config/default, line 26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ ui:
     - ./less:/var/www/less
     - ./less-discourse:/var/www/less-discourse
     - ./less-print:/var/www/less-print
+    - ./.git:/var/www/.git
   command: make -f config/docker serve
 # links:
 #    - redis


### PR DESCRIPTION
Actually, I do not understand why it does not bug with docker-compose up.

the point is that make build inside docker-compose exec ui bash fails without this fix.