### PR TITLE
Limit changes comment to 200 chars

### DIFF
--- a/c2corg_ui/templates/helpers/edit.html
+++ b/c2corg_ui/templates/helpers/edit.html
@@ -102,7 +102,8 @@
       % if updating_doc:
       <div id="message-group" class="full">
         <label translate>Comment about the changes</label>
-        <input type="text" name="message" ng-model="saveCtrl.message" class="form-control" placeholder="{{'Short description of the applied changes' | translate}}" />
+        <input type="text" name="message" ng-model="saveCtrl.message" maxlength="200" class="form-control"
+               placeholder="{{'Short description of the applied changes' | translate}}" />
       </div>
       % endif
       ## QUALITY


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/2179

It's a very simple and minimalistic fix (no error message is shown, the field can contain only 200 chars, period) but it does the job.
Perhaps it could be improved using ``ng-maxlength`` https://docs.angularjs.org/api/ng/directive/ngMaxlength but not sure it is a very common case, I guess it's OK like this.